### PR TITLE
Fix Github organisation in cloning instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-$PROVI
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
-$ git clone git@github.com:hashicorp/terraform-provider-$PROVIDER_NAME
+$ git clone git@github.com:terraform-providers/terraform-provider-$PROVIDER_NAME
 ```
 
 Enter the provider directory and build the provider


### PR DESCRIPTION
Change the Github organisation from hashicorp/ to terraform-providers/ so the repository can be cloned.