### PR TITLE
Change provider package path so `make build` succeeds.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/hashicorp/terraform-provider-google/google"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-google/google"
 )
 
 func main() {


### PR DESCRIPTION
Before:
```bash
$ make build
==> Checking that code complies with gofmt requirements...
go install
main.go:5:2: cannot find package "github.com/terraform-providers/hashicorp/google" in any of:
	<scrubbed>/go/src/github.com/hashicorp/terraform-provider-google/vendor/github.com/terraform-providers/hashicorp/google (vendor tree)
	/usr/lib/google-golang/src/github.com/terraform-providers/hashicorp/google (from $GOROOT)
	<scrubbed>/go/src/github.com/terraform-providers/hashicorp/google (from $GOPATH)
make: *** [build] Error 1
```

After:
```bash
$ make build
==> Checking that code complies with gofmt requirements...
go install
```