### PR TITLE
Updated checkout location in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-$PROVIDER_NAME`
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
 $ git clone git@github.com:terraform-providers/terraform-provider-$PROVIDER_NAME
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-$PROVIDER_NAME
+$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME
 $ make build
 ```
 


### PR DESCRIPTION
Looks like the CI expects the code to live in:
```
$GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME
```
instead of in:
```
$GOPATH/src/github.com/hashicorp/terraform-provider-$PROVIDER_NAME
```

Update the cloning instructions to reflect that.

Make build output after following these instructions:

```
$ make build
==> Checking that code complies with gofmt requirements...
go install
```