### PR TITLE
Add ability to import `google_sql_database`

### DIFF
--- a/google/import_sql_database_test.go
+++ b/google/import_sql_database_test.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGoogleSqlDatabase_importBasic(t *testing.T) {
+	resourceName := "google_sql_database.database"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabase_basic, acctest.RandString(10), acctest.RandString(10)),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -13,6 +14,9 @@ func resourceSqlDatabase() *schema.Resource {
 		Create: resourceSqlDatabaseCreate,
 		Read:   resourceSqlDatabaseRead,
 		Delete: resourceSqlDatabaseDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -84,6 +88,13 @@ func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
+	}
+
+	// In the import case this won't be set
+	if _, ok := d.GetOk("instance"); !ok {
+		s := strings.Split(d.Id(), ":")
+		d.Set("instance", s[0])
+		d.Set("name", s[1])
 	}
 
 	database_name := d.Get("name").(string)

--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -92,6 +92,12 @@ func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	s := strings.Split(d.Id(), ":")
+
+	if len(s) != 2 {
+		return fmt.Errorf("Error, failure importing database %s. "+
+			"ID format is instance:name", d.Id())
+	}
+
 	instance_name := s[0]
 	database_name := s[1]
 

--- a/google/resource_sql_database_test.go
+++ b/google/resource_sql_database_test.go
@@ -20,7 +20,8 @@ func TestAccGoogleSqlDatabase_basic(t *testing.T) {
 		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleSqlDatabase_basic,
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabase_basic, acctest.RandString(10), acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlDatabaseExists(
 						"google_sql_database.database", &database),
@@ -99,7 +100,7 @@ func testAccGoogleSqlDatabaseDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testGoogleSqlDatabase_basic = fmt.Sprintf(`
+var testGoogleSqlDatabase_basic = `
 resource "google_sql_database_instance" "instance" {
 	name = "sqldatabasetest%s"
 	region = "us-central"
@@ -112,4 +113,4 @@ resource "google_sql_database" "database" {
 	name = "sqldatabasetest%s"
 	instance = "${google_sql_database_instance.instance.name}"
 }
-`, acctest.RandString(10), acctest.RandString(10))
+`

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -48,3 +48,12 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Database resources can be imported using the `name` of the database instance
+combined with `name` of the database separated by a `:`, e.g.
+
+```
+$ terraform import google_sql_database.database instance_name:database_name
+```

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -24,7 +24,7 @@ resource "google_sql_database_instance" "master" {
 }
 
 resource "google_sql_database" "users" {
-  name     = "users"
+  name     = "users-db"
   instance = "${google_sql_database_instance.master.name}"
 }
 ```
@@ -51,9 +51,8 @@ exported:
 
 ## Import
 
-Database resources can be imported using the `name` of the database instance
-combined with `name` of the database separated by a `:`, e.g.
+SQL databases can be imported using the `instance` and `name`, e.g.
 
 ```
-$ terraform import google_sql_database.database instance_name:database_name
+$ terraform import google_sql_database.database master-instance:users-db
 ```


### PR DESCRIPTION
Previously raised as https://github.com/hashicorp/terraform/pull/15237

```$ make testacc TESTARGS='-run=TestAccGoogleSqlDatabase_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccGoogleSqlDatabase_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-google        [no test files]
=== RUN   TestAccGoogleSqlDatabase_importBasic
--- PASS: TestAccGoogleSqlDatabase_importBasic (78.63s)
=== RUN   TestAccGoogleSqlDatabase_basic
--- PASS: TestAccGoogleSqlDatabase_basic (67.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 145.863s
```