### PR TITLE
Typo: `make bin` => `make build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-google
 ...


### PR DESCRIPTION
```
# make bin
make: *** No rule to make target 'bin'.  Stop.
```