### PR TITLE
Changed google_compute_instance_group_manager target_size default to 0.

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -144,7 +144,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		InstanceTemplate: d.Get("instance_template").(string),
 		TargetSize:       targetSize,
 		// Force send TargetSize to allow a value of 0.
-		ForceSendFields:  []string{"TargetSize"},
+		ForceSendFields: []string{"TargetSize"},
 	}
 
 	// Set optional fields

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -132,10 +132,9 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	// Get group size, default to 1 if not given
-	var target_size int64 = 1
+	var targetSize int64 = 0
 	if v, ok := d.GetOk("target_size"); ok {
-		target_size = int64(v.(int))
+		targetSize = int64(v.(int))
 	}
 
 	// Build the parameter
@@ -143,7 +142,8 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		Name:             d.Get("name").(string),
 		BaseInstanceName: d.Get("base_instance_name").(string),
 		InstanceTemplate: d.Get("instance_template").(string),
-		TargetSize:       target_size,
+		TargetSize:       targetSize,
+		ForceSendFields:  []string{"TargetSize"},
 	}
 
 	// Set optional fields
@@ -256,7 +256,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	d.Set("named_port", flattenNamedPorts(manager.NamedPorts))
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", manager.InstanceGroup)
-	d.Set("target_size", manager.TargetSize)
 	d.Set("self_link", manager.SelfLink)
 	update_strategy, ok := d.GetOk("update_strategy")
 	if !ok {
@@ -382,23 +381,19 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		d.SetPartial("named_port")
 	}
 
-	// If size changes trigger a resize
+	// We won't ever see changes if target_size is unset
 	if d.HasChange("target_size") {
-		if v, ok := d.GetOk("target_size"); ok {
-			// Only do anything if the new size is set
-			target_size := int64(v.(int))
+		target_size := int64(d.Get("target_size").(int))
+		op, err := config.clientCompute.InstanceGroupManagers.Resize(
+			project, d.Get("zone").(string), d.Id(), target_size).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+		}
 
-			op, err := config.clientCompute.InstanceGroupManagers.Resize(
-				project, d.Get("zone").(string), d.Id(), target_size).Do()
-			if err != nil {
-				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-			}
-
-			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
-			if err != nil {
-				return err
-			}
+		// Wait for the operation to complete
+		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+		if err != nil {
+			return err
 		}
 
 		d.SetPartial("target_size")

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -132,7 +132,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	var targetSize int64 = 0
+	targetSize := int64(0)
 	if v, ok := d.GetOk("target_size"); ok {
 		targetSize = int64(v.(int))
 	}
@@ -143,6 +143,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		BaseInstanceName: d.Get("base_instance_name").(string),
 		InstanceTemplate: d.Get("instance_template").(string),
 		TargetSize:       targetSize,
+		// Force send TargetSize to allow a value of 0.
 		ForceSendFields:  []string{"TargetSize"},
 	}
 
@@ -381,11 +382,10 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		d.SetPartial("named_port")
 	}
 
-	// We won't ever see changes if target_size is unset
 	if d.HasChange("target_size") {
-		target_size := int64(d.Get("target_size").(int))
+		targetSize := int64(d.Get("target_size").(int))
 		op, err := config.clientCompute.InstanceGroupManagers.Resize(
-			project, d.Get("zone").(string), d.Id(), target_size).Do()
+			project, d.Get("zone").(string), d.Id(), targetSize).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 		}

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -42,8 +42,8 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 	var manager compute.InstanceGroupManager
 
-	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igmName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,7 +51,7 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccInstanceGroupManager_targetSizeZero(template, igm),
+				Config: testAccInstanceGroupManager_targetSizeZero(templateName, igmName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-basic", &manager),

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -74,9 +74,9 @@ The following arguments are supported:
     restart all of the instances at once. In the future, as the GCE API matures
     we will support `"ROLLING_UPDATE"` as well.
 
-* `target_size` - (Optional, Default `0`) The target number of running instances for this managed
+* `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to
-     an autoscaler, in which case it should never be set.
+     an autoscaler, in which case it should never be set. Defaults to `0`.
 
 * `target_pools` - (Optional) The full URL of all target pools to which new
     instances in the group are added. Updating the target pools attribute does

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -74,9 +74,9 @@ The following arguments are supported:
     restart all of the instances at once. In the future, as the GCE API matures
     we will support `"ROLLING_UPDATE"` as well.
 
-* `target_size` - (Optional) If not given at creation time, this defaults to 1.
-    Do not specify this if you are managing the group with an autoscaler, as
-    this will cause fighting.
+* `target_size` - (Optional, Default `0`) The target number of running instances for this managed
+    instance group. This value should always be explicitly set unless this resource is attached to
+     an autoscaler, in which case it should never be set.
 
 * `target_pools` - (Optional) The full URL of all target pools to which new
     instances in the group are added. Updating the target pools attribute does


### PR DESCRIPTION
Set the default target_size to 0 so that target sizes of 0 don't get set as the old default of 1. Existing configurations won't change as a result of changing the default, since the field is computed.

This is not a breaking change for existing configurations; resources with no value set will stay at their current setting. Scripts that rely on the old default of 1 at creation time will need to be updated.

Fixes #13 
@danawillow 