### PR TITLE
Support connection_draining_timeout_sec  in google_compute_region_backend_service

### DIFF
--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -165,6 +165,10 @@ func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testi
 			},
 		},
 	})
+
+	if svc.ConnectionDraining.DrainingTimeoutSec != 0 {
+		t.Errorf("Expected ConnectionDraining.DrainingTimeoutSec == 0, got %d", svc.ConnectionDraining.DrainingTimeoutSec)
+	}
 }
 
 func TestAccComputeRegionBackendService_withSessionAffinity(t *testing.T) {

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -14,7 +14,7 @@ and [API](https://cloud.google.com/compute/docs/reference/latest/backendServices
 
 ## Example Usage
 
-```tf
+```hcl
 resource "google_compute_region_backend_service" "foobar" {
   name             = "blablah"
   description      = "Hello World 1234"
@@ -95,6 +95,8 @@ The following arguments are supported:
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.
 
+* `connection_draining_timeout_sec` - (Optional) Time for which instance will be drained
+(not accept new connections, but still work to finish started ones). Defaults to `0`.
 
 The `backend` block supports:
 


### PR DESCRIPTION
Added connection_draining_timeout_sec support to google_compute_region_backend_service.

Regional equivalent to https://github.com/hashicorp/terraform/pull/14559
Part 2/2 for #85 
@danawillow 