### PR TITLE
Update existing resources import docs

### DIFF
--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -17,7 +17,7 @@ Creates a table resource in a dataset for Google BigQuery. For more information 
 
 ```hcl
 resource "google_bigquery_dataset" "default" {
-  dataset_id                  = "test"
+  dataset_id                  = "foo"
   friendly_name               = "test"
   description                 = "This is a test description"
   location                    = "EU"
@@ -30,7 +30,7 @@ resource "google_bigquery_dataset" "default" {
 
 resource "google_bigquery_table" "default" {
   dataset_id = "${google_bigquery_dataset.default.id}"
-  table_id   = "test"
+  table_id   = "bar"
 
   time_partitioning {
     type = "DAY"
@@ -106,8 +106,8 @@ exported:
 
 ## Import
 
-Tables can be imported using ID of the table (`projectID`:`datasetID`.`tableID`), e.g.
+BigQuery tables can be imported using the `project`, `dataset_id`, and `table_id`, e.g.
 
 ```
-$ terraform import bigquery_table.default testproject:testdataset.testtable
+$ terraform import bigquery_table.default gcp-project:foo.bar
 ```

--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -109,5 +109,5 @@ exported:
 BigQuery tables can be imported using the `project`, `dataset_id`, and `table_id`, e.g.
 
 ```
-$ terraform import bigquery_table.default gcp-project:foo.bar
+$ terraform import google_bigquery_table.default gcp-project:foo.bar
 ```

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -14,7 +14,7 @@ Manages a network within GCE.
 
 ```hcl
 resource "google_compute_network" "default" {
-  name                    = "test"
+  name                    = "foobar"
   auto_create_subnetworks = "true"
 }
 ```
@@ -63,5 +63,5 @@ exported:
 Networks can be imported using the `name`, e.g.
 
 ```
-$ terraform import google_compute_network.public my_network_name
+$ terraform import google_compute_network.default foobar
 ```

--- a/website/docs/r/compute_router.html.markdown
+++ b/website/docs/r/compute_router.html.markdown
@@ -146,6 +146,5 @@ exported:
 Routers can be imported using the `region` and `name`, e.g.
 
 ```
-$ terraform import google_compute_router.router-1 us-central1/router-1
+$ terraform import google_compute_router.foobar us-central1/router-1
 ```
-

--- a/website/docs/r/compute_router_interface.html.markdown
+++ b/website/docs/r/compute_router_interface.html.markdown
@@ -54,9 +54,8 @@ Only the arguments listed above are exposed as attributes.
 
 ## Import
 
-Router interfaces can be imported using the `region`, `router` and `name`, e.g.
+Router interfaces can be imported using the `region`, `router`, and `name`, e.g.
 
 ```
-$ terraform import google_compute_router_interface.interface-1 us-central1/router-1/interface-1
+$ terraform import google_compute_router_interface.foobar us-central1/router-1/interface-1
 ```
-

--- a/website/docs/r/compute_router_peer.html.markdown
+++ b/website/docs/r/compute_router_peer.html.markdown
@@ -65,8 +65,8 @@ exported:
 
 ## Import
 
-Router BGP peers can be imported using the `region`, `router` and `name`, e.g.
+Router BGP peers can be imported using the `region`, `router`, and `name`, e.g.
 
 ```
-$ terraform import google_compute_router_peer.peer-1 us-central1/router-1/peer-1
+$ terraform import google_compute_router_peer.foobar us-central1/router-1/peer-1
 ```

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -59,16 +59,10 @@ The following arguments are supported:
 
 Only the arguments listed above are exposed as attributes.
 
-## Import Format
+## Import
 
-Importing an SQL user is formatted as:
+SQL users can be imported using the `instance` and `name`, e.g.
 
-```bash
-terraform import google_sql_user.$RESOURCENAME $INSTANCENAME/$SQLUSERNAME
 ```
-
-For example, the sample at the top of this page could be imported with:
-
-```bash
-terraform import google_sql_user.users master-instance/me
+$ terraform import google_sql_user.users master-instance/me
 ```


### PR DESCRIPTION
We can improve the bottom-up discovery of importable GCP resources by improving the documentation on the page of resources that can be imported.

In each `Import` block;
- The fields specified as being used to import a resource should match their names in the schema exactly.
- The resource address and properties used to perform the example import should be the values used in the example.
- The properties used to perform an import should not be ambiguous; they should not share the same name, for example.
