### PR TITLE
Add Import blocks to docs for 5 various resources

### DIFF
--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -17,7 +17,7 @@ Creates a dataset resource for Google BigQuery. For more information see
 
 ```hcl
 resource "google_bigquery_dataset" "default" {
-  dataset_id                  = "test"
+  dataset_id                  = "foo"
   friendly_name               = "test"
   description                 = "This is a test description"
   location                    = "EU"
@@ -78,3 +78,11 @@ exported:
 
 * `last_modified_time` -  The date when this dataset or any of its tables was last modified,
   in milliseconds since the epoch.
+
+## Import
+
+BigQuery datasets can be imported using the `project` and `dataset_id`, e.g.
+
+```
+$ terraform import google_bigquery_dataset.default gcp-project:foo
+```

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -43,3 +43,11 @@ exported:
 
 * `self_link` - The URI of the created resource.
 * `address` - The IP of the created resource.
+
+## Import
+
+Addresses can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_address.default test-address
+```

--- a/website/docs/r/compute_autoscaler.html.markdown
+++ b/website/docs/r/compute_autoscaler.html.markdown
@@ -59,7 +59,7 @@ resource "google_compute_instance_group_manager" "foobar" {
 }
 
 resource "google_compute_autoscaler" "foobar" {
-  name   = "foobar"
+  name   = "scaler"
   zone   = "us-central1-f"
   target = "${google_compute_instance_group_manager.foobar.self_link}"
 
@@ -145,3 +145,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URL of the created resource.
+
+## Import
+
+Autoscalers can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_autoscaler.foobar scaler
+```

--- a/website/docs/r/compute_disk.html.markdown
+++ b/website/docs/r/compute_disk.html.markdown
@@ -67,3 +67,11 @@ exported:
     that protects this resource.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Disks can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_disk.default test-disk
+```

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -14,7 +14,7 @@ Manages a firewall resource within GCE.
 
 ```hcl
 resource "google_compute_firewall" "default" {
-  name    = "test"
+  name    = "test-firewall"
   network = "${google_compute_network.other.name}"
 
   allow {
@@ -69,3 +69,12 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+
+## Import
+
+Firewalls can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_firewall.default test-firewall
+```


### PR DESCRIPTION
Add docs specifying how to import 5 more of our 21 importable resources, bringing the total to 11. Specifically:

- google_bigquery_dataset
- google_compute_address
- google_compute_autoscaler
- google_compute_disk
- google_compute_firewall

Like in #119:

In each Import block;
- The fields specified as being used to import a resource should match their names in the schema exactly.
- The resource address and properties used to perform the example import should be the values used in the example.
- The properties used to perform an import should not be ambiguous; they should not share the same name, for example.