### PR TITLE
Add support for disk interface in google_compute_instance

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -57,6 +57,13 @@ func resourceComputeInstance() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"interface": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "SCSI",
+							ForceNew: true,
+						},
+
 						"auto_delete": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -410,6 +417,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		disk.Type = "PERSISTENT"
 		disk.Mode = "READ_WRITE"
 		disk.Boot = i == 0
+		disk.Interface = d.Get(prefix + ".interface").(string)
 		disk.AutoDelete = d.Get(prefix + ".auto_delete").(bool)
 
 		if _, ok := d.GetOk(prefix + ".disk"); ok {
@@ -867,6 +875,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 				"image":                   d.Get(fmt.Sprintf("disk.%d.image", dIndex)),
 				"type":                    d.Get(fmt.Sprintf("disk.%d.type", dIndex)),
 				"scratch":                 d.Get(fmt.Sprintf("disk.%d.scratch", dIndex)),
+				"interface":               d.Get(fmt.Sprintf("disk.%d.interface", dIndex)),
 				"auto_delete":             d.Get(fmt.Sprintf("disk.%d.auto_delete", dIndex)),
 				"size":                    d.Get(fmt.Sprintf("disk.%d.size", dIndex)),
 				"device_name":             d.Get(fmt.Sprintf("disk.%d.device_name", dIndex)),

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -303,6 +303,27 @@ func TestAccComputeInstance_local_ssd(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_local_ssd_nvme(t *testing.T) {
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_local_ssd_nvme(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.local-ssd-nvme", &instance),
+					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_update_deprecated_network(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
@@ -1218,6 +1239,30 @@ func testAccComputeInstance_local_ssd(instance string) string {
 		disk {
 			type = "local-ssd"
 			scratch = true
+		}
+
+		network_interface {
+			network = "default"
+		}
+
+	}`, instance)
+}
+
+func testAccComputeInstance_local_ssd_nvme(instance string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_instance" "local-ssd-nvme" {
+		name = "%s"
+		machine_type = "n1-standard-1"
+		zone = "us-central1-a"
+
+		disk {
+			image = "debian-8-jessie-v20160803"
+		}
+
+		disk {
+			type = "local-ssd"
+			scratch = true
+			interface = "NVME"
 		}
 
 		network_interface {

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -131,6 +131,11 @@ the type is "local-ssd", in which case scratch must be true).
 * `scratch` - (Optional) Whether the disk is a scratch disk as opposed to a
     persistent disk (required for local-ssd).
 
+* `interface` - (Optional) Specifies the disk interface to use for attaching this disk,
+    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use
+    SCSI and the request will fail if you attempt to attach a persistent disk in any
+    other format than SCSI. Local SSDs can use either NVME or SCSI.
+
 * `size` - (Optional) The size of the image in gigabytes. If not specified, it
     will inherit the size of its base image. Do not specify for local SSDs as
     their size is fixed.


### PR DESCRIPTION
This allows specifying the disk interface as documented at
https://cloud.google.com/compute/docs/reference/latest/instances#resource-representations

It addresses https://github.com/terraform-providers/terraform-provider-google/issues/24

```
$ make testacc TESTARGS='-run=TestAccComputeInstance_local_ssd'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccComputeInstance_local_ssd -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccComputeInstance_local_ssd
--- PASS: TestAccComputeInstance_local_ssd (66.80s)
=== RUN   TestAccComputeInstance_local_ssd_nvme
--- PASS: TestAccComputeInstance_local_ssd_nvme (64.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	130.834s
```