### PR TITLE
Refactor resource_compute_instance_group_manager for multi version support

### DIFF
--- a/google/api_levels.go
+++ b/google/api_levels.go
@@ -1,0 +1,8 @@
+package google
+
+type ApiLevel uint8
+
+const (
+	// PRODUCTION is the GA API.
+	PRODUCTION ApiLevel = iota
+)

--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -1,0 +1,22 @@
+package google
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+func computeSharedOperationWaitZone(config *Config, op interface{}, project string, zone, activity string) error {
+	return computeSharedOperationWaitZoneTime(config, op, project, zone, 4, activity)
+}
+
+func computeSharedOperationWaitZoneTime(config *Config, op interface{}, project string, zone string, minutes int, activity string) error {
+	if op == nil {
+		panic("Attempted to wait on an Operation that was nil.")
+	}
+
+	switch op.(type) {
+	case *compute.Operation:
+		return computeOperationWaitZoneTime(config, op.(*compute.Operation), project, zone, minutes, activity)
+	default:
+		panic("Attempted to wait on an Operation of unknown type.")
+	}
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -80,7 +80,7 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_image":                  resourceComputeImage(),
 			"google_compute_instance":               resourceComputeInstance(),
 			"google_compute_instance_group":         resourceComputeInstanceGroup(),
-			"google_compute_instance_group_manager": resourceComputeInstanceGroupManager(),
+			"google_compute_instance_group_manager": resourceComputeInstanceGroupManager(PRODUCTION),
 			"google_compute_instance_template":      resourceComputeInstanceTemplate(),
 			"google_compute_network":                resourceComputeNetwork(),
 			"google_compute_project_metadata":       resourceComputeProjectMetadata(),

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -344,3 +344,15 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 	d.SetId("")
 	return nil
 }
+
+func getNamedPorts(nps []interface{}) []*compute.NamedPort {
+	namedPorts := make([]*compute.NamedPort, 0, len(nps))
+	for _, v := range nps {
+		np := v.(map[string]interface{})
+		namedPorts = append(namedPorts, &compute.NamedPort{
+			Name: np["name"].(string),
+			Port: int64(np["port"].(int)),
+		})
+	}
+	return namedPorts
+}

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -7,15 +7,17 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-google/google/shared"
+
 	"google.golang.org/api/compute/v1"
 )
 
-func resourceComputeInstanceGroupManager() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceComputeInstanceGroupManagerCreate,
-		Read:   resourceComputeInstanceGroupManagerRead,
-		Update: resourceComputeInstanceGroupManagerUpdate,
-		Delete: resourceComputeInstanceGroupManagerDelete,
+func resourceComputeInstanceGroupManager(apiLevel ApiLevel) *schema.Resource {
+	s := &schema.Resource{
+		Create: resourceComputeInstanceGroupManagerCreate(apiLevel),
+		Read:   resourceComputeInstanceGroupManagerRead(apiLevel),
+		Update: resourceComputeInstanceGroupManagerUpdate(apiLevel),
+		Delete: resourceComputeInstanceGroupManagerDelete(apiLevel),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -28,8 +30,9 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"instance_template": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 
 			"name": &schema.Schema{
@@ -99,8 +102,11 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"target_pools": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: compareSelfLinkRelativePaths,
+				},
+				Set: selfLinkRelativePathHash,
 			},
 
 			"target_size": &schema.Schema{
@@ -110,13 +116,15 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 		},
 	}
+
+	return s
 }
 
-func getNamedPorts(nps []interface{}) []*compute.NamedPort {
-	namedPorts := make([]*compute.NamedPort, 0, len(nps))
+func getNamedPortsShared(nps []interface{}) []*shared.NamedPort {
+	namedPorts := make([]*shared.NamedPort, 0, len(nps))
 	for _, v := range nps {
 		np := v.(map[string]interface{})
-		namedPorts = append(namedPorts, &compute.NamedPort{
+		namedPorts = append(namedPorts, &shared.NamedPort{
 			Name: np["name"].(string),
 			Port: int64(np["port"].(int)),
 		})
@@ -124,70 +132,78 @@ func getNamedPorts(nps []interface{}) []*compute.NamedPort {
 	return namedPorts
 }
 
-func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
+func resourceComputeInstanceGroupManagerCreate(apiLevel ApiLevel) func(d *schema.ResourceData, meta interface{}) error {
+	level := apiLevel
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	// Get group size, default to 1 if not given
-	var target_size int64 = 1
-	if v, ok := d.GetOk("target_size"); ok {
-		target_size = int64(v.(int))
-	}
-
-	// Build the parameter
-	manager := &compute.InstanceGroupManager{
-		Name:             d.Get("name").(string),
-		BaseInstanceName: d.Get("base_instance_name").(string),
-		InstanceTemplate: d.Get("instance_template").(string),
-		TargetSize:       target_size,
-	}
-
-	// Set optional fields
-	if v, ok := d.GetOk("description"); ok {
-		manager.Description = v.(string)
-	}
-
-	if v, ok := d.GetOk("named_port"); ok {
-		manager.NamedPorts = getNamedPorts(v.([]interface{}))
-	}
-
-	if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
-		var s []string
-		for _, v := range attr.List() {
-			s = append(s, v.(string))
+		project, err := getProject(d, config)
+		if err != nil {
+			return err
 		}
-		manager.TargetPools = s
+
+		// Get group size, default to 1 if not given
+		var target_size int64 = 1
+		if v, ok := d.GetOk("target_size"); ok {
+			target_size = int64(v.(int))
+		}
+
+		// Build the parameter
+		manager := &shared.InstanceGroupManager{
+			Name:             d.Get("name").(string),
+			BaseInstanceName: d.Get("base_instance_name").(string),
+			InstanceTemplate: d.Get("instance_template").(string),
+			TargetSize:       target_size,
+		}
+
+		// Set optional fields
+		if v, ok := d.GetOk("description"); ok {
+			manager.Description = v.(string)
+		}
+
+		if v, ok := d.GetOk("named_port"); ok {
+			manager.NamedPorts = getNamedPortsShared(v.([]interface{}))
+		}
+
+		if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
+			var s []string
+			for _, v := range attr.List() {
+				s = append(s, v.(string))
+			}
+			manager.TargetPools = s
+		}
+
+		updateStrategy := d.Get("update_strategy").(string)
+		if !(updateStrategy == "NONE" || updateStrategy == "RESTART") {
+			return fmt.Errorf("Update strategy must be \"NONE\" or \"RESTART\"")
+		}
+
+		log.Printf("[DEBUG] InstanceGroupManager insert request: %#v", manager)
+		var op interface{}
+		switch level {
+		case PRODUCTION:
+			op, err = config.clientCompute.InstanceGroupManagers.Insert(
+				project, d.Get("zone").(string), manager.ToProduction()).Do()
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error creating InstanceGroupManager: %s", err)
+		}
+
+		// It probably maybe worked, so store the ID now
+		d.SetId(manager.Name)
+
+		// Wait for the operation to complete
+		err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating InstanceGroupManager")
+		if err != nil {
+			return err
+		}
+
+		return resourceComputeInstanceGroupManagerRead(level)(d, meta)
 	}
-
-	updateStrategy := d.Get("update_strategy").(string)
-	if !(updateStrategy == "NONE" || updateStrategy == "RESTART") {
-		return fmt.Errorf("Update strategy must be \"NONE\" or \"RESTART\"")
-	}
-
-	log.Printf("[DEBUG] InstanceGroupManager insert request: %#v", manager)
-	op, err := config.clientCompute.InstanceGroupManagers.Insert(
-		project, d.Get("zone").(string), manager).Do()
-	if err != nil {
-		return fmt.Errorf("Error creating InstanceGroupManager: %s", err)
-	}
-
-	// It probably maybe worked, so store the ID now
-	d.SetId(manager.Name)
-
-	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating InstanceGroupManager")
-	if err != nil {
-		return err
-	}
-
-	return resourceComputeInstanceGroupManagerRead(d, meta)
 }
 
-func flattenNamedPorts(namedPorts []*compute.NamedPort) []map[string]interface{} {
+func flattenNamedPorts(namedPorts []*shared.NamedPort) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(namedPorts))
 	for _, namedPort := range namedPorts {
 		namedPortMap := make(map[string]interface{})
@@ -199,264 +215,315 @@ func flattenNamedPorts(namedPorts []*compute.NamedPort) []map[string]interface{}
 
 }
 
-func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
+func resourceComputeInstanceGroupManagerRead(apiLevel ApiLevel) func(d *schema.ResourceData, meta interface{}) error {
+	level := apiLevel
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	region, err := getRegion(d, config)
-	if err != nil {
-		return err
-	}
-
-	getInstanceGroupManager := func(zone string) (interface{}, error) {
-		return config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
-	}
-
-	var manager *compute.InstanceGroupManager
-	var e error
-	if zone, ok := d.GetOk("zone"); ok {
-		manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
-
-		if e != nil {
-			return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
-		}
-	} else {
-		// If the resource was imported, the only info we have is the ID. Try to find the resource
-		// by searching in the region of the project.
-		var resource interface{}
-		resource, e = getZonalResourceFromRegion(getInstanceGroupManager, region, config.clientCompute, project)
-
-		if e != nil {
-			return e
+		project, err := getProject(d, config)
+		if err != nil {
+			return err
 		}
 
-		manager = resource.(*compute.InstanceGroupManager)
-	}
+		region, err := getRegion(d, config)
+		if err != nil {
+			return err
+		}
 
-	if manager == nil {
-		log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
-		// The resource doesn't exist anymore
-		d.SetId("")
+		var manager *shared.InstanceGroupManager
+		switch level {
+		case PRODUCTION:
+			getInstanceGroupManager := func(zone string) (interface{}, error) {
+				return config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
+			}
+
+			var productionManager *compute.InstanceGroupManager
+			var e error
+			if zone, ok := d.GetOk("zone"); ok {
+				productionManager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
+
+				if e != nil {
+					return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
+				}
+			} else {
+				// If the resource was imported, the only info we have is the ID. Try to find the resource
+				// by searching in the region of the project.
+				var resource interface{}
+				resource, e = getZonalResourceFromRegion(getInstanceGroupManager, region, config.clientCompute, project)
+
+				if e != nil {
+					return e
+				}
+
+				productionManager = resource.(*compute.InstanceGroupManager)
+			}
+
+			if productionManager == nil {
+				log.Printf("[WARN] Removing Instance Group Manager %q because it's gone", d.Get("name").(string))
+
+				// The resource doesn't exist anymore
+				d.SetId("")
+				return nil
+			}
+
+			manager = shared.InstanceGroupManagerFromProduction(productionManager)
+		}
+
+		zoneUrl := strings.Split(manager.Zone, "/")
+		d.Set("base_instance_name", manager.BaseInstanceName)
+		d.Set("instance_template", manager.InstanceTemplate)
+		d.Set("name", manager.Name)
+		d.Set("zone", zoneUrl[len(zoneUrl)-1])
+		d.Set("description", manager.Description)
+		d.Set("project", project)
+		d.Set("target_size", manager.TargetSize)
+		d.Set("target_pools", manager.TargetPools)
+		d.Set("named_port", flattenNamedPorts(manager.NamedPorts))
+		d.Set("fingerprint", manager.Fingerprint)
+		d.Set("instance_group", manager.InstanceGroup)
+		d.Set("target_size", manager.TargetSize)
+		d.Set("self_link", manager.SelfLink)
+		update_strategy, ok := d.GetOk("update_strategy")
+		if !ok {
+			update_strategy = "RESTART"
+		}
+		d.Set("update_strategy", update_strategy.(string))
+
 		return nil
 	}
-
-	zoneUrl := strings.Split(manager.Zone, "/")
-	d.Set("base_instance_name", manager.BaseInstanceName)
-	d.Set("instance_template", manager.InstanceTemplate)
-	d.Set("name", manager.Name)
-	d.Set("zone", zoneUrl[len(zoneUrl)-1])
-	d.Set("description", manager.Description)
-	d.Set("project", project)
-	d.Set("target_size", manager.TargetSize)
-	d.Set("target_pools", manager.TargetPools)
-	d.Set("named_port", flattenNamedPorts(manager.NamedPorts))
-	d.Set("fingerprint", manager.Fingerprint)
-	d.Set("instance_group", manager.InstanceGroup)
-	d.Set("target_size", manager.TargetSize)
-	d.Set("self_link", manager.SelfLink)
-	update_strategy, ok := d.GetOk("update_strategy")
-	if !ok {
-		update_strategy = "RESTART"
-	}
-	d.Set("update_strategy", update_strategy.(string))
-
-	return nil
 }
-func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
+func resourceComputeInstanceGroupManagerUpdate(apiLevel ApiLevel) func(d *schema.ResourceData, meta interface{}) error {
+	level := apiLevel
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	d.Partial(true)
-
-	// If target_pools changes then update
-	if d.HasChange("target_pools") {
-		var targetPools []string
-		if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
-			for _, v := range attr.List() {
-				targetPools = append(targetPools, v.(string))
-			}
-		}
-
-		// Build the parameter
-		setTargetPools := &compute.InstanceGroupManagersSetTargetPoolsRequest{
-			Fingerprint: d.Get("fingerprint").(string),
-			TargetPools: targetPools,
-		}
-
-		op, err := config.clientCompute.InstanceGroupManagers.SetTargetPools(
-			project, d.Get("zone").(string), d.Id(), setTargetPools).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+		project, err := getProject(d, config)
 		if err != nil {
 			return err
 		}
 
-		d.SetPartial("target_pools")
-	}
+		d.Partial(true)
 
-	// If instance_template changes then update
-	if d.HasChange("instance_template") {
-		// Build the parameter
-		setInstanceTemplate := &compute.InstanceGroupManagersSetInstanceTemplateRequest{
-			InstanceTemplate: d.Get("instance_template").(string),
-		}
-
-		op, err := config.clientCompute.InstanceGroupManagers.SetInstanceTemplate(
-			project, d.Get("zone").(string), d.Id(), setInstanceTemplate).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
-		if err != nil {
-			return err
-		}
-
-		if d.Get("update_strategy").(string) == "RESTART" {
-			managedInstances, err := config.clientCompute.InstanceGroupManagers.ListManagedInstances(
-				project, d.Get("zone").(string), d.Id()).Do()
-
-			managedInstanceCount := len(managedInstances.ManagedInstances)
-			instances := make([]string, managedInstanceCount)
-			for i, v := range managedInstances.ManagedInstances {
-				instances[i] = v.Instance
+		// If target_pools changes then update
+		if d.HasChange("target_pools") {
+			var targetPools []string
+			if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
+				for _, v := range attr.List() {
+					targetPools = append(targetPools, v.(string))
+				}
 			}
 
-			recreateInstances := &compute.InstanceGroupManagersRecreateInstancesRequest{
-				Instances: instances,
+			// Build the parameter
+			setTargetPools := &shared.InstanceGroupManagersSetTargetPoolsRequest{
+				Fingerprint: d.Get("fingerprint").(string),
+				TargetPools: targetPools,
 			}
 
-			op, err = config.clientCompute.InstanceGroupManagers.RecreateInstances(
-				project, d.Get("zone").(string), d.Id(), recreateInstances).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error restarting instance group managers instances: %s", err)
+			var op interface{}
+			switch level {
+			case PRODUCTION:
+				op, err = config.clientCompute.InstanceGroupManagers.SetTargetPools(
+					project, d.Get("zone").(string), d.Id(), setTargetPools.ToProduction()).Do()
 			}
 
-			// Wait for the operation to complete
-			err = computeOperationWaitZoneTime(config, op, project, d.Get("zone").(string),
-				managedInstanceCount*4, "Restarting InstanceGroupManagers instances")
-			if err != nil {
-				return err
-			}
-		}
-
-		d.SetPartial("instance_template")
-	}
-
-	// If named_port changes then update:
-	if d.HasChange("named_port") {
-
-		// Build the parameters for a "SetNamedPorts" request:
-		namedPorts := getNamedPorts(d.Get("named_port").([]interface{}))
-		setNamedPorts := &compute.InstanceGroupsSetNamedPortsRequest{
-			NamedPorts: namedPorts,
-		}
-
-		// Make the request:
-		op, err := config.clientCompute.InstanceGroups.SetNamedPorts(
-			project, d.Get("zone").(string), d.Id(), setNamedPorts).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete:
-		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("named_port")
-	}
-
-	// If size changes trigger a resize
-	if d.HasChange("target_size") {
-		if v, ok := d.GetOk("target_size"); ok {
-			// Only do anything if the new size is set
-			target_size := int64(v.(int))
-
-			op, err := config.clientCompute.InstanceGroupManagers.Resize(
-				project, d.Get("zone").(string), d.Id(), target_size).Do()
 			if err != nil {
 				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+			err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
 			if err != nil {
 				return err
 			}
+
+			d.SetPartial("target_pools")
 		}
 
-		d.SetPartial("target_size")
+		// If instance_template changes then update
+		if d.HasChange("instance_template") {
+			// Build the parameter
+			setInstanceTemplate := &shared.InstanceGroupManagersSetInstanceTemplateRequest{
+				InstanceTemplate: d.Get("instance_template").(string),
+			}
+
+			var op interface{}
+			switch level {
+			case PRODUCTION:
+				op, err = config.clientCompute.InstanceGroupManagers.SetInstanceTemplate(
+					project, d.Get("zone").(string), d.Id(), setInstanceTemplate.ToProduction()).Do()
+			}
+
+			if err != nil {
+				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+			}
+
+			// Wait for the operation to complete
+			err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+			if err != nil {
+				return err
+			}
+
+			if d.Get("update_strategy").(string) == "RESTART" {
+				// While there is an opportunity to have more shared code here, the ManagedInstances
+				// type goes 5 levels deep. For now at least, it isn't worth converting this section.
+				var managedInstanceCount int
+				switch level {
+				case PRODUCTION:
+					managedInstances, err := config.clientCompute.InstanceGroupManagers.ListManagedInstances(
+						project, d.Get("zone").(string), d.Id()).Do()
+
+					managedInstanceCount = len(managedInstances.ManagedInstances)
+					instances := make([]string, managedInstanceCount)
+					for i, v := range managedInstances.ManagedInstances {
+						instances[i] = v.Instance
+					}
+
+					recreateInstances := &compute.InstanceGroupManagersRecreateInstancesRequest{
+						Instances: instances,
+					}
+
+					op, err = config.clientCompute.InstanceGroupManagers.RecreateInstances(
+						project, d.Get("zone").(string), d.Id(), recreateInstances).Do()
+
+					if err != nil {
+						return fmt.Errorf("Error restarting instance group managers instances: %s", err)
+					}
+				}
+
+				// Wait for the operation to complete
+				err = computeSharedOperationWaitZoneTime(config, op, project, d.Get("zone").(string),
+					managedInstanceCount*4, "Restarting InstanceGroupManagers instances")
+				if err != nil {
+					return err
+				}
+			}
+
+			d.SetPartial("instance_template")
+		}
+
+		// If named_port changes then update:
+		if d.HasChange("named_port") {
+
+			// Build the parameters for a "SetNamedPorts" request:
+			namedPorts := getNamedPortsShared(d.Get("named_port").([]interface{}))
+			setNamedPorts := &shared.InstanceGroupsSetNamedPortsRequest{
+				NamedPorts: namedPorts,
+			}
+
+			// Make the request:
+			var op interface{}
+			switch level {
+			case PRODUCTION:
+				op, err = config.clientCompute.InstanceGroups.SetNamedPorts(
+					project, d.Get("zone").(string), d.Id(), setNamedPorts.ToProduction()).Do()
+			}
+
+			if err != nil {
+				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+			}
+
+			// Wait for the operation to complete:
+			err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+			if err != nil {
+				return err
+			}
+
+			d.SetPartial("named_port")
+		}
+
+		// If size changes trigger a resize
+		if d.HasChange("target_size") {
+			if v, ok := d.GetOk("target_size"); ok {
+				// Only do anything if the new size is set
+				target_size := int64(v.(int))
+
+				var op interface{}
+				switch level {
+				case PRODUCTION:
+					op, err = config.clientCompute.InstanceGroupManagers.Resize(
+						project, d.Get("zone").(string), d.Id(), target_size).Do()
+				}
+
+				if err != nil {
+					return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+				}
+
+				// Wait for the operation to complete
+				err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Updating InstanceGroupManager")
+				if err != nil {
+					return err
+				}
+			}
+
+			d.SetPartial("target_size")
+		}
+
+		d.Partial(false)
+
+		return resourceComputeInstanceGroupManagerRead(level)(d, meta)
 	}
-
-	d.Partial(false)
-
-	return resourceComputeInstanceGroupManagerRead(d, meta)
 }
 
-func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
+func resourceComputeInstanceGroupManagerDelete(apiLevel ApiLevel) func(d *schema.ResourceData, meta interface{}) error {
+	level := apiLevel
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	zone := d.Get("zone").(string)
-	op, err := config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
-	attempt := 0
-	for err != nil && attempt < 20 {
-		attempt++
-		time.Sleep(2000 * time.Millisecond)
-		op, err = config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
-	}
-	if err != nil {
-		return fmt.Errorf("Error deleting instance group manager: %s", err)
-	}
-
-	currentSize := int64(d.Get("target_size").(int))
-
-	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
-
-	for err != nil && currentSize > 0 {
-		if !strings.Contains(err.Error(), "timeout") {
+		project, err := getProject(d, config)
+		if err != nil {
 			return err
 		}
 
-		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
-			project, d.Get("zone").(string), d.Id()).Do()
+		zone := d.Get("zone").(string)
+
+		var op interface{}
+		switch level {
+		case PRODUCTION:
+			op, err = config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
+			attempt := 0
+			for err != nil && attempt < 20 {
+				attempt++
+				time.Sleep(2000 * time.Millisecond)
+				op, err = config.clientCompute.InstanceGroupManagers.Delete(project, zone, d.Id()).Do()
+			}
+		}
 
 		if err != nil {
-			return fmt.Errorf("Error getting instance group size: %s", err)
+			return fmt.Errorf("Error deleting instance group manager: %s", err)
 		}
 
-		if instanceGroup.Size >= currentSize {
-			return fmt.Errorf("Error, instance group isn't shrinking during delete")
+		currentSize := int64(d.Get("target_size").(int))
+
+		// Wait for the operation to complete
+		err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
+
+		for err != nil && currentSize > 0 {
+			if !strings.Contains(err.Error(), "timeout") {
+				return err
+			}
+
+			var instanceGroupSize int64
+			switch level {
+			case PRODUCTION:
+				instanceGroup, err := config.clientCompute.InstanceGroups.Get(
+					project, d.Get("zone").(string), d.Id()).Do()
+				if err != nil {
+					return fmt.Errorf("Error getting instance group size: %s", err)
+				}
+
+				instanceGroupSize = instanceGroup.Size
+			}
+
+			if instanceGroupSize >= currentSize {
+				return fmt.Errorf("Error, instance group isn't shrinking during delete")
+			}
+
+			log.Printf("[INFO] timeout occured, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
+			currentSize = instanceGroupSize
+			err = computeSharedOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
 		}
 
-		log.Printf("[INFO] timeout occured, but instance group is shrinking (%d < %d)", instanceGroup.Size, currentSize)
-
-		currentSize = instanceGroup.Size
-
-		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Deleting InstanceGroupManager")
+		d.SetId("")
+		return nil
 	}
-
-	d.SetId("")
-	return nil
 }

--- a/google/self_link_relative_path_helpers.go
+++ b/google/self_link_relative_path_helpers.go
@@ -1,0 +1,42 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+// Compare only the relative path of two self links.
+func compareSelfLinkRelativePaths(k, old, new string, d *schema.ResourceData) bool {
+	oldStripped, err := getRelativePath(old)
+	if err != nil {
+		return false
+	}
+
+	newStripped, err := getRelativePath(new)
+	if err != nil {
+		return false
+	}
+
+	if oldStripped == newStripped {
+		return true
+	}
+
+	return false
+}
+
+// Hash the relative path of a self link.
+func selfLinkRelativePathHash(selfLink interface{}) int {
+	path, _ := getRelativePath(selfLink.(string))
+	return hashcode.String(path)
+}
+
+func getRelativePath(selfLink string) (string, error) {
+	stringParts := strings.SplitAfterN(selfLink, "/", 6)
+	if len(stringParts) != 6 {
+		return "", fmt.Errorf("String was not a self link %s", selfLink)
+	}
+
+	return stringParts[5], nil
+}

--- a/google/shared/instance_group_manager.go
+++ b/google/shared/instance_group_manager.go
@@ -1,0 +1,156 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// InstanceGroupManager: An Instance Group Manager resource.
+type InstanceGroupManager struct {
+	// BaseInstanceName: The base instance name to use for instances in this
+	// group. The value must be 1-58 characters long. Instances are named by
+	// appending a hyphen and a random four-character string to the base
+	// instance name. The base instance name must comply with RFC1035.
+	BaseInstanceName string `json:"baseInstanceName,omitempty"`
+
+	// CreationTimestamp: [Output Only] The creation timestamp for this
+	// managed instance group in RFC3339 text format.
+	CreationTimestamp string `json:"creationTimestamp,omitempty"`
+
+	// CurrentActions: [Output Only] The list of instance actions and the
+	// number of instances in this managed instance group that are scheduled
+	// for each of those actions.
+	CurrentActions *InstanceGroupManagerActionsSummary `json:"currentActions,omitempty"`
+
+	// Description: An optional description of this resource. Provide this
+	// property when you create the resource.
+	Description string `json:"description,omitempty"`
+
+	// Fingerprint: [Output Only] The fingerprint of the resource data. You
+	// can use this optional field for optimistic locking when you update
+	// the resource.
+	Fingerprint string `json:"fingerprint,omitempty"`
+
+	// Id: [Output Only] A unique identifier for this resource type. The
+	// server generates this identifier.
+	Id uint64 `json:"id,omitempty,string"`
+
+	// InstanceGroup: [Output Only] The URL of the Instance Group resource.
+	InstanceGroup string `json:"instanceGroup,omitempty"`
+
+	// InstanceTemplate: The URL of the instance template that is specified
+	// for this managed instance group. The group uses this template to
+	// create all new instances in the managed instance group.
+	InstanceTemplate string `json:"instanceTemplate,omitempty"`
+
+	// Kind: [Output Only] The resource type, which is always
+	// compute#instanceGroupManager for managed instance groups.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: The name of the managed instance group. The name must be 1-63
+	// characters long, and comply with RFC1035.
+	Name string `json:"name,omitempty"`
+
+	// NamedPorts: Named ports configured for the Instance Groups
+	// complementary to this Instance Group Manager.
+	NamedPorts []*NamedPort `json:"namedPorts,omitempty"`
+
+	// Region: [Output Only] The URL of the region where the managed
+	// instance group resides (for regional resources).
+	Region string `json:"region,omitempty"`
+
+	// SelfLink: [Output Only] The URL for this managed instance group. The
+	// server defines this URL.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// TargetPools: The URLs for all TargetPool resources to which instances
+	// in the instanceGroup field are added. The target pools automatically
+	// apply to all of the instances in the managed instance group.
+	TargetPools []string `json:"targetPools,omitempty"`
+
+	// TargetSize: The target number of running instances for this managed
+	// instance group. Deleting or abandoning instances reduces this number.
+	// Resizing the group changes this number.
+	TargetSize int64 `json:"targetSize,omitempty"`
+
+	// Zone: [Output Only] The URL of the zone where the managed instance
+	// group is located (for zonal resources).
+	Zone string `json:"zone,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "BaseInstanceName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BaseInstanceName") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstanceGroupManager) ToProduction() *compute.InstanceGroupManager {
+	if s == nil {
+		return nil
+	}
+
+	return &compute.InstanceGroupManager{
+		BaseInstanceName:  s.BaseInstanceName,
+		CreationTimestamp: s.CreationTimestamp,
+		CurrentActions:    s.CurrentActions.ToProduction(),
+		Description:       s.Description,
+		Fingerprint:       s.Fingerprint,
+		Id:                s.Id,
+		InstanceGroup:     s.InstanceGroup,
+		InstanceTemplate:  s.InstanceTemplate,
+		Kind:              s.Kind,
+		Name:              s.Name,
+		NamedPorts:        NamedPortsToProduction(s.NamedPorts),
+		Region:            s.Region,
+		SelfLink:          s.SelfLink,
+		TargetPools:       s.TargetPools,
+		TargetSize:        s.TargetSize,
+		Zone:              s.Zone,
+		ServerResponse:    s.ServerResponse,
+		ForceSendFields:   s.ForceSendFields,
+		NullFields:        s.NullFields,
+	}
+}
+
+func InstanceGroupManagerFromProduction(s *compute.InstanceGroupManager) *InstanceGroupManager {
+	if s == nil {
+		return nil
+	}
+
+	return &InstanceGroupManager{
+		BaseInstanceName:  s.BaseInstanceName,
+		CreationTimestamp: s.CreationTimestamp,
+		CurrentActions:    InstanceGroupManagerActionsSummaryFromProduction(s.CurrentActions),
+		Description:       s.Description,
+		Fingerprint:       s.Fingerprint,
+		Id:                s.Id,
+		InstanceGroup:     s.InstanceGroup,
+		InstanceTemplate:  s.InstanceTemplate,
+		Kind:              s.Kind,
+		Name:              s.Name,
+		NamedPorts:        NamedPortsFromProduction(s.NamedPorts),
+		Region:            s.Region,
+		SelfLink:          s.SelfLink,
+		TargetPools:       s.TargetPools,
+		TargetSize:        s.TargetSize,
+		Zone:              s.Zone,
+		ServerResponse:    s.ServerResponse,
+		ForceSendFields:   s.ForceSendFields,
+		NullFields:        s.NullFields,
+	}
+}

--- a/google/shared/instance_group_manager_actions_summary.go
+++ b/google/shared/instance_group_manager_actions_summary.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+type InstanceGroupManagerActionsSummary struct {
+	// Abandoning: [Output Only] The total number of instances in the
+	// managed instance group that are scheduled to be abandoned. Abandoning
+	// an instance removes it from the managed instance group without
+	// deleting it.
+	Abandoning int64 `json:"abandoning,omitempty"`
+
+	// Creating: [Output Only] The number of instances in the managed
+	// instance group that are scheduled to be created or are currently
+	// being created. If the group fails to create any of these instances,
+	// it tries again until it creates the instance successfully.
+	//
+	// If you have disabled creation retries, this field will not be
+	// populated; instead, the creatingWithoutRetries field will be
+	// populated.
+	Creating int64 `json:"creating,omitempty"`
+
+	// CreatingWithoutRetries: [Output Only] The number of instances that
+	// the managed instance group will attempt to create. The group attempts
+	// to create each instance only once. If the group fails to create any
+	// of these instances, it decreases the group's targetSize value
+	// accordingly.
+	CreatingWithoutRetries int64 `json:"creatingWithoutRetries,omitempty"`
+
+	// Deleting: [Output Only] The number of instances in the managed
+	// instance group that are scheduled to be deleted or are currently
+	// being deleted.
+	Deleting int64 `json:"deleting,omitempty"`
+
+	// None: [Output Only] The number of instances in the managed instance
+	// group that are running and have no scheduled actions.
+	None int64 `json:"none,omitempty"`
+
+	// Recreating: [Output Only] The number of instances in the managed
+	// instance group that are scheduled to be recreated or are currently
+	// being being recreated. Recreating an instance deletes the existing
+	// root persistent disk and creates a new disk from the image that is
+	// defined in the instance template.
+	Recreating int64 `json:"recreating,omitempty"`
+
+	// Refreshing: [Output Only] The number of instances in the managed
+	// instance group that are being reconfigured with properties that do
+	// not require a restart or a recreate action. For example, setting or
+	// removing target pools for the instance.
+	Refreshing int64 `json:"refreshing,omitempty"`
+
+	// Restarting: [Output Only] The number of instances in the managed
+	// instance group that are scheduled to be restarted or are currently
+	// being restarted.
+	Restarting int64 `json:"restarting,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Abandoning") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Abandoning") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstanceGroupManagerActionsSummary) ToProduction() *compute.InstanceGroupManagerActionsSummary {
+	if s == nil {
+		return nil
+	}
+
+	n := compute.InstanceGroupManagerActionsSummary(*s)
+	return &n
+}
+
+func InstanceGroupManagerActionsSummaryFromProduction(s *compute.InstanceGroupManagerActionsSummary) *InstanceGroupManagerActionsSummary {
+	if s == nil {
+		return nil
+	}
+
+	n := InstanceGroupManagerActionsSummary(*s)
+	return &n
+}

--- a/google/shared/instance_group_managers_set_instance_template_request.go
+++ b/google/shared/instance_group_managers_set_instance_template_request.go
@@ -1,0 +1,47 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+type InstanceGroupManagersSetInstanceTemplateRequest struct {
+	// InstanceTemplate: The URL of the instance template that is specified
+	// for this managed instance group. The group uses this template to
+	// create all new instances in the managed instance group.
+	InstanceTemplate string `json:"instanceTemplate,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "InstanceTemplate") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "InstanceTemplate") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstanceGroupManagersSetInstanceTemplateRequest) ToProduction() *compute.InstanceGroupManagersSetInstanceTemplateRequest {
+	if s == nil {
+		return nil
+	}
+
+	n := compute.InstanceGroupManagersSetInstanceTemplateRequest(*s)
+	return &n
+}
+
+func InstanceGroupManagersSetInstanceTemplateRequestFromProduction(s *compute.InstanceGroupManagersSetInstanceTemplateRequest) *InstanceGroupManagersSetInstanceTemplateRequest {
+	if s == nil {
+		return nil
+	}
+
+	n := InstanceGroupManagersSetInstanceTemplateRequest(*s)
+	return &n
+}

--- a/google/shared/instance_group_managers_set_target_pools_request.go
+++ b/google/shared/instance_group_managers_set_target_pools_request.go
@@ -1,0 +1,56 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+type InstanceGroupManagersSetTargetPoolsRequest struct {
+	// Fingerprint: The fingerprint of the target pools information. Use
+	// this optional property to prevent conflicts when multiple users
+	// change the target pools settings concurrently. Obtain the fingerprint
+	// with the instanceGroupManagers.get method. Then, include the
+	// fingerprint in your request to ensure that you do not overwrite
+	// changes that were applied from another concurrent request.
+	Fingerprint string `json:"fingerprint,omitempty"`
+
+	// TargetPools: The list of target pool URLs that instances in this
+	// managed instance group belong to. The managed instance group applies
+	// these target pools to all of the instances in the group. Existing
+	// instances and new instances in the group all receive these target
+	// pool settings.
+	TargetPools []string `json:"targetPools,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Fingerprint") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Fingerprint") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstanceGroupManagersSetTargetPoolsRequest) ToProduction() *compute.InstanceGroupManagersSetTargetPoolsRequest {
+	if s == nil {
+		return nil
+	}
+
+	n := compute.InstanceGroupManagersSetTargetPoolsRequest(*s)
+	return &n
+}
+
+func InstanceGroupManagersSetTargetPoolsRequestFromProduction(s *compute.InstanceGroupManagersSetTargetPoolsRequest) *InstanceGroupManagersSetTargetPoolsRequest {
+	if s == nil {
+		return nil
+	}
+
+	n := InstanceGroupManagersSetTargetPoolsRequest(*s)
+	return &n
+}

--- a/google/shared/instance_groups_set_named_ports_request.go
+++ b/google/shared/instance_groups_set_named_ports_request.go
@@ -1,0 +1,60 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+type InstanceGroupsSetNamedPortsRequest struct {
+	// Fingerprint: The fingerprint of the named ports information for this
+	// instance group. Use this optional property to prevent conflicts when
+	// multiple users change the named ports settings concurrently. Obtain
+	// the fingerprint with the instanceGroups.get method. Then, include the
+	// fingerprint in your request to ensure that you do not overwrite
+	// changes that were applied from another concurrent request.
+	Fingerprint string `json:"fingerprint,omitempty"`
+
+	// NamedPorts: The list of named ports to set for this instance group.
+	NamedPorts []*NamedPort `json:"namedPorts,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Fingerprint") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Fingerprint") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstanceGroupsSetNamedPortsRequest) ToProduction() *compute.InstanceGroupsSetNamedPortsRequest {
+	if s == nil {
+		return nil
+	}
+
+	return &compute.InstanceGroupsSetNamedPortsRequest{
+		Fingerprint:     s.Fingerprint,
+		NamedPorts:      NamedPortsToProduction(s.NamedPorts),
+		ForceSendFields: s.ForceSendFields,
+		NullFields:      s.NullFields,
+	}
+}
+
+func InstanceGroupsSetNamedPortsRequestFromProduction(s *compute.InstanceGroupsSetNamedPortsRequest) *InstanceGroupsSetNamedPortsRequest {
+	if s == nil {
+		return nil
+	}
+
+	return &InstanceGroupsSetNamedPortsRequest{
+		Fingerprint:     s.Fingerprint,
+		NamedPorts:      NamedPortsFromProduction(s.NamedPorts),
+		ForceSendFields: s.ForceSendFields,
+		NullFields:      s.NullFields,
+	}
+}

--- a/google/shared/named_port.go
+++ b/google/shared/named_port.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+// NamedPort: The named port. For example: .
+type NamedPort struct {
+	// Name: The name for this named port. The name must be 1-63 characters
+	// long, and comply with RFC1035.
+	Name string `json:"name,omitempty"`
+
+	// Port: The port number, which can be a value between 1 and 65535.
+	Port int64 `json:"port,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *NamedPort) ToProduction() *compute.NamedPort {
+	if s == nil {
+		return nil
+	}
+
+	n := compute.NamedPort(*s)
+	return &n
+}
+
+func NamedPortFromProduction(s *compute.NamedPort) *NamedPort {
+	if s == nil {
+		return nil
+	}
+
+	n := NamedPort(*s)
+	return &n
+}
+
+func NamedPortsToProduction(namedPorts []*NamedPort) []*compute.NamedPort {
+	arr := make([]*compute.NamedPort, 0, len(namedPorts))
+	for _, v := range namedPorts {
+		arr = append(arr, v.ToProduction())
+	}
+	return arr
+}
+
+func NamedPortsFromProduction(namedPorts []*compute.NamedPort) []*NamedPort {
+	arr := make([]*NamedPort, 0, len(namedPorts))
+	for _, v := range namedPorts {
+		arr = append(arr, NamedPortFromProduction(v))
+	}
+	return arr
+}


### PR DESCRIPTION
This is the first step towards adding support for a beta field to a resource - converting it to being able to support multiple API fields. This means it needs to take in an enum specifying the API version, and switch which Compute API client it uses based on that.

`resource_compute_instance_group_manager` still only has the ability to support the GA api after this PR - it's refactoring the existing functionality only. Support for Beta operations and adding a Beta field will come later to keep it (moderately) reviewable.