### PR TITLE
Add support for google_bigtable_instance.

### DIFF
--- a/google/bigtable_client_factory.go
+++ b/google/bigtable_client_factory.go
@@ -8,15 +8,15 @@ import (
 	"google.golang.org/api/option"
 )
 
-type ClientFactoryBigtable struct {
+type BigtableClientFactory struct {
 	UserAgent   string
 	TokenSource oauth2.TokenSource
 }
 
-func (s *ClientFactoryBigtable) NewInstanceAdminClient(project string) (*bigtable.InstanceAdminClient, error) {
+func (s *BigtableClientFactory) NewInstanceAdminClient(project string) (*bigtable.InstanceAdminClient, error) {
 	return bigtable.NewInstanceAdminClient(context.Background(), project, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
 }
 
-func (s *ClientFactoryBigtable) NewAdminClient(project, instance string) (*bigtable.AdminClient, error) {
+func (s *BigtableClientFactory) NewAdminClient(project, instance string) (*bigtable.AdminClient, error) {
 	return bigtable.NewAdminClient(context.Background(), project, instance, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
 }

--- a/google/client_factory_bigtable.go
+++ b/google/client_factory_bigtable.go
@@ -1,0 +1,22 @@
+package google
+
+import (
+	"context"
+
+	"cloud.google.com/go/bigtable"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
+
+type ClientFactoryBigtable struct {
+	UserAgent   string
+	TokenSource oauth2.TokenSource
+}
+
+func (s *ClientFactoryBigtable) NewInstanceAdminClient(project string) (*bigtable.InstanceAdminClient, error) {
+	return bigtable.NewInstanceAdminClient(context.Background(), project, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
+}
+
+func (s *ClientFactoryBigtable) NewAdminClient(project, instance string) (*bigtable.AdminClient, error) {
+	return bigtable.NewAdminClient(context.Background(), project, instance, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
+}

--- a/google/config.go
+++ b/google/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	clientServiceMan      *servicemanagement.APIService
 	clientBigQuery        *bigquery.Service
 
-	clientFactoryBigtable *ClientFactoryBigtable
+	bigtableClientFactory *BigtableClientFactory
 }
 
 func (c *Config) loadAndValidate() error {
@@ -193,7 +193,7 @@ func (c *Config) loadAndValidate() error {
 	c.clientBigQuery.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating Google Cloud Bigtable Client Factory...")
-	c.clientFactoryBigtable = &ClientFactoryBigtable{
+	c.bigtableClientFactory = &BigtableClientFactory{
 		UserAgent:   userAgent,
 		TokenSource: tokenSource,
 	}

--- a/google/config.go
+++ b/google/config.go
@@ -90,18 +90,18 @@ func (c *Config) loadAndValidate() error {
 		// Initiate an http.Client. The following GET request will be
 		// authorized and authenticated on the behalf of
 		// your service account.
-		client = conf.Client(oauth2.NoContext)
+		client = conf.Client(context.Background())
 
 		tokenSource = conf.TokenSource(context.Background())
 	} else {
 		log.Printf("[INFO] Authenticating using DefaultClient")
 		err := error(nil)
-		client, err = google.DefaultClient(oauth2.NoContext, clientScopes...)
+		client, err = google.DefaultClient(context.Background(), clientScopes...)
 		if err != nil {
 			return err
 		}
 
-		tokenSource, err = google.DefaultTokenSource(oauth2.NoContext, clientScopes...)
+		tokenSource, err = google.DefaultTokenSource(context.Background(), clientScopes...)
 		if err != nil {
 			return err
 		}

--- a/google/provider.go
+++ b/google/provider.go
@@ -64,6 +64,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"google_bigquery_dataset":               resourceBigQueryDataset(),
 			"google_bigquery_table":                 resourceBigQueryTable(),
+			"google_bigtable_instance":              resourceBigtableInstance(),
 			"google_compute_autoscaler":             resourceComputeAutoscaler(),
 			"google_compute_address":                resourceComputeAddress(),
 			"google_compute_backend_bucket":         resourceComputeBackendBucket(),

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -99,7 +99,7 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		Zone:        d.Get("zone").(string),
 	}
 
-	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	c, err := config.bigtableClientFactory.NewInstanceAdminClient(project)
 	if err != nil {
 		return fmt.Errorf("Error starting instance admin client. %s", err)
 	}
@@ -125,7 +125,7 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	c, err := config.bigtableClientFactory.NewInstanceAdminClient(project)
 	if err != nil {
 		return fmt.Errorf("Error starting instance admin client. %s", err)
 	}
@@ -166,7 +166,7 @@ func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	c, err := config.bigtableClientFactory.NewInstanceAdminClient(project)
 	if err != nil {
 		return fmt.Errorf("Error starting instance admin client. %s", err)
 	}

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -23,17 +23,23 @@ func resourceBigtableInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
 			"display_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
-			},
-
-			"cluster_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 
 			"num_nodes": {
@@ -50,12 +56,6 @@ func resourceBigtableInstance() *schema.Resource {
 				ForceNew:     true,
 				Default:      "SSD",
 				ValidateFunc: validation.StringInSlice([]string{"SSD", "HDD"}, false),
-			},
-
-			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 
 			"project": {

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -1,0 +1,188 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"cloud.google.com/go/bigtable"
+	"golang.org/x/net/context"
+)
+
+func resourceBigtableInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBigtableInstanceCreate,
+		Read:   resourceBigtableInstanceRead,
+		Delete: resourceBigtableInstanceDestroy,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"num_nodes": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+				// 30 is the maximum number of nodes without a quota increase.
+				ValidateFunc: validation.IntBetween(3, 30),
+			},
+
+			"storage_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"SSD", "HDD"}, false),
+			},
+
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+	displayName, ok := d.GetOk("display_name")
+	if !ok {
+		displayName = name
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	numNodes := int32(d.Get("num_nodes").(int))
+	zone := d.Get("zone").(string)
+
+	var storageType bigtable.StorageType
+	switch value := d.Get("storage_type"); value {
+	case "HDD":
+		storageType = bigtable.HDD
+	case "SSD":
+		storageType = bigtable.SSD
+	}
+
+	instanceConf := &bigtable.InstanceConf{
+		InstanceId:  name,
+		DisplayName: displayName.(string),
+		ClusterId:   clusterId,
+		NumNodes:    numNodes,
+		StorageType: storageType,
+		Zone:        zone,
+	}
+
+	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	if err != nil {
+		return fmt.Errorf("Error starting instance admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	err = c.CreateInstance(ctx, instanceConf)
+	if err != nil {
+		return fmt.Errorf("Error creating instance. %s", err)
+	}
+
+	d.SetId(name)
+
+	return resourceBigtableInstanceRead(d, meta)
+}
+
+func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	if err != nil {
+		return fmt.Errorf("Error starting instance admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	name := d.Id()
+	instances, err := c.Instances(ctx)
+	if err != nil {
+		return fmt.Errorf("Error retrieving instances. %s", err)
+	}
+
+	var instanceInfo *bigtable.InstanceInfo
+	found := false
+	for _, i := range instances {
+		if i.Name == name {
+			instanceInfo = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("Error retrieving instance. Could not find %s.", name)
+	}
+
+	d.Set("name", instanceInfo.Name)
+	d.Set("display_name", instanceInfo.DisplayName)
+
+	return nil
+}
+
+func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	c, err := config.clientFactoryBigtable.NewInstanceAdminClient(project)
+	if err != nil {
+		return fmt.Errorf("Error starting instance admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	name := d.Id()
+	err = c.DeleteInstance(ctx, name)
+	if err != nil {
+		return fmt.Errorf("Error deleting instance. %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -37,7 +37,7 @@ func testAccCheckBigtableInstanceDestroy(s *terraform.State) error {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		c, err := config.clientFactoryBigtable.NewInstanceAdminClient(config.Project)
+		c, err := config.bigtableClientFactory.NewInstanceAdminClient(config.Project)
 		if err != nil {
 			return fmt.Errorf("Error starting instance admin client. %s", err)
 		}
@@ -77,7 +77,7 @@ func testAccBigtableInstanceExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 		config := testAccProvider.Meta().(*Config)
-		c, err := config.clientFactoryBigtable.NewInstanceAdminClient(config.Project)
+		c, err := config.bigtableClientFactory.NewInstanceAdminClient(config.Project)
 		if err != nil {
 			return fmt.Errorf("Error starting instance admin client. %s", err)
 		}

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -108,11 +108,11 @@ func testAccBigtableInstanceExists(n string) resource.TestCheckFunc {
 func testAccBigtableInstance(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
-  name     = "%s"
-  cluster_id = "%s"
-  zone = "us-central1-b"
-  num_nodes = 3
-  storage_type = "HDD"
+	name         = "%s"
+	cluster_id   = "%s"
+	zone         = "us-central1-b"
+	num_nodes    = 3
+	storage_type = "HDD"
 }
 `, instanceName, instanceName)
 }

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -1,0 +1,118 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"context"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccBigtableInstance_basic(t *testing.T) {
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableInstance(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableInstanceExists(
+						"google_bigtable_instance.instance"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBigtableInstanceDestroy(s *terraform.State) error {
+	var ctx = context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_bigtable_instance" {
+			continue
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		c, err := config.clientFactoryBigtable.NewInstanceAdminClient(config.Project)
+		if err != nil {
+			return fmt.Errorf("Error starting instance admin client. %s", err)
+		}
+
+		instances, err := c.Instances(ctx)
+		if err != nil {
+			return fmt.Errorf("Error retrieving instances. %s", err)
+		}
+
+		found := false
+		for _, i := range instances {
+			if i.Name == rs.Primary.Attributes["name"] {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			return fmt.Errorf("Instance %s still exists.", rs.Primary.Attributes["name"])
+		}
+
+		c.Close()
+	}
+
+	return nil
+}
+
+func testAccBigtableInstanceExists(n string) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*Config)
+		c, err := config.clientFactoryBigtable.NewInstanceAdminClient(config.Project)
+		if err != nil {
+			return fmt.Errorf("Error starting instance admin client. %s", err)
+		}
+
+		instances, err := c.Instances(ctx)
+		if err != nil {
+			return fmt.Errorf("Error retrieving instances. %s", err)
+		}
+
+		found := false
+		for _, i := range instances {
+			if i.Name == rs.Primary.Attributes["name"] {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Error retrieving instance %s.", rs.Primary.Attributes["name"])
+		}
+
+		c.Close()
+
+		return nil
+	}
+}
+
+func testAccBigtableInstance(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name     = "%s"
+  cluster_id = "%s"
+  zone = "us-central1-b"
+  num_nodes = 3
+  storage_type = "HDD"
+}
+`, instanceName, instanceName)
+}

--- a/website/docs/r/bigtable_instance.html.markdown
+++ b/website/docs/r/bigtable_instance.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "google"
+page_title: "Google: google_bigtable_instance"
+sidebar_current: "docs-google-bigtable_instance"
+description: |-
+  Creates a Google Bigtable instance.
+---
+
+# google_bigtable_instance
+
+Creates a Google Bigtable instance. For more information see
+[the official documentation](https://cloud.google.com/bigtable/) and
+[API](https://cloud.google.com/bigtable/docs/go/reference).
+
+
+## Example Usage
+
+```hcl
+resource "google_bigtable_instance" "instance" {
+  name     = "tf-instance"
+  cluster_id = "tf-instance-cluster"
+  zone = "us-central1-b"
+  num_nodes = 3
+  storage_type = "HDD"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Bigtable instance.
+
+* `cluster_id` - (Required) The name of the Bigtable instance's cluster.
+
+* `zone` - (Required) The zone to create the Bigtable instance in. Note: Many zones do not support Bigtable instances.
+
+* `num_nodes` - (Required) The number of nodes in your Bigtable instance. Minimum of 3.
+
+* `storage_type` - (Required) The storage type to use. One of `"SSD"` or `"HDD"`.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.

--- a/website/docs/r/bigtable_instance.html.markdown
+++ b/website/docs/r/bigtable_instance.html.markdown
@@ -17,10 +17,10 @@ Creates a Google Bigtable instance. For more information see
 
 ```hcl
 resource "google_bigtable_instance" "instance" {
-  name     = "tf-instance"
-  cluster_id = "tf-instance-cluster"
-  zone = "us-central1-b"
-  num_nodes = 3
+  name         = "tf-instance"
+  cluster_id   = "tf-instance-cluster"
+  zone         = "us-central1-b"
+  num_nodes    = 3
   storage_type = "HDD"
 }
 ```
@@ -33,11 +33,11 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) The name of the Bigtable instance's cluster.
 
-* `zone` - (Required) The zone to create the Bigtable instance in. Note: Many zones do not support Bigtable instances.
+* `zone` - (Required) The zone to create the Bigtable instance in. Zones that support Bigtable instances are noted on the [Cloud Locations page](https://cloud.google.com/about/locations/).
 
-* `num_nodes` - (Required) The number of nodes in your Bigtable instance. Minimum of 3.
+* `num_nodes` - (Required) The number of nodes in your Bigtable instance. Minimum of `3`. Defaults to `3`.
 
-* `storage_type` - (Required) The storage type to use. One of `"SSD"` or `"HDD"`.
+* `storage_type` - (Required) The storage type to use. One of `"SSD"` or `"HDD"`. Defaults to `SSD`.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.

--- a/website/docs/r/bigtable_instance.html.markdown
+++ b/website/docs/r/bigtable_instance.html.markdown
@@ -35,9 +35,9 @@ The following arguments are supported:
 
 * `zone` - (Required) The zone to create the Bigtable instance in. Zones that support Bigtable instances are noted on the [Cloud Locations page](https://cloud.google.com/about/locations/).
 
-* `num_nodes` - (Required) The number of nodes in your Bigtable instance. Minimum of `3`. Defaults to `3`.
+* `num_nodes` - (Optional) The number of nodes in your Bigtable instance. Minimum of `3`. Defaults to `3`.
 
-* `storage_type` - (Required) The storage type to use. One of `"SSD"` or `"HDD"`. Defaults to `SSD`.
+* `storage_type` - (Optional) The storage type to use. One of `"SSD"` or `"HDD"`. Defaults to `SSD`.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.


### PR DESCRIPTION
Add support for creating Bigtable instances.

`Read` is pretty sparse;  we will need to file bugs upstream against the [client library repo](https://github.com/GoogleCloudPlatform/google-cloud-go/tree/master/bigtable) to get more attributes exposed.

Part of #66 