### PR TITLE
Update 5 more importable resources' docs

### DIFF
--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -17,7 +17,7 @@ documentation](https://cloud.google.com/compute/docs/load-balancing/network/forw
 
 ```tf
 resource "google_compute_forwarding_rule" "default" {
-  name       = "test"
+  name       = "website-forwarding-rule"
   target     = "${google_compute_target_pool.default.self_link}"
   port_range = "80"
 }
@@ -77,3 +77,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Forwarding rules can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_forwarding_rule.default website-forwarding-rule
+```

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -17,7 +17,7 @@ Creates a static IP address resource global to a Google Compute Engine project. 
 
 ```hcl
 resource "google_compute_global_address" "default" {
-  name = "test-address"
+  name = "global-appserver-ip"
 }
 ```
 
@@ -41,3 +41,11 @@ exported:
 * `address` - The assigned address.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Global addresses can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_global_address.default global-appserver-ip
+```

--- a/website/docs/r/compute_http_health_check.html.markdown
+++ b/website/docs/r/compute_http_health_check.html.markdown
@@ -19,7 +19,7 @@ and
 
 ```hcl
 resource "google_compute_http_health_check" "default" {
-  name         = "test"
+  name         = "authentication-health-check"
   request_path = "/health_check"
 
   timeout_sec        = 1
@@ -64,3 +64,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+HTTP health checks can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_http_health_check.default authentication-health-check
+```

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -16,16 +16,15 @@ and [API](https://cloud.google.com/compute/docs/instance-groups/manager/v1beta2/
 ## Example Usage
 
 ```hcl
-resource "google_compute_instance_group_manager" "foobar" {
-  name        = "terraform-test"
-  description = "Terraform test instance group manager"
+resource "google_compute_instance_group_manager" "appserver" {
+  name        = "appserver-igm"
 
-  base_instance_name = "foobar"
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  base_instance_name = "app"
+  instance_template  = "${google_compute_instance_template.appserver.self_link}"
   update_strategy    = "NONE"
   zone               = "us-central1-a"
 
-  target_pools = ["${google_compute_target_pool.foobar.self_link}"]
+  target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2
 
   named_port {
@@ -98,3 +97,12 @@ exported:
 * `instance_group` - The full URL of the instance group created by the manager.
 
 * `self_link` - The URL of the created resource.
+
+
+## Import
+
+Instance group managers can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_instance_group_manager.appserver appserver-igm
+```

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -18,9 +18,9 @@ and
 ## Example Usage
 
 ```hcl
-resource "google_compute_instance_template" "foobar" {
-  name        = "terraform-test"
-  description = "template description"
+resource "google_compute_instance_template" "default" {
+  name        = "appserver-template"
+  description = "This template is used to create app server instances."
 
   tags = ["foo", "bar"]
 
@@ -261,3 +261,11 @@ exported:
 
 [1]: /docs/providers/google/r/compute_instance_group_manager.html
 [2]: /docs/configuration/resources.html#lifecycle
+
+## Import
+
+Instance templates can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_instance_template.default appserver-template
+```


### PR DESCRIPTION
Update the documentation of 5 more of our importable resources to include `Import` blocks specifying how to import them.

We now have explicit documentation for:

- google_compute_forwarding_rule
- google_compute_global_address
- google_compute_http_health_check
- google_compute_instance_group_manager
- google_compute_instance_template

As in #119, to review:

In each Import block;

- The fields specified as being used to import a resource should match their names in the schema exactly.
- The resource address and properties used to perform the example import should be the values used in the example.
- The properties used to perform an import should not be ambiguous; they should not share the same name, for example.