### PR TITLE
Update container_engine_versions test.

### DIFF
--- a/google/data_source_google_container_engine_versions_test.go
+++ b/google/data_source_google_container_engine_versions_test.go
@@ -70,8 +70,8 @@ func testAccCheckGoogleContainerEngineVersionsMeta(n string) resource.TestCheckF
 		if err != nil {
 			return errors.New("failed to read number of valid master versions")
 		}
-		if noOfMasters < 2 {
-			return fmt.Errorf("expected at least 2 valid master versions, received %d, this is most likely a bug",
+		if noOfMasters < 1 {
+			return fmt.Errorf("expected at least 1 valid master versions, received %d, this is most likely a bug",
 				noOfMasters)
 		}
 


### PR DESCRIPTION
Only expect 1 container engine master version, not 2. The API is only
currently reporting one. This fixes the failing test.