### PR TITLE
Restrict the number of health_checks in Backend Service resources to exactly 1.

### DIFF
--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -40,8 +40,10 @@ func resourceComputeBackendService() *schema.Resource {
 			"health_checks": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
 				Set:      schema.HashString,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 1,
 			},
 
 			"backend": &schema.Schema{

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -171,6 +171,27 @@ func TestAccComputeBackendService_withConnectionDrainingAndUpdate(t *testing.T) 
 	}
 }
 
+func TestAccComputeBackendService_withHttpsHealthCheck(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var svc compute.BackendService
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withHttpsHealthCheck(serviceName, checkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeBackendServiceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -415,4 +436,21 @@ resource "google_compute_http_health_check" "zero" {
   timeout_sec        = 1
 }
 `, serviceName, drainingTimeout, checkName)
+}
+
+func testAccComputeBackendService_withHttpsHealthCheck(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = ["${google_compute_https_health_check.zero.self_link}"]
+  protocol      = "HTTPS"
+}
+
+resource "google_compute_https_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, checkName)
 }

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -37,8 +37,10 @@ func resourceComputeRegionBackendService() *schema.Resource {
 			"health_checks": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
 				Set:      schema.HashString,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 1,
 			},
 
 			"backend": &schema.Schema{

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the backend service.
 
-* `health_checks` - (Required) Specifies a list of HTTP health check objects
+* `health_checks` - (Required) Specifies a list of HTTP/HTTPS health checks
     for checking the health of the backend service. Currently at most one health
     check can be specified, and a health check is required.
 

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -70,7 +70,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the backend service.
 
 * `health_checks` - (Required) Specifies a list of HTTP health check objects
-    for checking the health of the backend service.
+    for checking the health of the backend service. Currently at most one health
+    check can be specified, and a health check is required.
 
 - - -
 

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the backend service.
 
-* `health_checks` - (Required) Specifies a list of HTTP/HTTPS health checks
+* `health_checks` - (Required) Specifies a list of health checks
     for checking the health of the backend service. Currently at most
     one health check can be specified, and a health check is required.
 

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the backend service.
 
-* `health_checks` - (Required) Specifies a list of health check objects
+* `health_checks` - (Required) Specifies a list of HTTP/HTTPS health checks
     for checking the health of the backend service. Currently at most
     one health check can be specified, and a health check is required.
 

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -70,7 +70,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the backend service.
 
 * `health_checks` - (Required) Specifies a list of health check objects
-    for checking the health of the backend service.
+    for checking the health of the backend service. Currently at most
+    one health check can be specified, and a health check is required.
 
 - - -
 


### PR DESCRIPTION
Fix for #144.

Affects `google_compute_backend_service` and `google_compute_region_backend_service`.
- Update documentation to specify that exactly 1 health check is required.
- Perform a plan-time validation that there is exactly 1 element in the health check list.