### PR TITLE
compute_firewall: set source_ranges to Computed to avoid perpetual diff

### DIFF
--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -76,6 +76,7 @@ func resourceComputeFirewall() *schema.Resource {
 			"source_ranges": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},

--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -61,6 +61,27 @@ func TestAccComputeFirewall_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewall_noSource(t *testing.T) {
+	var firewall compute.Firewall
+	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
+	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeFirewallDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeFirewall_noSource(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeFirewallDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -158,6 +179,25 @@ func testAccComputeFirewall_update(network, firewall string) string {
 		allow {
 			protocol = "tcp"
 			ports = ["80-255"]
+		}
+	}`, network, firewall)
+}
+
+func testAccComputeFirewall_noSource(network, firewall string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_network" "foobar" {
+		name = "%s"
+		ipv4_range = "10.0.0.0/16"
+	}
+
+	resource "google_compute_firewall" "foobar" {
+		name = "firewall-test-%s"
+		description = "Resource created for Terraform acceptance testing"
+		network = "${google_compute_network.foobar.name}"
+
+		allow {
+			protocol = "tcp"
+			ports    = [22]
 		}
 	}`, network, firewall)
 }


### PR DESCRIPTION
If this is not set in Terraform, then the API defaults to `0.0.0.0/0`,
Terraform would then attempt to remove that value and so on.

Fixes #108 

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccComputeFirewall_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccComputeFirewall_importBasic
--- PASS: TestAccComputeFirewall_importBasic (72.87s)
=== RUN   TestAccComputeFirewall_basic
--- PASS: TestAccComputeFirewall_basic (65.87s)
=== RUN   TestAccComputeFirewall_update
--- PASS: TestAccComputeFirewall_update (88.22s)
=== RUN   TestAccComputeFirewall_noSource
--- PASS: TestAccComputeFirewall_noSource (79.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	306.762s
```