### PR TITLE
allow updating additional_zones, turn it into a set

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -286,3 +286,14 @@ func linkDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	}
 	return false
 }
+
+func convertStringArr(ifaceArr []interface{}) []string {
+	var arr []string
+	for _, v := range ifaceArr {
+		if v == nil {
+			continue
+		}
+		arr = append(arr, v.(string))
+	}
+	return arr
+}

--- a/google/resource_compute_target_pool.go
+++ b/google/resource_compute_target_pool.go
@@ -88,17 +88,6 @@ func resourceComputeTargetPool() *schema.Resource {
 	}
 }
 
-func convertStringArr(ifaceArr []interface{}) []string {
-	var arr []string
-	for _, v := range ifaceArr {
-		if v == nil {
-			continue
-		}
-		arr = append(arr, v.(string))
-	}
-	return arr
-}
-
 // Healthchecks need to exist before being referred to from the target pool.
 func convertHealthChecks(config *Config, project string, names []string) ([]string, error) {
 	urls := make([]string, len(names))

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -667,7 +667,11 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("additional_zones") {
-		azs := convertStringArr(d.Get("additional_zones").(*schema.Set).List())
+		azSet := d.Get("additional_zones").(*schema.Set)
+		if azSet.Contains(zoneName) {
+			return fmt.Errorf("additional_zones should not contain the original 'zone'.")
+		}
+		azs := convertStringArr(azSet.List())
 		locations := append(azs, zoneName)
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -106,10 +106,9 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"additional_zones": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -386,7 +385,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("additional_zones"); ok {
-		locationsList := v.([]interface{})
+		locationsList := v.(*schema.Set).List()
 		locations := []string{}
 		for _, v := range locationsList {
 			location := v.(string)
@@ -634,29 +633,61 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	zoneName := d.Get("zone").(string)
 	clusterName := d.Get("name").(string)
-	desiredNodeVersion := d.Get("node_version").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
-	req := &container.UpdateClusterRequest{
-		Update: &container.ClusterUpdate{
-			DesiredNodeVersion: desiredNodeVersion,
-		},
-	}
-	op, err := config.clientContainer.Projects.Zones.Clusters.Update(
-		project, zoneName, clusterName, req).Do()
-	if err != nil {
-		return err
+	d.Partial(true)
+
+	if d.HasChange("node_version") {
+		desiredNodeVersion := d.Get("node_version").(string)
+
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredNodeVersion: desiredNodeVersion,
+			},
+		}
+		op, err := config.clientContainer.Projects.Zones.Clusters.Update(
+			project, zoneName, clusterName, req).Do()
+		if err != nil {
+			return err
+		}
+
+		// Wait until it's updated
+		waitErr := containerOperationWait(config, op, project, zoneName, "updating GKE cluster version", timeoutInMinutes, 2)
+		if waitErr != nil {
+			return waitErr
+		}
+
+		log.Printf("[INFO] GKE cluster %s has been updated to %s", d.Id(),
+			desiredNodeVersion)
+
+		d.SetPartial("node_version")
 	}
 
-	// Wait until it's updated
+	if d.HasChange("additional_zones") {
+		azs := convertStringArr(d.Get("additional_zones").(*schema.Set).List())
+		locations := append(azs, zoneName)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredLocations: locations,
+			},
+		}
+		op, err := config.clientContainer.Projects.Zones.Clusters.Update(
+			project, zoneName, clusterName, req).Do()
+		if err != nil {
+			return err
+		}
 
-	waitErr := containerOperationWait(config, op, project, zoneName, "updating GKE cluster", timeoutInMinutes, 2)
-	if waitErr != nil {
-		return waitErr
+		// Wait until it's updated
+		waitErr := containerOperationWait(config, op, project, zoneName, "updating GKE cluster locations", timeoutInMinutes, 2)
+		if waitErr != nil {
+			return waitErr
+		}
+
+		log.Printf("[INFO] GKE cluster %s locations have been updated to %v", d.Id(),
+			locations)
 	}
 
-	log.Printf("[INFO] GKE cluster %s has been updated to %s", d.Id(),
-		desiredNodeVersion)
+	d.Partial(false)
 
 	return resourceContainerClusterRead(d, meta)
 }

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -29,6 +29,9 @@ func resourceContainerCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceContainerClusterMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"master_auth": {
 				Type:     schema.TypeList,

--- a/google/resource_container_cluster_migrate.go
+++ b/google/resource_container_cluster_migrate.go
@@ -1,0 +1,74 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceContainerClusterMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Container Cluster State v0; migrating to v1")
+		is, err := migrateClusterStateV0toV1(is)
+		if err != nil {
+			return is, err
+		}
+		return is, nil
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateClusterStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	newZones := []string{}
+
+	for k, v := range is.Attributes {
+		if !strings.HasPrefix(k, "additional_zones.") {
+			continue
+		}
+
+		if k == "additional_zones.#" {
+			continue
+		}
+
+		// Key is now of the form additional_zones.%d
+		kParts := strings.Split(k, ".")
+
+		// Sanity check: two parts should be there and <N> should be a number
+		badFormat := false
+		if len(kParts) != 2 {
+			badFormat = true
+		} else if _, err := strconv.Atoi(kParts[1]); err != nil {
+			badFormat = true
+		}
+
+		if badFormat {
+			return is, fmt.Errorf("migration error: found additional_zones key in unexpected format: %s", k)
+		}
+
+		newZones = append(newZones, v)
+		delete(is.Attributes, k)
+	}
+
+	for _, v := range newZones {
+		hash := schema.HashString(v)
+		newKey := fmt.Sprintf("additional_zones.%d", hash)
+		is.Attributes[newKey] = v
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/google/resource_container_cluster_migrate.go
+++ b/google/resource_container_cluster_migrate.go
@@ -20,11 +20,7 @@ func resourceContainerClusterMigrateState(
 	switch v {
 	case 0:
 		log.Println("[INFO] Found Container Cluster State v0; migrating to v1")
-		is, err := migrateClusterStateV0toV1(is)
-		if err != nil {
-			return is, err
-		}
-		return is, nil
+		return migrateClusterStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}

--- a/google/resource_container_cluster_migrate_test.go
+++ b/google/resource_container_cluster_migrate_test.go
@@ -16,12 +16,12 @@ func TestContainerClusterMigrateState(t *testing.T) {
 		"change additional_zones from list to set": {
 			StateVersion: 0,
 			Attributes: map[string]string{
-				"additional_zones.#": "1",
+				"additional_zones.#": "2",
 				"additional_zones.0": "us-central1-c",
 				"additional_zones.1": "us-central1-b",
 			},
 			Expected: map[string]string{
-				"additional_zones.#":          "1",
+				"additional_zones.#":          "2",
 				"additional_zones.90274510":   "us-central1-c",
 				"additional_zones.1919306328": "us-central1-b",
 			},

--- a/google/resource_container_cluster_migrate_test.go
+++ b/google/resource_container_cluster_migrate_test.go
@@ -1,0 +1,75 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestContainerClusterMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"change additional_zones from list to set": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"additional_zones.#": "1",
+				"additional_zones.0": "us-central1-c",
+				"additional_zones.1": "us-central1-b",
+			},
+			Expected: map[string]string{
+				"additional_zones.#":          "1",
+				"additional_zones.90274510":   "us-central1-c",
+				"additional_zones.1919306328": "us-central1-b",
+			},
+			Meta: &Config{},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "i-abc123",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceContainerClusterMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestContainerClusterMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta *Config
+
+	// should handle nil
+	is, err := resourceContainerClusterMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceContainerClusterMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}


### PR DESCRIPTION
Fixes #104.

`additional_zones` had to be turned into a set because GCP returns them in alphabetical order regardless of the order they're set in the request.