### PR TITLE
Fix read method + test/document import for google_compute_health_check

### DIFF
--- a/google/import_compute_health_check_test.go
+++ b/google/import_compute_health_check_test.go
@@ -1,0 +1,96 @@
+package google
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeHealthCheck_importBasicHttp(t *testing.T) {
+	resourceName := "google_compute_health_check.foobar"
+	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_http(hckName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeHealthCheck_importBasicHttps(t *testing.T) {
+	resourceName := "google_compute_health_check.foobar"
+	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_https(hckName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeHealthCheck_importBasicTcp(t *testing.T) {
+	resourceName := "google_compute_health_check.foobar"
+	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_tcp(hckName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccComputeHealthCheck_importBasicSsl(t *testing.T) {
+	resourceName := "google_compute_health_check.foobar"
+	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_ssl(hckName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/resource_compute_health_check.go
+++ b/google/resource_compute_health_check.go
@@ -448,10 +448,10 @@ func resourceComputeHealthCheckRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("healthy_threshold", hchk.HealthyThreshold)
 	d.Set("timeout_sec", hchk.TimeoutSec)
 	d.Set("unhealthy_threshold", hchk.UnhealthyThreshold)
-	d.Set("tcp_health_check", hchk.TcpHealthCheck)
-	d.Set("ssl_health_check", hchk.SslHealthCheck)
-	d.Set("http_health_check", hchk.HttpHealthCheck)
-	d.Set("https_health_check", hchk.HttpsHealthCheck)
+	d.Set("tcp_health_check", flattenTcpHealthCheck(hchk.TcpHealthCheck))
+	d.Set("ssl_health_check", flattenSslHealthCheck(hchk.SslHealthCheck))
+	d.Set("http_health_check", flattenHttpHealthCheck(hchk.HttpHealthCheck))
+	d.Set("https_health_check", flattenHttpsHealthCheck(hchk.HttpsHealthCheck))
 	d.Set("self_link", hchk.SelfLink)
 	d.Set("name", hchk.Name)
 	d.Set("description", hchk.Description)
@@ -482,4 +482,64 @@ func resourceComputeHealthCheckDelete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
+}
+
+func flattenTcpHealthCheck(hchk *compute.TCPHealthCheck) []map[string]interface{} {
+	if hchk == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, 1)
+	data := make(map[string]interface{})
+	data["port"] = hchk.Port
+	data["proxy_header"] = hchk.ProxyHeader
+	data["request"] = hchk.Request
+	data["response"] = hchk.Response
+	result = append(result, data)
+	return result
+}
+
+func flattenSslHealthCheck(hchk *compute.SSLHealthCheck) []map[string]interface{} {
+	if hchk == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, 1)
+	data := make(map[string]interface{})
+	data["port"] = hchk.Port
+	data["proxy_header"] = hchk.ProxyHeader
+	data["request"] = hchk.Request
+	data["response"] = hchk.Response
+	result = append(result, data)
+	return result
+}
+
+func flattenHttpHealthCheck(hchk *compute.HTTPHealthCheck) []map[string]interface{} {
+	if hchk == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, 1)
+	data := make(map[string]interface{})
+	data["host"] = hchk.Host
+	data["port"] = hchk.Port
+	data["proxy_header"] = hchk.ProxyHeader
+	data["request_path"] = hchk.RequestPath
+	result = append(result, data)
+	return result
+}
+
+func flattenHttpsHealthCheck(hchk *compute.HTTPSHealthCheck) []map[string]interface{} {
+	if hchk == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, 1)
+	data := make(map[string]interface{})
+	data["host"] = hchk.Host
+	data["port"] = hchk.Port
+	data["proxy_header"] = hchk.ProxyHeader
+	data["request_path"] = hchk.RequestPath
+	result = append(result, data)
+	return result
 }

--- a/website/docs/r/compute_health_check.html.markdown
+++ b/website/docs/r/compute_health_check.html.markdown
@@ -46,17 +46,17 @@ The following arguments are supported:
 
 * `healthy_threshold` - (Optional) Consecutive successes required (default 2).
 
-* `http_health_check` - (Optional) An HTTP Health Check.
-    See *HTTP Health Check* below.
+* `http_health_check` - (Optional) An HTTP Health Check. Only one kind of Health Check can be added.
+    Structure is documented below.
 
-* `https_health_check` - (Optional) An HTTPS Health Check.
-    See *HTTPS Health Check* below.
+* `https_health_check` - (Optional) An HTTPS Health Check. Only one kind of Health Check can be added.
+    Structure is documented below.
 
-* `ssl_health_check` - (Optional) An SSL Health Check.
-    See *SSL Health Check* below.
+* `ssl_health_check` - (Optional) An SSL Health Check. Only one kind of Health Check can be added.
+    Structure is documented below.
 
-* `tcp_health_check` - (Optional) A TCP Health Check.
-    See *TCP Health Check* below.
+* `tcp_health_check` - (Optional) A TCP Health Check. Only one kind of Health Check can be added.
+    Structure is documented below.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `unhealthy_threshold` - (Optional) Consecutive failures required (default 2).
 
 
-**HTTP Health Check** supports the following attributes:
+The `http_health_check` block supports:
 
 * `host` - (Optional) HTTP host header field (default instance's public ip).
 
@@ -79,7 +79,7 @@ The following arguments are supported:
 * `request_path` - (Optional) URL path to query (default /).
 
 
-**HTTPS Health Check** supports the following attributes:
+The `https_health_check` block supports:
 
 * `host` - (Optional) HTTPS host header field (default instance's public ip).
 
@@ -91,7 +91,7 @@ The following arguments are supported:
 * `request_path` - (Optional) URL path to query (default /).
 
 
-**SSL Health Check** supports the following attributes:
+The `ssl_health_check` block supports:
 
 * `port` - (Optional) TCP port to connect to (default 443).
 
@@ -104,7 +104,7 @@ The following arguments are supported:
 * `response` - (Optional) The response that indicates health (default "")
 
 
-**TCP Health Check** supports the following attributes:
+The `tcp_health_check` block supports:
 
 * `port` - (Optional) TCP port to connect to (default 80).
 

--- a/website/docs/r/compute_health_check.html.markdown
+++ b/website/docs/r/compute_health_check.html.markdown
@@ -19,7 +19,7 @@ and
 
 ```tf
 resource "google_compute_health_check" "default" {
-  name = "test"
+  name = "internal-service-health-check"
 
   timeout_sec        = 1
   check_interval_sec = 1
@@ -123,3 +123,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Health checks can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_health_check.default internal-service-health-check
+```


### PR DESCRIPTION
- Make `google_compute_health_check` refresh the HealthCheck blocks on Read.
- Test importing a `google_compute_health_check` with each block type
- Document importing a `google_compute_health_check`

Fixes #134.