### PR TITLE
Update import documentation for 5 resources

### DIFF
--- a/website/docs/r/compute_route.html.markdown
+++ b/website/docs/r/compute_route.html.markdown
@@ -13,13 +13,13 @@ Manages a network route within GCE.
 ## Example Usage
 
 ```hcl
-resource "google_compute_network" "foobar" {
-  name       = "test"
+resource "google_compute_network" "default" {
+  name       = "compute-network"
   ipv4_range = "10.0.0.0/16"
 }
 
-resource "google_compute_route" "foobar" {
-  name        = "test"
+resource "google_compute_route" "default" {
+  name        = "network-route"
   dest_range  = "15.0.0.0/24"
   network     = "${google_compute_network.foobar.name}"
   next_hop_ip = "10.0.1.5"
@@ -72,3 +72,11 @@ exported:
 * `next_hop_network` - The name of the next hop network, if available.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Network routes can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_route.default network-route
+```

--- a/website/docs/r/compute_target_pool.html.markdown
+++ b/website/docs/r/compute_target_pool.html.markdown
@@ -19,7 +19,7 @@ and [API](https://cloud.google.com/compute/docs/reference/latest/targetPools).
 
 ```hcl
 resource "google_compute_target_pool" "default" {
-  name = "test"
+  name = "instance-pool"
 
   instances = [
     "us-central1-a/myinstance1",
@@ -73,3 +73,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Target pools can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_target_pool.default instance-pool
+```

--- a/website/docs/r/dns_managed_zone.markdown
+++ b/website/docs/r/dns_managed_zone.markdown
@@ -44,3 +44,11 @@ exported:
 * `name_servers` - The list of nameservers that will be authoritative for this
     domain. Use NS records to redirect from your DNS provider to these names,
     thus making Google Cloud DNS authoritative for this zone.
+
+## Import
+
+DNS managed zones can be imported using the `name`, e.g.
+
+```
+$ terraform import google_dns_managed_zone.prod prod-zone
+```

--- a/website/docs/r/google_project.html.markdown
+++ b/website/docs/r/google_project.html.markdown
@@ -101,3 +101,11 @@ the Google Cloud provider is configured with. If you're using the `id` field in 
 configurations, know that it is being ignored, and its value will always be seen as the
 ID of the project being used to authenticate Terraform's requests. You should move to the
 `project_id` field as soon as possible.
+
+## Import
+
+Projects can be imported using the `project_id`, e.g.
+
+```
+$ terraform import google_project.my_project your-project-id
+```

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -86,3 +86,11 @@ exported:
 * `self_link` - The URI of the created resource.
 
 * `url` - The base URL of the bucket, in the format `gs://<bucket-name>`.
+
+## Import
+
+Storage buckets can be imported using the `name`, e.g.
+
+```
+$ terraform import google_storage_bucket.image-store image-store-bucket
+```


### PR DESCRIPTION
Update the documentation of 5 more of our importable resources to include Import blocks specifying how to import them.

We now have explicit documentation for:

- google_compute_route
- google_compute_target_pool
- google_dns_managed_zone
- google_project
- google_storage_bucket

As in #119, to review:

In each Import block;

- The fields specified as being used to import a resource should match their names in the schema exactly.
- The resource address and properties used to perform the example import should be the values used in the example.
- The properties used to perform an import should not be ambiguous; they should not share the same name, for example.