### PR TITLE
Add support for node pool autoscaling

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -63,12 +63,6 @@ func resourceContainerNodePool() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": &schema.Schema{
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-
 						"min_node_count": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
@@ -130,7 +124,7 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOk("autoscaling"); ok {
 		autoscaling := v.([]interface{})[0].(map[string]interface{})
 		nodePool.Autoscaling = &container.NodePoolAutoscaling{
-			Enabled:      autoscaling["enabled"].(bool),
+			Enabled:      true,
 			MinNodeCount: int64(autoscaling["min_node_count"].(int)),
 			MaxNodeCount: int64(autoscaling["max_node_count"].(int)),
 		}
@@ -180,16 +174,17 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", nodePool.Name)
 	d.Set("initial_node_count", nodePool.InitialNodeCount)
+
+	autoscaling := []map[string]interface{}{}
 	if nodePool.Autoscaling != nil && nodePool.Autoscaling.Enabled {
-		autoscaling := []map[string]interface{}{
+		autoscaling = []map[string]interface{}{
 			map[string]interface{}{
-				"enabled":        nodePool.Autoscaling.Enabled,
 				"min_node_count": nodePool.Autoscaling.MinNodeCount,
 				"max_node_count": nodePool.Autoscaling.MaxNodeCount,
 			},
 		}
-		d.Set("autoscaling", autoscaling)
 	}
+	d.Set("autoscaling", autoscaling)
 
 	return nil
 }
@@ -213,7 +208,7 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 		if v, ok := d.GetOk("autoscaling"); ok {
 			autoscaling := v.([]interface{})[0].(map[string]interface{})
 			update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
-				Enabled:      autoscaling["enabled"].(bool),
+				Enabled:      true,
 				MinNodeCount: int64(autoscaling["min_node_count"].(int)),
 				MaxNodeCount: int64(autoscaling["max_node_count"].(int)),
 			}

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -14,6 +14,7 @@ func resourceContainerNodePool() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceContainerNodePoolCreate,
 		Read:   resourceContainerNodePoolRead,
+		Update: resourceContainerNodePoolUpdate,
 		Delete: resourceContainerNodePoolDelete,
 		Exists: resourceContainerNodePoolExists,
 
@@ -55,6 +56,47 @@ func resourceContainerNodePool() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"autoscaling": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+
+						"min_node_count": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(int)
+
+								if value < 1 {
+									errors = append(errors, fmt.Errorf("%q must be >=1", k))
+								}
+								return
+							},
+						},
+
+						"max_node_count": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(int)
+
+								if value < 1 {
+									errors = append(errors, fmt.Errorf("%q must be >=1", k))
+								}
+								return
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -83,6 +125,15 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	nodePool := &container.NodePool{
 		Name:             name,
 		InitialNodeCount: int64(nodeCount),
+	}
+
+	if v, ok := d.GetOk("autoscaling"); ok {
+		autoscaling := v.([]interface{})[0].(map[string]interface{})
+		nodePool.Autoscaling = &container.NodePoolAutoscaling{
+			Enabled:      autoscaling["enabled"].(bool),
+			MinNodeCount: int64(autoscaling["min_node_count"].(int)),
+			MaxNodeCount: int64(autoscaling["max_node_count"].(int)),
+		}
 	}
 
 	req := &container.CreateNodePoolRequest{
@@ -129,8 +180,68 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", nodePool.Name)
 	d.Set("initial_node_count", nodePool.InitialNodeCount)
+	if nodePool.Autoscaling != nil && nodePool.Autoscaling.Enabled {
+		autoscaling := []map[string]interface{}{
+			map[string]interface{}{
+				"enabled":        nodePool.Autoscaling.Enabled,
+				"min_node_count": nodePool.Autoscaling.MinNodeCount,
+				"max_node_count": nodePool.Autoscaling.MaxNodeCount,
+			},
+		}
+		d.Set("autoscaling", autoscaling)
+	}
 
 	return nil
+}
+
+func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	zone := d.Get("zone").(string)
+	name := d.Get("name").(string)
+	cluster := d.Get("cluster").(string)
+
+	if d.HasChange("autoscaling") {
+		update := &container.ClusterUpdate{
+			DesiredNodePoolId: name,
+		}
+		if v, ok := d.GetOk("autoscaling"); ok {
+			autoscaling := v.([]interface{})[0].(map[string]interface{})
+			update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
+				Enabled:      autoscaling["enabled"].(bool),
+				MinNodeCount: int64(autoscaling["min_node_count"].(int)),
+				MaxNodeCount: int64(autoscaling["max_node_count"].(int)),
+			}
+		} else {
+			update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
+				Enabled: false,
+			}
+		}
+
+		req := &container.UpdateClusterRequest{
+			Update: update,
+		}
+		op, err := config.clientContainer.Projects.Zones.Clusters.Update(
+			project, zone, cluster, req).Do()
+		if err != nil {
+			return err
+		}
+
+		// Wait until it's updated
+		waitErr := containerOperationWait(config, op, project, zone, "updating GKE node pool", 10, 2)
+		if waitErr != nil {
+			return waitErr
+		}
+
+		log.Printf("[INFO] Updated autoscaling in Node Pool %s", d.Id())
+	}
+
+	return resourceContainerNodePoolRead(d, meta)
 }
 
 func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) error {

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -112,7 +112,7 @@ func testAccCheckContainerNodePoolMatches(n string) resource.TestCheckFunc {
 				attributes["initial_node_count"], found.InitialNodeCount)
 		}
 
-		tfAS := attributes["autoscaling.0.enabled"] == "true"
+		tfAS := attributes["autoscaling.#"] == "1"
 		if gcpAS := found.Autoscaling != nil && found.Autoscaling.Enabled == true; tfAS != gcpAS {
 			return fmt.Errorf("Mismatched autoscaling status. TF State: %t. GCP State: %t", tfAS, gcpAS)
 		}

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -11,13 +11,47 @@ import (
 )
 
 func TestAccContainerNodePool_basic(t *testing.T) {
+	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerNodePoolDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccContainerNodePool_basic,
+				Config: testAccContainerNodePool_basic(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContainerNodePool_autoscaling(t *testing.T) {
+	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerNodePool_autoscaling(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainerNodePool_updateAutoscaling(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainerNodePool_basic(cluster, np),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
 				),
@@ -77,13 +111,32 @@ func testAccCheckContainerNodePoolMatches(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Mismatched initialNodeCount. TF State: %s. GCP State: %d",
 				attributes["initial_node_count"], found.InitialNodeCount)
 		}
+
+		tfAS := attributes["autoscaling.0.enabled"] == "true"
+		if gcpAS := found.Autoscaling != nil && found.Autoscaling.Enabled == true; tfAS != gcpAS {
+			return fmt.Errorf("Mismatched autoscaling status. TF State: %t. GCP State: %t", tfAS, gcpAS)
+		}
+		if tfAS {
+			if tf := attributes["autoscaling.0.min_node_count"]; strconv.FormatInt(found.Autoscaling.MinNodeCount, 10) != tf {
+				return fmt.Errorf("Mismatched Autoscaling.MinNodeCount. TF State: %s. GCP State: %d",
+					tf, found.Autoscaling.MinNodeCount)
+			}
+
+			if tf := attributes["autoscaling.0.max_node_count"]; strconv.FormatInt(found.Autoscaling.MaxNodeCount, 10) != tf {
+				return fmt.Errorf("Mismatched Autoscaling.MaxNodeCount. TF State: %s. GCP State: %d",
+					tf, found.Autoscaling.MaxNodeCount)
+			}
+
+		}
+
 		return nil
 	}
 }
 
-var testAccContainerNodePool_basic = fmt.Sprintf(`
+func testAccContainerNodePool_basic(cluster, np string) string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "tf-cluster-nodepool-test-%s"
+	name = "%s"
 	zone = "us-central1-a"
 	initial_node_count = 3
 
@@ -94,8 +147,59 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "np" {
-	name = "tf-nodepool-test-%s"
+	name = "%s"
 	zone = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
-}`, acctest.RandString(10), acctest.RandString(10))
+}`, cluster, np)
+}
+
+func testAccContainerNodePool_autoscaling(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+}
+
+resource "google_container_node_pool" "np" {
+	name = "%s"
+	zone = "us-central1-a"
+	cluster = "${google_container_cluster.cluster.name}"
+	initial_node_count = 2
+	autoscaling {
+		min_node_count = 1
+		max_node_count = 3
+	}
+}`, cluster, np)
+}
+
+func testAccContainerNodePool_updateAutoscaling(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+}
+
+resource "google_container_node_pool" "np" {
+	name = "%s"
+	zone = "us-central1-a"
+	cluster = "${google_container_cluster.cluster.name}"
+	initial_node_count = 2
+	autoscaling {
+		min_node_count = 1
+		max_node_count = 5
+	}
+}`, cluster, np)
+}

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -67,3 +67,15 @@ resource "google_container_cluster" "primary" {
 
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
+
+* `autoscaling` - (Optional) Configuration required by cluster autoscaler to adjust
+    the size of the node pool to the current cluster usage. Structure is documented below.
+
+The `autoscaling` block supports:
+
+* `enabled` - (Optional) Whether autoscaling is enabled for this node pool.
+
+* `minNodeCount` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
+    <= `maxNodeCount`.
+
+* `maxNodeCount` - (Required) Maximum number of nodes in the NodePool. Must be >= minNodeCount.

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -73,8 +73,6 @@ resource "google_container_cluster" "primary" {
 
 The `autoscaling` block supports:
 
-* `enabled` - (Optional) Whether autoscaling is enabled for this node pool.
-
 * `minNodeCount` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
     <= `maxNodeCount`.
 


### PR DESCRIPTION
Fixes #44.

This is essentially the same code as https://github.com/hashicorp/terraform/pull/12779, except I added the `enabled` attribute and support for update.

```
TF_ACC=1 go test ./google -v -run=TestAccContainerNodePool_autoscaling -timeout 120m
=== RUN   TestAccContainerNodePool_autoscaling
--- PASS: TestAccContainerNodePool_autoscaling (1056.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	1056.417s
```