### PR TITLE
Get a single bigtable instance when performing reads

### DIFF
--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	"golang.org/x/net/context"
+	"log"
 )
 
 func resourceBigtableInstance() *schema.Resource {
@@ -134,7 +135,9 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 	instance, err := c.InstanceInfo(ctx, d.Id())
 	if err != nil {
-		return fmt.Errorf("Error retrieving instance. Could not find %s.", d.Id())
+		log.Printf("[WARN] Removing %s because it's gone", d.Id())
+		d.SetId("")
+		return fmt.Errorf("Error retrieving instance. Could not find %s. %s", d.Id(), err)
 	}
 
 	d.Set("name", instance.Name)

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -132,27 +132,13 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 	defer c.Close()
 
-	instances, err := c.Instances(ctx)
+	instance, err := c.InstanceInfo(ctx, d.Id())
 	if err != nil {
-		return fmt.Errorf("Error retrieving instances. %s", err)
+		return fmt.Errorf("Error retrieving instance. Could not find %s.", d.Id())
 	}
 
-	var instanceInfo *bigtable.InstanceInfo
-	name := d.Id()
-	found := false
-	for _, i := range instances {
-		if i.Name == name {
-			instanceInfo = i
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("Error retrieving instance. Could not find %s.", name)
-	}
-
-	d.Set("name", instanceInfo.Name)
-	d.Set("display_name", instanceInfo.DisplayName)
+	d.Set("name", instance.Name)
+	d.Set("display_name", instance.DisplayName)
 
 	return nil
 }

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -42,20 +42,8 @@ func testAccCheckBigtableInstanceDestroy(s *terraform.State) error {
 			return fmt.Errorf("Error starting instance admin client. %s", err)
 		}
 
-		instances, err := c.Instances(ctx)
-		if err != nil {
-			return fmt.Errorf("Error retrieving instances. %s", err)
-		}
-
-		found := false
-		for _, i := range instances {
-			if i.Name == rs.Primary.Attributes["name"] {
-				found = true
-				break
-			}
-		}
-
-		if found {
+		_, err = c.InstanceInfo(ctx, rs.Primary.Attributes["name"])
+		if err == nil {
 			return fmt.Errorf("Instance %s still exists.", rs.Primary.Attributes["name"])
 		}
 
@@ -82,20 +70,8 @@ func testAccBigtableInstanceExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Error starting instance admin client. %s", err)
 		}
 
-		instances, err := c.Instances(ctx)
+		_, err = c.InstanceInfo(ctx, rs.Primary.Attributes["name"])
 		if err != nil {
-			return fmt.Errorf("Error retrieving instances. %s", err)
-		}
-
-		found := false
-		for _, i := range instances {
-			if i.Name == rs.Primary.Attributes["name"] {
-				found = true
-				break
-			}
-		}
-
-		if !found {
 			return fmt.Errorf("Error retrieving instance %s.", rs.Primary.Attributes["name"])
 		}
 

--- a/vendor/cloud.google.com/go/bigtable/admin.go
+++ b/vendor/cloud.google.com/go/bigtable/admin.go
@@ -369,3 +369,24 @@ func (iac *InstanceAdminClient) Instances(ctx context.Context) ([]*InstanceInfo,
 	}
 	return is, nil
 }
+
+// InstanceInfo returns information about an instance.
+func (iac *InstanceAdminClient) InstanceInfo(ctx context.Context, instanceId string) (*InstanceInfo, error) {
+	ctx = mergeOutgoingMetadata(ctx, iac.md)
+	req := &btapb.GetInstanceRequest{
+		Name: "projects/" + iac.project + "/instances/" + instanceId,
+	}
+	res, err := iac.iClient.GetInstance(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	m := instanceNameRegexp.FindStringSubmatch(res.Name)
+	if m == nil {
+		return nil, fmt.Errorf("malformed instance name %q", res.Name)
+	}
+	return &InstanceInfo{
+		Name:        m[2],
+		DisplayName: res.DisplayName,
+	}, nil
+}

--- a/vendor/cloud.google.com/go/bigtable/bigtable.go
+++ b/vendor/cloud.google.com/go/bigtable/bigtable.go
@@ -73,7 +73,7 @@ func (c *Client) Close() error {
 }
 
 var (
-	idempotentRetryCodes  = []codes.Code{codes.DeadlineExceeded, codes.Unavailable, codes.Aborted, codes.Internal}
+	idempotentRetryCodes  = []codes.Code{codes.DeadlineExceeded, codes.Unavailable, codes.Aborted}
 	isIdempotentRetryCode = make(map[codes.Code]bool)
 	retryOptions          = []gax.CallOption{
 		gax.WithDelayTimeoutSettings(100*time.Millisecond, 2000*time.Millisecond, 1.2),

--- a/vendor/cloud.google.com/go/bigtable/filter.go
+++ b/vendor/cloud.google.com/go/bigtable/filter.go
@@ -154,7 +154,7 @@ func (stripValueFilter) proto() *btpb.RowFilter {
 	return &btpb.RowFilter{Filter: &btpb.RowFilter_StripValueTransformer{true}}
 }
 
-// TimestampRangeFilter returns a filter that matches any rows whose timestamp is within the given time bounds.  A zero
+// TimestampRangeFilter returns a filter that matches any cells whose timestamp is within the given time bounds.  A zero
 // time means no bound.
 // The timestamp will be truncated to millisecond granularity.
 func TimestampRangeFilter(startTime time.Time, endTime time.Time) Filter {
@@ -168,7 +168,7 @@ func TimestampRangeFilter(startTime time.Time, endTime time.Time) Filter {
 	return trf
 }
 
-// TimestampRangeFilterMicros returns a filter that matches any rows whose timestamp is within the given time bounds,
+// TimestampRangeFilterMicros returns a filter that matches any cells whose timestamp is within the given time bounds,
 // specified in units of microseconds since 1 January 1970. A zero value for the end time is interpreted as no bound.
 // The timestamp will be truncated to millisecond granularity.
 func TimestampRangeFilterMicros(startTime Timestamp, endTime Timestamp) Filter {
@@ -187,10 +187,10 @@ func (trf timestampRangeFilter) String() string {
 func (trf timestampRangeFilter) proto() *btpb.RowFilter {
 	return &btpb.RowFilter{
 		Filter: &btpb.RowFilter_TimestampRangeFilter{
-				&btpb.TimestampRange{
-					int64(trf.startTime.TruncateToMilliseconds()),
-					int64(trf.endTime.TruncateToMilliseconds()),
-				},
+			&btpb.TimestampRange{
+				int64(trf.startTime.TruncateToMilliseconds()),
+				int64(trf.endTime.TruncateToMilliseconds()),
+			},
 		}}
 }
 
@@ -228,8 +228,8 @@ func ValueRangeFilter(start, end []byte) Filter {
 }
 
 type valueRangeFilter struct {
-	start  []byte
-	end    []byte
+	start []byte
+	end   []byte
 }
 
 func (vrf valueRangeFilter) String() string {
@@ -260,8 +260,8 @@ func ConditionFilter(predicateFilter, trueFilter, falseFilter Filter) Filter {
 
 type conditionFilter struct {
 	predicateFilter Filter
-	trueFilter			Filter
-	falseFilter			Filter
+	trueFilter      Filter
+	falseFilter     Filter
 }
 
 func (cf conditionFilter) String() string {
@@ -282,7 +282,7 @@ func (cf conditionFilter) proto() *btpb.RowFilter {
 			cf.predicateFilter.proto(),
 			tf,
 			ff,
-	}}}
+		}}}
 }
 
 // TODO(dsymonds): More filters: sampling

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/",
 	"package": [
 		{
-			"checksumSHA1": "fEobtlzPZ57VXi864qMmblI2gsA=",
+			"checksumSHA1": "NrTYYg3++pBxH1Z8xjVg6ssQTYY=",
 			"path": "cloud.google.com/go/bigtable",
-			"revision": "69931d826ffbbcb4f8451b42d5cf7fc2ac6c7443",
-			"revisionTime": "2017-06-09T14:31:37Z"
+			"revision": "f6bedb5a8dbce75418580cedf5c2434c78d06cfa",
+			"revisionTime": "2017-06-27T21:12:08Z"
 		},
 		{
 			"checksumSHA1": "B1HkIrBavSgy6ntVyGr/eNUy44I=",


### PR DESCRIPTION
With https://github.com/GoogleCloudPlatform/google-cloud-go/issues/682 resolved, we don't need to loop over the list of instances in the Admin api client anymore.