### PR TITLE
Add google_project_iam_binding and google_project_iam_member resources.

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -108,6 +108,7 @@ func Provider() terraform.ResourceProvider {
 			"google_project":                        resourceGoogleProject(),
 			"google_project_iam_policy":             resourceGoogleProjectIamPolicy(),
 			"google_project_iam_binding":            resourceGoogleProjectIamBinding(),
+			"google_project_iam_member":             resourceGoogleProjectIamMember(),
 			"google_project_services":               resourceGoogleProjectServices(),
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),

--- a/google/provider.go
+++ b/google/provider.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -106,6 +107,7 @@ func Provider() terraform.ResourceProvider {
 			"google_sql_user":                       resourceSqlUser(),
 			"google_project":                        resourceGoogleProject(),
 			"google_project_iam_policy":             resourceGoogleProjectIamPolicy(),
+			"google_project_iam_binding":            resourceGoogleProjectIamBinding(),
 			"google_project_services":               resourceGoogleProjectServices(),
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),
@@ -277,6 +279,18 @@ func handleNotFoundError(err error, d *schema.ResourceData, resource string) err
 	}
 
 	return fmt.Errorf("Error reading %s: %s", resource, err)
+}
+
+func isConflictError(err error) bool {
+	if e, ok := err.(*googleapi.Error); ok && e.Code == 409 {
+		return true
+	} else if !ok && errwrap.ContainsType(err, &googleapi.Error{}) {
+		e := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error)
+		if e.Code == 409 {
+			return true
+		}
+	}
+	return false
 }
 
 func linkDiffSuppress(k, old, new string, d *schema.ResourceData) bool {

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -91,6 +91,7 @@ func resourceGoogleProjectIamBindingRead(d *schema.ResourceData, meta interface{
 		break
 	}
 	if binding == nil {
+		log.Printf("[DEBUG]: Binding for role %q not found in policy for %q, removing from state file.\n", eBinding.Role, pid)
 		d.SetId("")
 		return nil
 	}

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -1,0 +1,244 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func resourceGoogleProjectIamBinding() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectIamBindingCreate,
+		Read:   resourceGoogleProjectIamBindingRead,
+		Update: resourceGoogleProjectIamBindingUpdate,
+		Delete: resourceGoogleProjectIamBindingDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"role": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"members": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"etag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectIamBindingCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	// Get the binding in the template
+	log.Println("[DEBUG]: Reading google_project_iam_binding")
+	p := getResourceIamBinding(d)
+	mutexKV.Lock(projectIamBindingMutexKey(pid, p.Role))
+	defer mutexKV.Unlock(projectIamBindingMutexKey(pid, p.Role))
+
+	for {
+		backoff := time.Second
+		// Get the existing bindings
+		log.Println("[DEBUG]: Retrieving policy for project", pid)
+		ep, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, ep)
+
+		// Merge the bindings together
+		ep.Bindings = mergeBindings(append(ep.Bindings, p))
+		log.Printf("[DEBUG]: Setting policy for project %q to %+v\n", pid, ep)
+		err = setProjectIamPolicy(ep, config, pid)
+		if err != nil && isConflictError(err) {
+			log.Printf("[DEBUG]: Concurrent policy changes, restarting read-modify-write after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+		break
+	}
+	log.Printf("[DEBUG]: Set policy for project %q", pid)
+	d.SetId(pid + ":" + p.Role)
+	return resourceGoogleProjectIamBindingRead(d, meta)
+}
+
+func resourceGoogleProjectIamBindingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	eBinding := getResourceIamBinding(d)
+
+	log.Println("[DEBUG]: Retrieving policy for project", pid)
+	p, err := getProjectIamPolicy(pid, config)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, p)
+
+	var binding *cloudresourcemanager.Binding
+	for _, b := range p.Bindings {
+		if b.Role != eBinding.Role {
+			continue
+		}
+		binding = b
+		break
+	}
+	if binding == nil {
+		return fmt.Errorf("No binding for role %q in project %q", eBinding.Role, pid)
+	}
+	d.Set("etag", p.Etag)
+	d.Set("members", binding.Members)
+	d.Set("role", binding.Role)
+	return nil
+}
+
+func resourceGoogleProjectIamBindingUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	binding := getResourceIamBinding(d)
+	mutexKV.Lock(projectIamBindingMutexKey(pid, binding.Role))
+	defer mutexKV.Unlock(projectIamBindingMutexKey(pid, binding.Role))
+
+	for {
+		backoff := time.Second
+		log.Println("[DEBUG]: Retrieving policy for project", pid)
+		p, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, p)
+
+		var found bool
+		for pos, b := range p.Bindings {
+			if b.Role != binding.Role {
+				continue
+			}
+			found = true
+			p.Bindings[pos] = binding
+			break
+		}
+		if !found {
+			p.Bindings = append(p.Bindings, binding)
+		}
+
+		log.Printf("[DEBUG]: Setting policy for project %q to %+v\n", pid, p)
+		err = setProjectIamPolicy(p, config, pid)
+		if err != nil && isConflictError(err) {
+			log.Printf("[DEBUG]: Concurrent policy changes, restarting read-modify-write after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+		break
+	}
+	log.Printf("[DEBUG]: Set policy for project %q\n", pid)
+
+	return resourceGoogleProjectIamPolicyRead(d, meta)
+}
+
+func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	binding := getResourceIamBinding(d)
+	mutexKV.Lock(projectIamBindingMutexKey(pid, binding.Role))
+	defer mutexKV.Unlock(projectIamBindingMutexKey(pid, binding.Role))
+
+	for {
+		backoff := time.Second
+		log.Println("[DEBUG]: Retrieving policy for project", pid)
+		p, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, p)
+
+		toRemove := -1
+		for pos, b := range p.Bindings {
+			if b.Role != binding.Role {
+				continue
+			}
+			toRemove = pos
+			break
+		}
+		if toRemove < 0 {
+			return resourceGoogleProjectIamPolicyRead(d, meta)
+		}
+
+		p.Bindings = append(p.Bindings[:toRemove], p.Bindings[toRemove+1:]...)
+
+		log.Printf("[DEBUG]: Setting policy for project %q to %+v\n", pid, p)
+		err = setProjectIamPolicy(p, config, pid)
+		if err != nil && isConflictError(err) {
+			log.Printf("[DEBUG]: Concurrent policy changes, restarting read-modify-write after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+		break
+	}
+	log.Printf("[DEBUG]: Set policy for project %q\n", pid)
+
+	return resourceGoogleProjectIamPolicyRead(d, meta)
+}
+
+// Get a cloudresourcemanager.Binding from a schema.ResourceData
+func getResourceIamBinding(d *schema.ResourceData) *cloudresourcemanager.Binding {
+	members := d.Get("members").(*schema.Set).List()
+	m := make([]string, 0, len(members))
+	for _, member := range members {
+		m = append(m, member.(string))
+	}
+	return &cloudresourcemanager.Binding{
+		Members: m,
+		Role:    d.Get("role").(string),
+	}
+}
+
+func projectIamBindingMutexKey(pid, role string) string {
+	return fmt.Sprintf("google-project-iam-binding-%s-%s", pid, role)
+}

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -74,7 +74,7 @@ func resourceGoogleProjectIamBindingCreate(d *schema.ResourceData, meta interfac
 			time.Sleep(backoff)
 			backoff = backoff * 2
 			if backoff > 30*time.Second {
-				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n", pid)
 			}
 			continue
 		} else if err != nil {
@@ -161,7 +161,7 @@ func resourceGoogleProjectIamBindingUpdate(d *schema.ResourceData, meta interfac
 			time.Sleep(backoff)
 			backoff = backoff * 2
 			if backoff > 30*time.Second {
-				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n", pid)
 			}
 			continue
 		} else if err != nil {
@@ -215,7 +215,7 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 			time.Sleep(backoff)
 			backoff = backoff * 2
 			if backoff > 30*time.Second {
-				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n")
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n", pid)
 			}
 			continue
 		} else if err != nil {

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -112,7 +112,8 @@ func resourceGoogleProjectIamBindingRead(d *schema.ResourceData, meta interface{
 		break
 	}
 	if binding == nil {
-		return fmt.Errorf("No binding for role %q in project %q", eBinding.Role, pid)
+		d.SetId("")
+		return nil
 	}
 	d.Set("etag", p.Etag)
 	d.Set("members", binding.Members)

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -204,7 +204,9 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 			break
 		}
 		if toRemove < 0 {
-			return resourceGoogleProjectIamBindingRead(d, meta)
+			log.Printf("[DEBUG]: Policy bindings for project %q did not include a binding for role %q, no need to delete", pid, binding.Role)
+			d.SetId("")
+			return nil
 		}
 
 		p.Bindings = append(p.Bindings[:toRemove], p.Bindings[toRemove+1:]...)

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -62,7 +62,7 @@ func resourceGoogleProjectIamBindingCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	d.SetId(pid + ":" + p.Role)
+	d.SetId(pid + "/" + p.Role)
 	return resourceGoogleProjectIamBindingRead(d, meta)
 }
 

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -16,24 +16,24 @@ func resourceGoogleProjectIamBinding() *schema.Resource {
 		Delete: resourceGoogleProjectIamBindingDelete,
 
 		Schema: map[string]*schema.Schema{
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"role": &schema.Schema{
+			"role": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"members": &schema.Schema{
+			"members": {
 				Type:     schema.TypeSet,
 				Required: true,
-				Elem: &schema.Schema{
+				Elem: {
 					Type: schema.TypeString,
 				},
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -29,7 +29,7 @@ func resourceGoogleProjectIamBinding() *schema.Resource {
 			"members": {
 				Type:     schema.TypeSet,
 				Required: true,
-				Elem: {
+				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -172,12 +172,8 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 // Get a cloudresourcemanager.Binding from a schema.ResourceData
 func getResourceIamBinding(d *schema.ResourceData) *cloudresourcemanager.Binding {
 	members := d.Get("members").(*schema.Set).List()
-	m := make([]string, 0, len(members))
-	for _, member := range members {
-		m = append(m, member.(string))
-	}
 	return &cloudresourcemanager.Binding{
-		Members: m,
+		Members: convertStringArr(members),
 		Role:    d.Get("role").(string),
 	}
 }

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -25,6 +25,7 @@ func resourceGoogleProjectIamBinding() *schema.Resource {
 			"role": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"members": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -169,7 +170,7 @@ func resourceGoogleProjectIamBindingUpdate(d *schema.ResourceData, meta interfac
 	}
 	log.Printf("[DEBUG]: Set policy for project %q\n", pid)
 
-	return resourceGoogleProjectIamPolicyRead(d, meta)
+	return resourceGoogleProjectIamBindingRead(d, meta)
 }
 
 func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interface{}) error {
@@ -201,7 +202,7 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 			break
 		}
 		if toRemove < 0 {
-			return resourceGoogleProjectIamPolicyRead(d, meta)
+			return resourceGoogleProjectIamBindingRead(d, meta)
 		}
 
 		p.Bindings = append(p.Bindings[:toRemove], p.Bindings[toRemove+1:]...)
@@ -223,7 +224,7 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 	}
 	log.Printf("[DEBUG]: Set policy for project %q\n", pid)
 
-	return resourceGoogleProjectIamPolicyRead(d, meta)
+	return resourceGoogleProjectIamBindingRead(d, meta)
 }
 
 // Get a cloudresourcemanager.Binding from a schema.ResourceData

--- a/google/resource_google_project_iam_binding.go
+++ b/google/resource_google_project_iam_binding.go
@@ -155,8 +155,7 @@ func resourceGoogleProjectIamBindingDelete(d *schema.ResourceData, meta interfac
 			break
 		}
 		if toRemove < 0 {
-			log.Printf("[DEBUG]: Policy bindings for project %q did not include a binding for role %q, no need to delete", pid, binding.Role)
-			d.SetId("")
+			log.Printf("[DEBUG]: Policy bindings for project %q did not include a binding for role %q", pid, binding.Role)
 			return nil
 		}
 

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -195,7 +195,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_binding" "acceptance" {
-  project = "${google_project.acceptance.id}"
+  project = "${google_project.acceptance.project_id}"
   members = ["user:admin@hashicorptest.com"]
   role    = "roles/compute.instanceAdmin"
 }
@@ -211,13 +211,13 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_binding" "acceptance" {
-  project = "${google_project.acceptance.id}"
+  project = "${google_project.acceptance.project_id}"
   members = ["user:admin@hashicorptest.com"]
   role    = "roles/compute.instanceAdmin"
 }
 
 resource "google_project_iam_binding" "multiple" {
-  project = "${google_project.acceptance.id}"
+  project = "${google_project.acceptance.project_id}"
   members = ["user:paddy@hashicorp.com"]
   role    = "roles/viewer"
 }
@@ -233,7 +233,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_binding" "acceptance" {
-  project = "${google_project.acceptance.id}"
+  project = "${google_project.acceptance.project_id}"
   members = ["user:admin@hashicorptest.com", "user:paddy@hashicorp.com"]
   role    = "roles/compute.instanceAdmin"
 }

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -1,0 +1,237 @@
+package google
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+// Test that an IAM binding can be applied to a project
+func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that multiple IAM bindings can be applied to a project
+func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+			// Apply another IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
+						Role:    "roles/viewer",
+						Members: []string{"user:paddy@hashicorp.com"},
+					}, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that an IAM binding can be updated once applied to a project
+func TestAccGoogleProjectIamBinding_update(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+			// Apply an updated IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingUpdated(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.updated", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com", "user:paddy@hashicorp.com"},
+					}, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that an IAM binding can be removed from a project
+func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply multiple IAM bindings
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
+						Role:    "roles/viewer",
+						Members: []string{"user:paddy@hashicorp.com"},
+					}, pid),
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+			// Remove the bindings
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectIamBindingExists(key string, expected *cloudresourcemanager.Binding, pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		projectPolicy, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve IAM policy for project %q: %s", pid, err)
+		}
+
+		var result *cloudresourcemanager.Binding
+		for _, binding := range projectPolicy.Bindings {
+			if binding.Role == expected.Role {
+				result = binding
+				break
+			}
+		}
+		if result == nil {
+			return fmt.Errorf("IAM policy for project %q had no role %q", pid, expected.Role)
+		}
+		if len(result.Members) != len(expected.Members) {
+			return fmt.Errorf("Got %v as members for role %q of project %q, expected %v", result.Members, expected.Role, pid, expected.Members)
+		}
+		sort.Strings(result.Members)
+		sort.Strings(expected.Members)
+		for pos, exp := range expected.Members {
+			if result.Members[pos] != exp {
+				return fmt.Errorf("Expected members for role %q of project %q to be %v, got %v", expected.Role, pid, expected.Members, result.Members)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccGoogleProjectAssociateBindingBasic(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_binding" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    members = ["user:admin@hashicorptest.com"]
+    role = "roles/compute.instanceAdmin"
+}
+`, pid, name, org)
+}
+
+func testAccGoogleProjectAssociateBindingMultiple(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_binding" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    members = ["user:admin@hashicorptest.com"]
+    role = "roles/compute.instanceAdmin"
+}
+resource "google_project_iam_binding" "multiple" {
+    project = "${google_project.acceptance.id}"
+    members = ["user:paddy@hashicorp.com"]
+    role = "roles/viewer"
+}
+`, pid, name, org)
+}
+
+func testAccGoogleProjectAssociateBindingUpdated(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_binding" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    members = ["user:admin@hashicorptest.com", "user:paddy@hashicorp.com"]
+    role = "roles/compute.instanceAdmin"
+}
+`, pid, name, org)
+}

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -189,14 +189,15 @@ func testAccCheckGoogleProjectIamBindingExists(key string, expected *cloudresour
 func testAccGoogleProjectAssociateBindingBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }
+
 resource "google_project_iam_binding" "acceptance" {
-    project = "${google_project.acceptance.id}"
-    members = ["user:admin@hashicorptest.com"]
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.id}"
+  members = ["user:admin@hashicorptest.com"]
+  role    = "roles/compute.instanceAdmin"
 }
 `, pid, name, org)
 }
@@ -204,19 +205,21 @@ resource "google_project_iam_binding" "acceptance" {
 func testAccGoogleProjectAssociateBindingMultiple(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }
+
 resource "google_project_iam_binding" "acceptance" {
-    project = "${google_project.acceptance.id}"
-    members = ["user:admin@hashicorptest.com"]
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.id}"
+  members = ["user:admin@hashicorptest.com"]
+  role    = "roles/compute.instanceAdmin"
 }
+
 resource "google_project_iam_binding" "multiple" {
-    project = "${google_project.acceptance.id}"
-    members = ["user:paddy@hashicorp.com"]
-    role = "roles/viewer"
+  project = "${google_project.acceptance.id}"
+  members = ["user:paddy@hashicorp.com"]
+  role    = "roles/viewer"
 }
 `, pid, name, org)
 }
@@ -224,14 +227,15 @@ resource "google_project_iam_binding" "multiple" {
 func testAccGoogleProjectAssociateBindingUpdated(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }
+
 resource "google_project_iam_binding" "acceptance" {
-    project = "${google_project.acceptance.id}"
-    members = ["user:admin@hashicorptest.com", "user:paddy@hashicorp.com"]
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.id}"
+  members = ["user:admin@hashicorptest.com", "user:paddy@hashicorp.com"]
+  role    = "roles/compute.instanceAdmin"
 }
 `, pid, name, org)
 }

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -111,6 +111,16 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 					}, pid),
 				),
 			},
+			// Drop the original member
+			{
+				Config: testAccGoogleProjectAssociateBindingDropMemberFromBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.dropped", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:paddy@hashicorp.com"},
+					}, pid),
+				),
+			},
 		},
 	})
 }
@@ -235,6 +245,22 @@ resource "google_project" "acceptance" {
 resource "google_project_iam_binding" "acceptance" {
   project = "${google_project.acceptance.project_id}"
   members = ["user:admin@hashicorptest.com", "user:paddy@hashicorp.com"]
+  role    = "roles/compute.instanceAdmin"
+}
+`, pid, name, org)
+}
+
+func testAccGoogleProjectAssociateBindingDropMemberFromBasic(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+}
+
+resource "google_project_iam_binding" "dropped" {
+  project = "${google_project.acceptance.project_id}"
+  members = ["user:paddy@hashicorp.com"]
   role    = "roles/compute.instanceAdmin"
 }
 `, pid, name, org)

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -19,14 +19,14 @@ func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
@@ -47,14 +47,14 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
@@ -64,7 +64,7 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 				),
 			},
 			// Apply another IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
@@ -85,14 +85,14 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
@@ -102,7 +102,7 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 				),
 			},
 			// Apply an updated IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingUpdated(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.updated", &cloudresourcemanager.Binding{
@@ -123,14 +123,14 @@ func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply multiple IAM bindings
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
@@ -144,7 +144,7 @@ func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
 				),
 			},
 			// Remove the bindings
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -82,7 +82,7 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a project all at once
-func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
+func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_iam_member.go
+++ b/google/resource_google_project_iam_member.go
@@ -75,7 +75,7 @@ func resourceGoogleProjectIamMemberCreate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	d.SetId(pid + ":" + p.Role + ":" + p.Members[0])
+	d.SetId(pid + "/" + p.Role + "/" + p.Members[0])
 	return resourceGoogleProjectIamMemberRead(d, meta)
 }
 
@@ -104,6 +104,7 @@ func resourceGoogleProjectIamMemberRead(d *schema.ResourceData, meta interface{}
 		break
 	}
 	if binding == nil {
+		log.Printf("[DEBUG]: Binding for role %q does not exist in policy of project %q, removing member %q from state.", eMember.Role, pid, eMember.Members[0])
 		d.SetId("")
 		return nil
 	}
@@ -114,6 +115,7 @@ func resourceGoogleProjectIamMemberRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 	if member == "" {
+		log.Printf("[DEBUG]: Member %q for binding for role %q does not exist in policy of project %q, removing from state.", eMember.Members[0], eMember.Role, pid)
 		d.SetId("")
 		return nil
 	}
@@ -156,6 +158,8 @@ func resourceGoogleProjectIamMemberDelete(d *schema.ResourceData, meta interface
 			break
 		}
 		if memberToRemove < 0 {
+			log.Printf("[DEBUG]: Member %q for binding for role %q does not exist in policy of project %q, removing from state.", member.Members[0], member.Role, pid)
+			d.SetId("")
 			return nil
 		}
 		binding.Members = append(binding.Members[:memberToRemove], binding.Members[memberToRemove+1:]...)

--- a/google/resource_google_project_iam_member.go
+++ b/google/resource_google_project_iam_member.go
@@ -146,6 +146,7 @@ func resourceGoogleProjectIamMemberDelete(d *schema.ResourceData, meta interface
 			break
 		}
 		if bindingToRemove < 0 {
+			log.Printf("[DEBUG]: Binding for role %q does not exist in policy of project %q, so member %q can't be on it.", eMember.Role, pid, eMember.Members[0])
 			return nil
 		}
 		binding := p.Bindings[bindingToRemove]
@@ -158,8 +159,7 @@ func resourceGoogleProjectIamMemberDelete(d *schema.ResourceData, meta interface
 			break
 		}
 		if memberToRemove < 0 {
-			log.Printf("[DEBUG]: Member %q for binding for role %q does not exist in policy of project %q, removing from state.", member.Members[0], member.Role, pid)
-			d.SetId("")
+			log.Printf("[DEBUG]: Member %q for binding for role %q does not exist in policy of project %q.", member.Members[0], member.Role, pid)
 			return nil
 		}
 		binding.Members = append(binding.Members[:memberToRemove], binding.Members[memberToRemove+1:]...)

--- a/google/resource_google_project_iam_member.go
+++ b/google/resource_google_project_iam_member.go
@@ -146,7 +146,7 @@ func resourceGoogleProjectIamMemberDelete(d *schema.ResourceData, meta interface
 			break
 		}
 		if bindingToRemove < 0 {
-			log.Printf("[DEBUG]: Binding for role %q does not exist in policy of project %q, so member %q can't be on it.", eMember.Role, pid, eMember.Members[0])
+			log.Printf("[DEBUG]: Binding for role %q does not exist in policy of project %q, so member %q can't be on it.", member.Role, pid, member.Members[0])
 			return nil
 		}
 		binding := p.Bindings[bindingToRemove]

--- a/google/resource_google_project_iam_member.go
+++ b/google/resource_google_project_iam_member.go
@@ -1,0 +1,219 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func resourceGoogleProjectIamMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectIamMemberCreate,
+		Read:   resourceGoogleProjectIamMemberRead,
+		Delete: resourceGoogleProjectIamMemberDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"role": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"member": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"etag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectIamMemberCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	// Get the binding in the template
+	log.Println("[DEBUG]: Reading google_project_iam_member")
+	p := getResourceIamMember(d)
+	mutexKV.Lock(projectIamMemberMutexKey(pid, p.Role, p.Members[0]))
+	defer mutexKV.Unlock(projectIamMemberMutexKey(pid, p.Role, p.Members[0]))
+
+	for {
+		backoff := time.Second
+		// Get the existing bindings
+		log.Println("[DEBUG]: Retrieving policy for project", pid)
+		ep, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, ep)
+
+		// find the binding
+		var binding *cloudresourcemanager.Binding
+		for _, b := range ep.Bindings {
+			if b.Role != p.Role {
+				continue
+			}
+			binding = b
+			break
+		}
+		if binding == nil {
+			binding = &cloudresourcemanager.Binding{
+				Role:    p.Role,
+				Members: p.Members,
+			}
+		}
+
+		// Merge the bindings together
+		ep.Bindings = mergeBindings(append(ep.Bindings, p))
+		log.Printf("[DEBUG]: Setting policy for project %q to %+v\n", pid, ep)
+		err = setProjectIamPolicy(ep, config, pid)
+		if err != nil && isConflictError(err) {
+			log.Printf("[DEBUG]: Concurrent policy changes, restarting read-modify-write after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n", pid)
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+		break
+	}
+	log.Printf("[DEBUG]: Set policy for project %q", pid)
+	d.SetId(pid + ":" + p.Role + ":" + p.Members[0])
+	return resourceGoogleProjectIamMemberRead(d, meta)
+}
+
+func resourceGoogleProjectIamMemberRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	eMember := getResourceIamMember(d)
+
+	log.Println("[DEBUG]: Retrieving policy for project", pid)
+	p, err := getProjectIamPolicy(pid, config)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, p)
+
+	var binding *cloudresourcemanager.Binding
+	for _, b := range p.Bindings {
+		if b.Role != eMember.Role {
+			continue
+		}
+		binding = b
+		break
+	}
+	if binding == nil {
+		d.SetId("")
+		return nil
+	}
+	var member string
+	for _, m := range binding.Members {
+		if m == eMember.Members[0] {
+			member = m
+		}
+	}
+	d.Set("etag", p.Etag)
+	d.Set("member", member)
+	d.Set("role", binding.Role)
+	return nil
+}
+
+func resourceGoogleProjectIamMemberDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	member := getResourceIamMember(d)
+	mutexKV.Lock(projectIamMemberMutexKey(pid, member.Role, member.Members[0]))
+	defer mutexKV.Unlock(projectIamMemberMutexKey(pid, member.Role, member.Members[0]))
+
+	for {
+		backoff := time.Second
+		log.Println("[DEBUG]: Retrieving policy for project", pid)
+		p, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]: Retrieved policy for project %q: %+v\n", pid, p)
+
+		bindingToRemove := -1
+		for pos, b := range p.Bindings {
+			if b.Role != member.Role {
+				continue
+			}
+			bindingToRemove = pos
+			break
+		}
+		if bindingToRemove < 0 {
+			return resourceGoogleProjectIamMemberRead(d, meta)
+		}
+		binding := p.Bindings[bindingToRemove]
+		memberToRemove := -1
+		for pos, m := range binding.Members {
+			if m != member.Members[0] {
+				continue
+			}
+			memberToRemove = pos
+			break
+		}
+		if memberToRemove < 0 {
+			return resourceGoogleProjectIamMemberRead(d, meta)
+		}
+		binding.Members = append(binding.Members[:memberToRemove], binding.Members[memberToRemove+1:]...)
+		p.Bindings[bindingToRemove] = binding
+
+		log.Printf("[DEBUG]: Setting policy for project %q to %+v\n", pid, p)
+		err = setProjectIamPolicy(p, config, pid)
+		if err != nil && isConflictError(err) {
+			log.Printf("[DEBUG]: Concurrent policy changes, restarting read-modify-write after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return fmt.Errorf("Error applying IAM policy to project %q: too many concurrent policy changes.\n", pid)
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+		break
+	}
+	log.Printf("[DEBUG]: Set policy for project %q\n", pid)
+
+	return resourceGoogleProjectIamMemberRead(d, meta)
+}
+
+// Get a cloudresourcemanager.Binding from a schema.ResourceData
+func getResourceIamMember(d *schema.ResourceData) *cloudresourcemanager.Binding {
+	return &cloudresourcemanager.Binding{
+		Members: []string{d.Get("member").(string)},
+		Role:    d.Get("role").(string),
+	}
+}
+
+func projectIamMemberMutexKey(pid, role, member string) string {
+	return fmt.Sprintf("google-project-iam-member-%s-%s-%s", pid, role, member)
+}

--- a/google/resource_google_project_iam_member.go
+++ b/google/resource_google_project_iam_member.go
@@ -15,22 +15,22 @@ func resourceGoogleProjectIamMember() *schema.Resource {
 		Delete: resourceGoogleProjectIamMemberDelete,
 
 		Schema: map[string]*schema.Schema{
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"role": &schema.Schema{
+			"role": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"member": &schema.Schema{
+			"member": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -1,0 +1,146 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+// Test that an IAM binding can be applied to a project
+func TestAccGoogleProjectIamMember_basic(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that multiple IAM bindings can be applied to a project
+func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com"},
+					}, pid),
+				),
+			},
+			// Apply another IAM binding
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.multiple", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com", "user:paddy@hashicorp.com"},
+					}, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that an IAM binding can be removed from a project
+func TestAccGoogleProjectIamMember_remove(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply multiple IAM bindings
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
+						Role:    "roles/compute.instanceAdmin",
+						Members: []string{"user:admin@hashicorptest.com", "user:paddy@hashicorp.com"},
+					}, pid),
+				),
+			},
+			// Remove the bindings
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+		},
+	})
+}
+
+func testAccGoogleProjectAssociateMemberBasic(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_member" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    member = "user:admin@hashicorptest.com"
+    role = "roles/compute.instanceAdmin"
+}
+`, pid, name, org)
+}
+
+func testAccGoogleProjectAssociateMemberMultiple(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_member" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    member = "user:admin@hashicorptest.com"
+    role = "roles/compute.instanceAdmin"
+}
+resource "google_project_iam_member" "multiple" {
+    project = "${google_project.acceptance.id}"
+    member = "user:paddy@hashicorp.com"
+    role = "roles/compute.instanceAdmin"
+}
+`, pid, name, org)
+}

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -118,7 +118,7 @@ resource "google_project" "acceptance" {
     org_id = "%s"
 }
 resource "google_project_iam_member" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     member = "user:admin@hashicorptest.com"
     role = "roles/compute.instanceAdmin"
 }
@@ -133,12 +133,12 @@ resource "google_project" "acceptance" {
     org_id = "%s"
 }
 resource "google_project_iam_member" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     member = "user:admin@hashicorptest.com"
     role = "roles/compute.instanceAdmin"
 }
 resource "google_project_iam_member" "multiple" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     member = "user:paddy@hashicorp.com"
     role = "roles/compute.instanceAdmin"
 }

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -17,14 +17,14 @@ func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
@@ -45,14 +45,14 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
@@ -62,7 +62,7 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 				),
 			},
 			// Apply another IAM binding
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.multiple", &cloudresourcemanager.Binding{
@@ -83,14 +83,14 @@ func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create a new project
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),
 				),
 			},
 			// Apply multiple IAM bindings
-			resource.TestStep{
+			{
 				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
@@ -100,7 +100,7 @@ func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 				),
 			},
 			// Remove the bindings
-			resource.TestStep{
+			{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccGoogleProjectExistingPolicy(pid),

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -113,14 +113,15 @@ func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 func testAccGoogleProjectAssociateMemberBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }
+
 resource "google_project_iam_member" "acceptance" {
-    project = "${google_project.acceptance.project_id}"
-    member = "user:admin@hashicorptest.com"
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.project_id}"
+  member  = "user:admin@hashicorptest.com"
+  role    = "roles/compute.instanceAdmin"
 }
 `, pid, name, org)
 }
@@ -128,19 +129,21 @@ resource "google_project_iam_member" "acceptance" {
 func testAccGoogleProjectAssociateMemberMultiple(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }
+
 resource "google_project_iam_member" "acceptance" {
-    project = "${google_project.acceptance.project_id}"
-    member = "user:admin@hashicorptest.com"
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.project_id}"
+  member  = "user:admin@hashicorptest.com"
+  role    = "roles/compute.instanceAdmin"
 }
+
 resource "google_project_iam_member" "multiple" {
-    project = "${google_project.acceptance.project_id}"
-    member = "user:paddy@hashicorp.com"
-    role = "roles/compute.instanceAdmin"
+  project = "${google_project.acceptance.project_id}"
+  member  = "user:paddy@hashicorp.com"
+  role    = "roles/compute.instanceAdmin"
 }
 `, pid, name, org)
 }

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"sort"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
@@ -257,7 +258,7 @@ func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pi
 		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy}).Do()
 
 	if err != nil {
-		return fmt.Errorf("Error applying IAM policy for project %q. Policy is %#v, error is %s", pid, policy, err)
+		return errwrap.Wrap(fmt.Errorf("Error applying IAM policy for project %q. Policy is %#v, error is {{err}}", pid, policy), err)
 	}
 	return nil
 }

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -36,8 +36,7 @@ The following arguments are supported:
 * `role` - (Required) The role that should be applied. Only one
     `google_project_iam_binding` can be used per role.
 
-* `project` - (Optional) The project ID.
-    Changing this forces a new project to be created. If not specified, uses the
+* `project` - (Optional) The project ID. If not specified, uses the
     ID of the project configured with the provider.## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -44,3 +44,4 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `etag` - (Computed) The etag of the project's IAM policy.
+

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "google"
+page_title: "Google: google_project_iam_binding"
+sidebar_current: "docs-google-project-iam-binding"
+description: |-
+ Allows management of a single binding with an IAM policy for a Google Cloud Platform project.
+---
+
+# google\_project\_iam\_binding
+
+Allows creation and management of a single binding within IAM policy for
+an existing Google Cloud Platform project.
+
+~> **Note:** This resource _must not_ be used in conjunction with
+   `google_project_iam_policy` or they will fight over what your policy
+   should be.
+
+## Example Usage
+
+```hcl
+resource "google_project_iam_binding" "project" {
+  project     = "your-project-id"
+  role = "roles/editor"
+  members = [
+    "user:jane@example.com",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `members` - (Required) A list of users that the role should apply to.
+
+* `role` - (Required) The role that should be applied. Only one
+    `google_project_iam_binding` can be used per role.
+
+* `project` - (Optional) The project ID.
+    Changing this forces a new project to be created. If not specified, uses the
+    ID of the project configured with the provider.## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `etag` - (Computed) The etag of the project's IAM policy.

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -19,8 +19,9 @@ an existing Google Cloud Platform project.
 
 ```hcl
 resource "google_project_iam_binding" "project" {
-  project     = "your-project-id"
-  role = "roles/editor"
+  project = "your-project-id"
+  role    = "roles/editor"
+
   members = [
     "user:jane@example.com",
   ]

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -38,7 +38,9 @@ The following arguments are supported:
     `google_project_iam_binding` can be used per role.
 
 * `project` - (Optional) The project ID. If not specified, uses the
-    ID of the project configured with the provider.## Attributes Reference
+    ID of the project configured with the provider.
+
+## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are
 exported:

--- a/website/docs/r/google_project_iam_member.html.markdown
+++ b/website/docs/r/google_project_iam_member.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "google"
+page_title: "Google: google_project_iam_member"
+sidebar_current: "docs-google-project-iam-member"
+description: |-
+ Allows management of a single member for a single binding on the IAM policy for a Google Cloud Platform project.
+---
+
+# google\_project\_iam\_member
+
+Allows creation and management of a single member for a single binding within
+the IAM policy for an existing Google Cloud Platform project.
+
+~> **Note:** This resource _must not_ be used in conjunction with
+   `google_project_iam_policy` or they will fight over what your policy
+   should be. Similarly, roles controlled by `google_project_iam_binding`
+   should not be assigned to using `google_project_iam_member`.
+
+## Example Usage
+
+```hcl
+resource "google_project_iam_member" "project" {
+  project     = "your-project-id"
+  role = "roles/editor"
+  member = "user:jane@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `member` - (Required) The user that the role should apply to.
+
+* `role` - (Required) The role that should be applied.
+
+* `project` - (Optional) The project ID. If not specified, uses the
+    ID of the project configured with the provider.## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `etag` - (Computed) The etag of the project's IAM policy.

--- a/website/docs/r/google_project_iam_member.html.markdown
+++ b/website/docs/r/google_project_iam_member.html.markdown
@@ -35,10 +35,11 @@ The following arguments are supported:
 * `role` - (Required) The role that should be applied.
 
 * `project` - (Optional) The project ID. If not specified, uses the
-    ID of the project configured with the provider.## Attributes Reference
+    ID of the project configured with the provider.
+    
+## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `etag` - (Computed) The etag of the project's IAM policy.
-

--- a/website/docs/r/google_project_iam_member.html.markdown
+++ b/website/docs/r/google_project_iam_member.html.markdown
@@ -20,9 +20,9 @@ the IAM policy for an existing Google Cloud Platform project.
 
 ```hcl
 resource "google_project_iam_member" "project" {
-  project     = "your-project-id"
-  role = "roles/editor"
-  member = "user:jane@example.com"
+  project = "your-project-id"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
 }
 ```
 

--- a/website/docs/r/google_project_iam_member.html.markdown
+++ b/website/docs/r/google_project_iam_member.html.markdown
@@ -41,3 +41,4 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `etag` - (Computed) The etag of the project's IAM policy.
+

--- a/website/google.erb
+++ b/website/google.erb
@@ -51,6 +51,9 @@
       <li<%= sidebar_current("docs-google-project") %>>
       <a href="/docs/providers/google/r/google_project.html">google_project</a>
             </li>
+            <li<%= sidebar_current("docs-google-project-iam-binding") %>>
+      <a href="/docs/providers/google/r/google_project_iam_binding.html">google_project_iam_binding</a>
+            </li>
             <li<%= sidebar_current("docs-google-project-iam-policy") %>>
       <a href="/docs/providers/google/r/google_project_iam_policy.html">google_project_iam_policy</a>
             </li>

--- a/website/google.erb
+++ b/website/google.erb
@@ -54,6 +54,9 @@
             <li<%= sidebar_current("docs-google-project-iam-binding") %>>
       <a href="/docs/providers/google/r/google_project_iam_binding.html">google_project_iam_binding</a>
             </li>
+            <li<%= sidebar_current("docs-google-project-iam-member") %>>
+      <a href="/docs/providers/google/r/google_project_iam_member.html">google_project_iam_member</a>
+            </li>
             <li<%= sidebar_current("docs-google-project-iam-policy") %>>
       <a href="/docs/providers/google/r/google_project_iam_policy.html">google_project_iam_policy</a>
             </li>


### PR DESCRIPTION
Add a resource that manages just a single binding within a Google
project's IAM Policy.

Add a resource that manages just a single member of a single binding
within a Google project's IAM Policy.

Note that these resources should not be used when
google_project_iam_policy is used, or they will fight over which is
correct. They should also not be assigned the same role within the
same project, or they will fight with each other.

This also required wrapping the error returned from setProjectIamPolicy,
as we need to test to see if it's a 409 error and retry, which can't be
done if we just use fmt.Errorf.

~The code that is here works, and the tests pass. I still need to add a `google_project_iam_member` resource that controls IAM at the member level, which is the full solution to this problem. That will be pushed to this PR shortly.~ This is now complete and ready for review.

This should resolve #72 and #58.