### PR TITLE
Allow for running acceptance tests using the default credentials.

### DIFF
--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -53,6 +53,7 @@ func testAccPreCheck(t *testing.T) {
 		"GOOGLE_CREDENTIALS",
 		"GOOGLE_CLOUD_KEYFILE_JSON",
 		"GCLOUD_KEYFILE_JSON",
+		"GOOGLE_USE_DEFAULT_CREDENTIALS",
 	}
 	if v := multiEnvSearch(creds); v == "" {
 		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(creds, ", "))


### PR DESCRIPTION
This change adds another option for supplying authentication credentials
to acceptance tests: If GOOGLE_USE_DEFAULT_CREDENTIALS is set, the default
credentials are used. When run from a compute engine instance, the compute
engine default credentials are used. When run from the user's workstation,
the user's credentials are used, if the user has authenticated with the
GCloud CLI beforehand.