### PR TITLE
Add v0beta support to google_compute_instance_group_manager.

### DIFF
--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -84,7 +84,7 @@ func (s Feature) HasChangeBy(d TerraformResourceData) bool {
 // Return true when a feature appears in schema or has been modified.
 func (s Feature) InUseBy(d TerraformResourceData) bool {
 	_, ok := d.GetOk(s.Item)
-	return ok && s.HasChangeBy(d)
+	return ok || s.HasChangeBy(d)
 }
 
 func maxVersion(versionsInUse map[ComputeApiVersion]struct{}) ComputeApiVersion {

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -11,6 +11,11 @@ const (
 	v0beta
 )
 
+var ORDERED_COMPUTE_API_VERSIONS = []ComputeApiVersion{
+	v0beta,
+	v1,
+}
+
 // Convert between two types by converting to/from JSON. Intended to switch
 // between multiple API versions, as they are strict supersets of one another.
 func Convert(item, out interface{}) error {
@@ -25,4 +30,64 @@ func Convert(item, out interface{}) error {
 	}
 
 	return nil
+}
+
+type TerraformResourceData interface {
+	HasChange(string) bool
+	GetOk(string) (interface{}, bool)
+}
+
+// Compare the keys set in schema against a list of features and their versions to determine
+//what version of the API is required in order to manage the resource.
+func getComputeApiVersion(d TerraformResourceData, baseVersion ComputeApiVersion, keys []Key) ComputeApiVersion {
+	versions := map[ComputeApiVersion]struct{}{baseVersion: struct{}{}}
+	for _, key := range keys {
+		if key.InUseBy(d) {
+			versions[key.Version] = struct{}{}
+		}
+	}
+
+	return maxVersion(versions)
+}
+
+// Compare the keys set in schema against a list of features and their version, and a
+// list of features that exist at the base version that can only be update at some other version,
+// to determine what version of the API is required in order to update the resource.
+func getComputeApiVersionUpdate(d TerraformResourceData, baseVersion ComputeApiVersion, keys, updateOnlyKeys []Key) ComputeApiVersion {
+	versions := map[ComputeApiVersion]struct{}{baseVersion: struct{}{}}
+	schemaVersion := getComputeApiVersion(d, baseVersion, keys)
+	versions[schemaVersion] = struct{}{}
+
+	for _, key := range updateOnlyKeys {
+		if key.HasChangeBy(d) {
+			versions[key.Version] = struct{}{}
+		}
+	}
+
+	return maxVersion(versions)
+}
+
+type Key struct {
+	Version ComputeApiVersion
+	Item    string
+}
+
+func (s Key) HasChangeBy(d TerraformResourceData) bool {
+	return d.HasChange(s.Item)
+}
+
+func (s Key) InUseBy(d TerraformResourceData) bool {
+	_, ok := d.GetOk(s.Item)
+	return ok && s.HasChangeBy(d)
+}
+
+func maxVersion(versionsInUse map[ComputeApiVersion]struct{}) ComputeApiVersion {
+	for _, version := range ORDERED_COMPUTE_API_VERSIONS {
+		if _, ok := versionsInUse[version]; ok {
+			return version
+		}
+	}
+
+	// Fallback to the final, most stable version
+	return ORDERED_COMPUTE_API_VERSIONS[len(ORDERED_COMPUTE_API_VERSIONS)-1]
 }

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -8,6 +8,7 @@ type ComputeApiVersion uint8
 
 const (
 	v1 ComputeApiVersion = iota
+	v0beta
 )
 
 // Convert between two types by converting to/from JSON. Intended to switch

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -7,69 +7,69 @@ func TestResourceWithOnlyBaseVersionFields(t *testing.T) {
 		FieldsInSchema: []string{"normal_field"},
 	}
 
-	baseVersion := v1
-	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{})
-	if computeApiVersion != baseVersion {
-		t.Errorf("Expected to see version: %v. Saw version: %v.", baseVersion, computeApiVersion)
+	resourceVersion := v1
+	computeApiVersion := getComputeApiVersion(d, resourceVersion, []Feature{})
+	if computeApiVersion != resourceVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", resourceVersion, computeApiVersion)
 	}
 
-	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{}, []Key{})
-	if computeApiVersion != baseVersion {
-		t.Errorf("Expected to see version: %v. Saw version: %v.", baseVersion, computeApiVersion)
+	computeApiVersion = getComputeApiVersionUpdate(d, resourceVersion, []Feature{}, []Feature{})
+	if computeApiVersion != resourceVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", resourceVersion, computeApiVersion)
 	}
 }
 
 func TestResourceWithBetaFields(t *testing.T) {
-	baseVersion := v1
+	resourceVersion := v1
 	d := &ResourceDataMock{
 		FieldsInSchema: []string{"normal_field", "beta_field"},
 	}
 
 	expectedVersion := v0beta
-	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}})
+	computeApiVersion := getComputeApiVersion(d, resourceVersion, []Feature{{Version: expectedVersion, Item: "beta_field"}})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}
 
-	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}}, []Key{})
+	computeApiVersion = getComputeApiVersionUpdate(d, resourceVersion, []Feature{{Version: expectedVersion, Item: "beta_field"}}, []Feature{})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}
 }
 
 func TestResourceWithBetaFieldsNotInSchema(t *testing.T) {
-	baseVersion := v1
+	resourceVersion := v1
 	d := &ResourceDataMock{
 		FieldsInSchema: []string{"normal_field"},
 	}
 
 	expectedVersion := v1
-	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}})
+	computeApiVersion := getComputeApiVersion(d, resourceVersion, []Feature{{Version: expectedVersion, Item: "beta_field"}})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}
 
-	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}}, []Key{})
+	computeApiVersion = getComputeApiVersionUpdate(d, resourceVersion, []Feature{{Version: expectedVersion, Item: "beta_field"}}, []Feature{})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}
 }
 
 func TestResourceWithBetaUpdateFields(t *testing.T) {
-	baseVersion := v1
+	resourceVersion := v1
 	d := &ResourceDataMock{
 		FieldsInSchema:      []string{"normal_field", "beta_update_field"},
 		FieldsWithHasChange: []string{"beta_update_field"},
 	}
 
 	expectedVersion := v1
-	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{})
+	computeApiVersion := getComputeApiVersion(d, resourceVersion, []Feature{})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}
 
 	expectedVersion = v0beta
-	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{}, []Key{{Version: expectedVersion, Item: "beta_update_field"}})
+	computeApiVersion = getComputeApiVersionUpdate(d, resourceVersion, []Feature{}, []Feature{{Version: expectedVersion, Item: "beta_update_field"}})
 	if computeApiVersion != expectedVersion {
 		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
 	}

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -83,12 +83,6 @@ type ResourceDataMock struct {
 
 func (d *ResourceDataMock) HasChange(key string) bool {
 	exists := false
-	for _, val := range d.FieldsInSchema {
-		if key == val {
-			exists = true
-		}
-	}
-
 	for _, val := range d.FieldsWithHasChange {
 		if key == val {
 			exists = true

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -1,0 +1,111 @@
+package google
+
+import "testing"
+
+func TestResourceWithOnlyBaseVersionFields(t *testing.T) {
+	d := &ResourceDataMock{
+		FieldsInSchema: []string{"normal_field"},
+	}
+
+	baseVersion := v1
+	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{})
+	if computeApiVersion != baseVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", baseVersion, computeApiVersion)
+	}
+
+	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{}, []Key{})
+	if computeApiVersion != baseVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", baseVersion, computeApiVersion)
+	}
+}
+
+func TestResourceWithBetaFields(t *testing.T) {
+	baseVersion := v1
+	d := &ResourceDataMock{
+		FieldsInSchema: []string{"normal_field", "beta_field"},
+	}
+
+	expectedVersion := v0beta
+	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+
+	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}}, []Key{})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+}
+
+func TestResourceWithBetaFieldsNotInSchema(t *testing.T) {
+	baseVersion := v1
+	d := &ResourceDataMock{
+		FieldsInSchema: []string{"normal_field"},
+	}
+
+	expectedVersion := v1
+	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+
+	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{{Version: expectedVersion, Item: "beta_field"}}, []Key{})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+}
+
+func TestResourceWithBetaUpdateFields(t *testing.T) {
+	baseVersion := v1
+	d := &ResourceDataMock{
+		FieldsInSchema:      []string{"normal_field", "beta_update_field"},
+		FieldsWithHasChange: []string{"beta_update_field"},
+	}
+
+	expectedVersion := v1
+	computeApiVersion := getComputeApiVersion(d, baseVersion, []Key{})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+
+	expectedVersion = v0beta
+	computeApiVersion = getComputeApiVersionUpdate(d, baseVersion, []Key{}, []Key{{Version: expectedVersion, Item: "beta_update_field"}})
+	if computeApiVersion != expectedVersion {
+		t.Errorf("Expected to see version: %v. Saw version: %v.", expectedVersion, computeApiVersion)
+	}
+
+}
+
+type ResourceDataMock struct {
+	FieldsInSchema      []string
+	FieldsWithHasChange []string
+}
+
+func (d *ResourceDataMock) HasChange(key string) bool {
+	exists := false
+	for _, val := range d.FieldsInSchema {
+		if key == val {
+			exists = true
+		}
+	}
+
+	for _, val := range d.FieldsWithHasChange {
+		if key == val {
+			exists = true
+		}
+	}
+
+	return exists
+}
+
+func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
+	exists := false
+	for _, val := range d.FieldsInSchema {
+		if key == val {
+			exists = true
+		}
+
+	}
+
+	return nil, exists
+}

--- a/google/compute_beta_operation.go
+++ b/google/compute_beta_operation.go
@@ -1,0 +1,167 @@
+package google
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
+)
+
+// OperationBetaWaitType is an enum specifying what type of operation
+// we're waiting on from the beta API.
+type ComputeBetaOperationWaitType byte
+
+const (
+	ComputeBetaOperationWaitInvalid ComputeBetaOperationWaitType = iota
+	ComputeBetaOperationWaitGlobal
+	ComputeBetaOperationWaitRegion
+	ComputeBetaOperationWaitZone
+)
+
+type ComputeBetaOperationWaiter struct {
+	Service *computeBeta.Service
+	Op      *computeBeta.Operation
+	Project string
+	Region  string
+	Type    ComputeBetaOperationWaitType
+	Zone    string
+}
+
+func (w *ComputeBetaOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var op *computeBeta.Operation
+		var err error
+
+		switch w.Type {
+		case ComputeBetaOperationWaitGlobal:
+			op, err = w.Service.GlobalOperations.Get(
+				w.Project, w.Op.Name).Do()
+		case ComputeBetaOperationWaitRegion:
+			op, err = w.Service.RegionOperations.Get(
+				w.Project, w.Region, w.Op.Name).Do()
+		case ComputeBetaOperationWaitZone:
+			op, err = w.Service.ZoneOperations.Get(
+				w.Project, w.Zone, w.Op.Name).Do()
+		default:
+			return nil, "bad-type", fmt.Errorf(
+				"Invalid wait type: %#v", w.Type)
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] Got %q when asking for operation %q", op.Status, w.Op.Name)
+
+		return op, op.Status, nil
+	}
+}
+
+func (w *ComputeBetaOperationWaiter) Conf() *resource.StateChangeConf {
+	return &resource.StateChangeConf{
+		Pending: []string{"PENDING", "RUNNING"},
+		Target:  []string{"DONE"},
+		Refresh: w.RefreshFunc(),
+	}
+}
+
+// ComputeBetaOperationError wraps computeBeta.OperationError and implements the
+// error interface so it can be returned.
+type ComputeBetaOperationError computeBeta.OperationError
+
+func (e ComputeBetaOperationError) Error() string {
+	var buf bytes.Buffer
+
+	for _, err := range e.Errors {
+		buf.WriteString(err.Message + "\n")
+	}
+
+	return buf.String()
+}
+
+func computeBetaOperationWaitGlobal(config *Config, op *computeBeta.Operation, project string, activity string) error {
+	return computeBetaOperationWaitGlobalTime(config, op, project, activity, 4)
+}
+
+func computeBetaOperationWaitGlobalTime(config *Config, op *computeBeta.Operation, project string, activity string, timeoutMin int) error {
+	w := &ComputeBetaOperationWaiter{
+		Service: config.clientComputeBeta,
+		Op:      op,
+		Project: project,
+		Type:    ComputeBetaOperationWaitGlobal,
+	}
+
+	state := w.Conf()
+	state.Delay = 10 * time.Second
+	state.Timeout = time.Duration(timeoutMin) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+	}
+
+	op = opRaw.(*computeBeta.Operation)
+	if op.Error != nil {
+		return ComputeBetaOperationError(*op.Error)
+	}
+
+	return nil
+}
+
+func computeBetaOperationWaitRegion(config *Config, op *computeBeta.Operation, project string, region, activity string) error {
+	w := &ComputeBetaOperationWaiter{
+		Service: config.clientComputeBeta,
+		Op:      op,
+		Project: project,
+		Type:    ComputeBetaOperationWaitRegion,
+		Region:  region,
+	}
+
+	state := w.Conf()
+	state.Delay = 10 * time.Second
+	state.Timeout = 4 * time.Minute
+	state.MinTimeout = 2 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+	}
+
+	op = opRaw.(*computeBeta.Operation)
+	if op.Error != nil {
+		return ComputeBetaOperationError(*op.Error)
+	}
+
+	return nil
+}
+
+func computeBetaOperationWaitZone(config *Config, op *computeBeta.Operation, project string, zone, activity string) error {
+	return computeBetaOperationWaitZoneTime(config, op, project, zone, 4, activity)
+}
+
+func computeBetaOperationWaitZoneTime(config *Config, op *computeBeta.Operation, project string, zone string, minutes int, activity string) error {
+	w := &ComputeBetaOperationWaiter{
+		Service: config.clientComputeBeta,
+		Op:      op,
+		Project: project,
+		Zone:    zone,
+		Type:    ComputeBetaOperationWaitZone,
+	}
+	state := w.Conf()
+	state.Delay = 10 * time.Second
+	state.Timeout = time.Duration(minutes) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+	}
+	op = opRaw.(*computeBeta.Operation)
+	if op.Error != nil {
+		// Return the error
+		return ComputeBetaOperationError(*op.Error)
+	}
+	return nil
+}

--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -16,6 +17,8 @@ func computeSharedOperationWaitZoneTime(config *Config, op interface{}, project 
 	switch op.(type) {
 	case *compute.Operation:
 		return computeOperationWaitZoneTime(config, op.(*compute.Operation), project, zone, minutes, activity)
+	case *computeBeta.Operation:
+		return computeBetaOperationWaitZoneTime(config, op.(*computeBeta.Operation), project, zone, minutes, activity)
 	default:
 		panic("Attempted to wait on an Operation of unknown type.")
 	}

--- a/google/config.go
+++ b/google/config.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/cloudbilling/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/dns/v1"
@@ -36,6 +37,7 @@ type Config struct {
 
 	clientBilling         *cloudbilling.Service
 	clientCompute         *compute.Service
+	clientComputeBeta     *computeBeta.Service
 	clientContainer       *container.Service
 	clientDns             *dns.Service
 	clientPubsub          *pubsub.Service
@@ -110,6 +112,13 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientCompute.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating GCE Beta client...")
+	c.clientComputeBeta, err = computeBeta.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientComputeBeta.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating GKE client...")
 	c.clientContainer, err = container.New(client)

--- a/google/provider.go
+++ b/google/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -187,6 +188,30 @@ func getProject(d *schema.ResourceData, config *Config) (string, error) {
 }
 
 func getZonalResourceFromRegion(getResource func(string) (interface{}, error), region string, compute *compute.Service, project string) (interface{}, error) {
+	zoneList, err := compute.Zones.List(project).Do()
+	if err != nil {
+		return nil, err
+	}
+	var resource interface{}
+	for _, zone := range zoneList.Items {
+		if strings.Contains(zone.Name, region) {
+			resource, err = getResource(zone.Name)
+			if err != nil {
+				if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+					// Resource was not found in this zone
+					continue
+				}
+				return nil, fmt.Errorf("Error reading Resource: %s", err)
+			}
+			// Resource was found
+			return resource, nil
+		}
+	}
+	// Resource does not exist in this region
+	return nil, nil
+}
+
+func getZonalBetaResourceFromRegion(getResource func(string) (interface{}, error), region string, compute *computeBeta.Service, project string) (interface{}, error) {
 	zoneList, err := compute.Zones.List(project).Do()
 	if err != nil {
 		return nil, err

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -144,10 +144,10 @@ func getNamedPortsBeta(nps []interface{}) []*computeBeta.NamedPort {
 	return namedPorts
 }
 
-var INSTANCE_GROUP_MANAGER_BASE_VERSION = v1
+var InstanceGroupManagerBaseVersion = v1
 
 func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta interface{}) error {
-	computeApiVersion := getComputeApiVersion(d, INSTANCE_GROUP_MANAGER_BASE_VERSION, []Key{})
+	computeApiVersion := getComputeApiVersion(d, InstanceGroupManagerBaseVersion, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -243,7 +243,7 @@ func flattenNamedPortsBeta(namedPorts []*computeBeta.NamedPort) []map[string]int
 }
 
 func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
-	computeApiVersion := getComputeApiVersion(d, INSTANCE_GROUP_MANAGER_BASE_VERSION, []Key{})
+	computeApiVersion := getComputeApiVersion(d, InstanceGroupManagerBaseVersion, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -357,7 +357,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 }
 
 func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
-	computeApiVersion := getComputeApiVersionUpdate(d, INSTANCE_GROUP_MANAGER_BASE_VERSION, []Key{}, []Key{})
+	computeApiVersion := getComputeApiVersionUpdate(d, InstanceGroupManagerBaseVersion, []Feature{}, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -613,7 +613,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
-	computeApiVersion := getComputeApiVersion(d, INSTANCE_GROUP_MANAGER_BASE_VERSION, []Key{})
+	computeApiVersion := getComputeApiVersion(d, InstanceGroupManagerBaseVersion, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)


### PR DESCRIPTION
Add support for `v0beta` to `google_compute_instance_group_manager`, but add no `v0beta` fields yet; all operations will still be performed at `v1`, as `getComputeApiVersion` and `getComputeApiVersionLevelUpdate` will not be able to see any other versions as being necessary.

Beta operations can be tested locally by changing `INSTANCE_GROUP_MANAGER_BASE_VERSION` to `v0beta` and running the acceptance test suite with `TESTARGS='-run=TestAccInstanceGroupManager'`.