### PR TITLE
Use polling when waiting for compute operations instead of exponentia…

### DIFF
--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -78,7 +78,7 @@ func computeOperationWaitTime(config *Config, op *compute.Operation, project, ac
 	state := w.Conf()
 	state.Delay = 10 * time.Second
 	state.Timeout = time.Duration(timeoutMin) * time.Minute
-	state.MinTimeout = 2 * time.Second
+	state.PollInterval = 2 * time.Second
 	opRaw, err := state.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Error waiting for %s: %s", activity, err)


### PR DESCRIPTION
…l backoff

Currently in compute resources, when waiting for an operation to complete, we use exponential backoff to sleep between checks (with a maximum wait time of 10 seconds). This change results in a constant 2 second sleep time when polling for operations.

The upside is that tests will be faster and command-line operations will feel faster.

The downside is that this increases the TPS on GCP. If we assume that an operation takes 60 seconds to complete, then currently we do an average of 0.125 TPS (peaking at 0.5 TPS in the beginning and ramping down to 0.1 TPS). After this change we'll do a constant 0.5 TPS. Personally this doesn't seem too aggressive to me, but please comment if you feel this is too aggressive.

Other services have similar exponential backoff currently; if this change is deemed appropriate I can modify those as well.