### PR TITLE
Update compute instance docs/tests to use new boot and scratch disk attributes

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1393,18 +1393,18 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk) []map[s
 		"auto_delete": disk.AutoDelete,
 		"device_name": disk.DeviceName,
 		"source":      sourceUrl[len(sourceUrl)-1],
-		// disk_encryption_key_raw is not returned from the API, so don't store it in state.
-		// If necessary in the future, this can be copied from what the user originally specified.
+		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
+		// originally specified to avoid diffs.
+		"disk_encryption_key_raw": d.Get("boot_disk.0.disk_encryption_key_raw"),
 	}
 	if disk.DiskEncryptionKey != nil {
 		result["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256
 	}
-	if v, ok := d.GetOk("boot_disk.0.initialize_params.#"); ok {
-		result["initialize_params.#"] = v.(int)
-		// initialize_params is not returned from the API, so don't store its values in state.
-		// If necessary in the future, this can be copied from what the user originally specified.
-		// However, because Terraform automatically sets `boot_disk.0.initialize_params.#` to 0 if
-		// nothing is set in state for it, set it to whatever it was set to before to avoid a perpetual diff.
+	if _, ok := d.GetOk("boot_disk.0.initialize_params.#"); ok {
+		// initialize_params is not returned from the API, so copy it from what the user
+		// originally specified to avoid diffs.
+		m := d.Get("boot_disk.0.initialize_params")
+		result["initialize_params"] = m
 	}
 
 	return []map[string]interface{}{result}

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -858,6 +858,9 @@ func testAccCheckComputeInstanceDiskEncryptionKey(n string, instance *compute.In
 
 		for i, disk := range instance.Disks {
 			attr := rs.Primary.Attributes[fmt.Sprintf("disk.%d.disk_encryption_key_sha256", i)]
+			if attr == "" && disk.Boot {
+				attr = rs.Primary.Attributes["boot_disk.0.disk_encryption_key_sha256"]
+			}
 			if disk.DiskEncryptionKey == nil && attr != "" {
 				return fmt.Errorf("Disk %d has mismatched encryption key.\nTF State: %+v\nGCP State: <empty>", i, attr)
 			}

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -175,7 +175,7 @@ func TestAccComputeInstance_IP(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_disksWithoutAutodelete(t *testing.T) {
+func TestAccComputeInstance_deprecated_disksWithoutAutodelete(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-testd-%s", acctest.RandString(10))
@@ -186,7 +186,7 @@ func TestAccComputeInstance_disksWithoutAutodelete(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstance_disks(diskName, instanceName, false),
+				Config: testAccComputeInstance_deprecated_disks(diskName, instanceName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", &instance),
@@ -198,7 +198,7 @@ func TestAccComputeInstance_disksWithoutAutodelete(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_disksWithAutodelete(t *testing.T) {
+func TestAccComputeInstance_deprecated_disksWithAutodelete(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-testd-%s", acctest.RandString(10))
@@ -209,7 +209,7 @@ func TestAccComputeInstance_disksWithAutodelete(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstance_disks(diskName, instanceName, true),
+				Config: testAccComputeInstance_deprecated_disks(diskName, instanceName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", &instance),
@@ -267,27 +267,6 @@ func TestAccComputeInstance_attachedDisk(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_bootDisk(t *testing.T) {
-	var instance compute.Instance
-	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeInstance_bootDisk(instanceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceBootDisk(&instance, instanceName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccComputeInstance_bootDisk_source(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
@@ -326,7 +305,7 @@ func TestAccComputeInstance_noDisk(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_local_ssd(t *testing.T) {
+func TestAccComputeInstance_deprecated_local_ssd(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -336,7 +315,7 @@ func TestAccComputeInstance_local_ssd(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstance_local_ssd(instanceName),
+				Config: testAccComputeInstance_deprecated_local_ssd(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.local-ssd", &instance),
@@ -634,7 +613,7 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_invalid_disk(t *testing.T) {
+func TestAccComputeInstance_deprecated_invalid_disk(t *testing.T) {
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-testd-%s", acctest.RandString(10))
 
@@ -644,7 +623,7 @@ func TestAccComputeInstance_invalid_disk(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:      testAccComputeInstance_invalid_disk(diskName, instanceName),
+				Config:      testAccComputeInstance_deprecated_invalid_disk(diskName, instanceName),
 				ExpectError: regexp.MustCompile("Error: cannot define both disk and type."),
 			},
 		},
@@ -986,8 +965,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network {
@@ -1009,8 +990,10 @@ resource "google_compute_instance" "foobar" {
 	zone         = "us-central1-a"
 	tags         = ["baz"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network {
@@ -1033,8 +1016,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1067,8 +1052,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "debian-8"
+	boot_disk {
+		initialize_params{
+			image = "debian-8"
+		}
 	}
 
 	network_interface {
@@ -1091,8 +1078,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "debian-cloud/debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-cloud/debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1115,8 +1104,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "debian-cloud/debian-8"
+	boot_disk {
+		initialize_params{
+			image = "debian-cloud/debian-8"
+		}
 	}
 
 	network_interface {
@@ -1140,8 +1131,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["foo", "bar"]
 
-	disk {
-		image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1165,8 +1158,10 @@ resource "google_compute_instance" "foobar" {
 	zone         = "us-central1-b"
 	tags         = ["baz"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1191,8 +1186,10 @@ resource "google_compute_instance" "foobar" {
 	can_ip_forward = false
 	tags           = ["baz"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1227,8 +1224,10 @@ resource "google_compute_instance" "foobar" {
 	zone         = "us-central1-a"
 	tags         = ["foo", "bar"]
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1245,7 +1244,7 @@ resource "google_compute_instance" "foobar" {
 `, ip, instance)
 }
 
-func testAccComputeInstance_disks(disk, instance string, autodelete bool) string {
+func testAccComputeInstance_deprecated_disks(disk, instance string, autodelete bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
@@ -1293,8 +1292,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 		disk_encryption_key_raw = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
 	}
 
@@ -1342,27 +1343,6 @@ resource "google_compute_instance" "foobar" {
 `, disk, instance)
 }
 
-func testAccComputeInstance_bootDisk(instance string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance" "foobar" {
-	name         = "%s"
-	machine_type = "n1-standard-1"
-	zone         = "us-central1-a"
-
-	boot_disk {
-		initialize_params {
-			image = "debian-8-jessie-v20160803"
-		}
-		disk_encryption_key_raw = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
-	}
-
-	network_interface {
-		network = "default"
-	}
-}
-`, instance)
-}
-
 func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
@@ -1405,15 +1385,17 @@ resource "google_compute_instance" "foobar" {
 `, instance)
 }
 
-func testAccComputeInstance_local_ssd(instance string) string {
+func testAccComputeInstance_deprecated_local_ssd(instance string) string {
 	return fmt.Sprintf(`
 resource "google_compute_instance" "local-ssd" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	disk {
@@ -1465,8 +1447,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1491,8 +1475,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1518,8 +1504,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1551,8 +1539,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1586,8 +1576,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1616,8 +1608,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1645,8 +1639,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "debian-8-jessie-v20160803"
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
 	}
 
 	network_interface {
@@ -1678,8 +1674,10 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
-	disk {
-		image = "${google_compute_image.foobar.family}"
+	boot_disk {
+		initialize_params {
+			image = "${google_compute_image.foobar.family}"
+		}
 	}
 
 	network_interface {
@@ -1693,7 +1691,7 @@ resource "google_compute_instance" "foobar" {
 `, disk, image, family, instance)
 }
 
-func testAccComputeInstance_invalid_disk(disk, instance string) string {
+func testAccComputeInstance_deprecated_invalid_disk(disk, instance string) string {
 	return fmt.Sprintf(`
 resource "google_compute_instance" "foobar" {
   name         = "%s"

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -24,14 +24,14 @@ resource "google_compute_instance" "default" {
 
   tags = ["foo", "bar"]
 
-  disk {
-    image = "debian-cloud/debian-8"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
   }
 
   // Local SSD disk
-  disk {
-    type    = "local-ssd"
-    scratch = true
+  scratch_disk {
   }
 
   network_interface {
@@ -76,8 +76,7 @@ The following arguments are supported:
 
 - - -
 
-* `scratch_disk` - (Optional) Scratch disks to attach to the instance. This can be
-    specified multiple times for multiple scratch disks. Structure is documented below.
+* `attached_disk` - (Optional) List of disks to attach to the instance. Structure is documented below.
 
 * `can_ip_forward` - (Optional) Whether to allow sending and receiving of
     packets with non-matching source or destination IPs.
@@ -104,6 +103,9 @@ The following arguments are supported:
 
 * `scheduling` - (Optional) The scheduling strategy to use. More details about
     this configuration option are detailed below.
+
+* `scratch_disk` - (Optional) Scratch disks to attach to the instance. This can be
+    specified multiple times for multiple scratch disks. Structure is documented below.
 
 * `service_account` - (Optional) Service account to attach to the instance.
     Structure is documented below.
@@ -191,6 +193,18 @@ the type is "local-ssd", in which case scratch must be true).
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     to encrypt this disk.
 
+The `attached_disk` block supports:
+
+* `source` - (Required) The self_link of the disk to attach to this instance.
+
+* `device_name` - (Optional) Name with which the attached disk will be accessible
+    under `/dev/disk/by-id/`
+
+* `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
+    encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    to encrypt this disk.
+
 The `network_interface` block supports:
 
 * `network` - (Optional) The name or self_link of the network to attach this interface to.
@@ -261,6 +275,14 @@ exported:
 * `network_interface.0.address` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.assigned_nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
+
+* `attached_disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    encoded SHA-256 hash of the [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
+
+* `boot_disk.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    encoded SHA-256 hash of the [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
 
 * `disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     encoded SHA-256 hash of the [customer-supplied encryption key]


### PR DESCRIPTION
This will add clarity for users on how to do compute instance disk operations without the `disks` attribute, since it's deprecated.

Tests are currently running, but so far all are passing except one (not including xpn tests, which I'm going to ignore for now). Will investigate the failing test and update once it's working (and once all the others have finished running).