### PR TITLE
Store non-v1 resources' self links as v1

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -373,7 +373,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", manager.InstanceGroup)
 	d.Set("target_size", manager.TargetSize)
-	d.Set("self_link", manager.SelfLink)
+	d.Set("self_link", ConvertSelfLinkToV1(manager.SelfLink))
 	update_strategy, ok := d.GetOk("update_strategy")
 	if !ok {
 		update_strategy = "RESTART"

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -197,6 +197,9 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	}
 }
 
+// This test is to make sure that a single version resource can link to a versioned resource
+// without perpetual diffs because the self links mismatch.
+// Once auto_healing_policies is no longer beta, we will need to use a new field or resource.
 func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
 	var manager computeBeta.InstanceGroupManager
 
@@ -782,6 +785,9 @@ func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck 
 	`, template, target, igm, hck)
 }
 
+// This test is to make sure that a single version resource can link to a versioned resource
+// without perpetual diffs because the self links mismatch.
+// Once auto_healing_policies is no longer beta, we will need to use a new field or resource.
 func testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_instance_template" "igm-basic" {

--- a/google/self_link_helpers.go
+++ b/google/self_link_helpers.go
@@ -2,9 +2,11 @@ package google
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
 )
 
 // Compare only the relative path of two self links.
@@ -39,4 +41,9 @@ func getRelativePath(selfLink string) (string, error) {
 	}
 
 	return "projects/" + stringParts[1], nil
+}
+
+func ConvertSelfLinkToV1(link string) string {
+	reg := regexp.MustCompile("/compute/[a-zA-Z0-9]*/projects/")
+	return reg.ReplaceAllString(link, "/compute/v1/projects/")
 }


### PR DESCRIPTION
Store non-v1 resources' self links as v1 so that dependent single-version resources don't see diffs.

