### PR TITLE
Fix refresh for google_sql_database_instance when location_preference is set

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -1079,25 +1079,26 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+		locationPreference := &sqladmin.LocationPreference{}
 		if v, ok := _settings["location_preference"]; ok {
-			_locationPreferenceList := v.([]interface{})
-			if len(_locationPreferenceList) > 1 {
+			locationPreferenceList := v.([]interface{})
+			if len(locationPreferenceList) > 1 {
 				return fmt.Errorf("At most one location_preference block is allowed")
 			}
 
-			if len(_locationPreferenceList) == 1 && _locationPreferenceList[0] != nil {
-				settings.LocationPreference = &sqladmin.LocationPreference{}
-				_locationPreference := _locationPreferenceList[0].(map[string]interface{})
+			if len(locationPreferenceList) == 1 && locationPreferenceList[0] != nil {
+				lp := locationPreferenceList[0].(map[string]interface{})
 
-				if vp, okp := _locationPreference["follow_gae_application"]; okp {
-					settings.LocationPreference.FollowGaeApplication = vp.(string)
+				if vp, okp := lp["follow_gae_application"]; okp {
+					locationPreference.FollowGaeApplication = vp.(string)
 				}
 
-				if vp, okp := _locationPreference["zone"]; okp {
-					settings.LocationPreference.Zone = vp.(string)
+				if vp, okp := lp["zone"]; okp {
+					locationPreference.Zone = vp.(string)
 				}
 			}
 		}
+		settings.LocationPreference = locationPreference
 
 		if v, ok := _settings["maintenance_window"]; ok && len(v.([]interface{})) > 0 {
 			settings.MaintenanceWindow = &sqladmin.MaintenanceWindow{}

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -792,28 +792,14 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if v, ok := _settings["location_preference"]; ok && len(v.([]interface{})) > 0 {
-		_locationPreferenceList := v.([]interface{})
-		if len(_locationPreferenceList) > 1 {
-			return fmt.Errorf("At most one location_preference block is allowed")
+	if settings.LocationPreference != nil {
+		locationPreferences := []interface{}{
+			map[string]interface{}{
+				"follow_gae_application": settings.LocationPreference.FollowGaeApplication,
+				"zone": settings.LocationPreference.Zone,
+			},
 		}
-
-		if len(_locationPreferenceList) == 1 && _locationPreferenceList[0] != nil &&
-			settings.LocationPreference != nil {
-			_locationPreference := _locationPreferenceList[0].(map[string]interface{})
-
-			if vp, okp := _locationPreference["follow_gae_application"]; okp && vp != nil {
-				_locationPreference["follow_gae_application"] =
-					settings.LocationPreference.FollowGaeApplication
-			}
-
-			if vp, okp := _locationPreference["zone"]; okp && vp != nil {
-				_locationPreference["zone"] = settings.LocationPreference.Zone
-			}
-
-			_locationPreferenceList[0] = _locationPreference
-			_settings["location_preference"] = _locationPreferenceList[0]
-		}
+		_settings["location_preference"] = locationPreferences
 	}
 
 	if v, ok := _settings["maintenance_window"]; ok && len(v.([]interface{})) > 0 &&
@@ -845,7 +831,11 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 
 	_settingsList = make([]interface{}, 1)
 	_settingsList[0] = _settings
-	d.Set("settings", _settingsList)
+	err = d.Set("settings", _settingsList)
+	if err != nil {
+		log.Printf("[ERROR] Google Cloud SQL Database Instance Settings state failing to "+
+			" update due to: %s", err)
+	}
 
 	if v, ok := d.GetOk("replica_configuration"); ok && v != nil {
 		_replicaConfigurationList := v.([]interface{})


### PR DESCRIPTION
It looks like one of the fields was in the wrong format when trying to d.Set() it. This blocked most of the resource from updating. It only occurred in some configs because this resource conditionally reads values. 
Fix that field and cause an error to be logged in case other fields do the same thing.

Fixes #86 