### PR TITLE
[WIP] Add support for google_service_account_key

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -112,6 +112,7 @@ func Provider() terraform.ResourceProvider {
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),
 			"google_service_account":                resourceGoogleServiceAccount(),
+			"google_service_account_key":            resourceGoogleServiceAccountKey(),
 			"google_storage_bucket":                 resourceStorageBucket(),
 			"google_storage_bucket_acl":             resourceStorageBucketAcl(),
 			"google_storage_bucket_object":          resourceStorageBucketObject(),

--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -1,0 +1,143 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/encryption"
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/iam/v1"
+)
+
+func resourceGoogleServiceAccountKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleServiceAccountKeyCreate,
+		Read:   resourceGoogleServiceAccountKeyRead,
+		Delete: resourceGoogleServiceAccountKeyDelete,
+		Schema: map[string]*schema.Schema{
+			"service_account_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_algorithm": &schema.Schema{
+				Type:     schema.TypeString,
+				Default:  "KEY_ALG_RSA_2048",
+				Optional: true,
+				ForceNew: true,
+			},
+			"private_key": &schema.Schema{
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"private_key_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Default:  "TYPE_GOOGLE_CREDENTIALS_FILE",
+				Optional: true,
+				ForceNew: true,
+			},
+			"valid_after": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"valid_before": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pgp_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"private_key_encrypted": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_key_fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleServiceAccountKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serviceAccount := d.Get("service_account_id").(string)
+
+	r := &iam.CreateServiceAccountKeyRequest{}
+
+	if v, ok := d.GetOk("key_algorithm"); ok {
+		r.KeyAlgorithm = v.(string)
+	}
+
+	if v, ok := d.GetOk("private_key_type"); ok {
+		r.PrivateKeyType = v.(string)
+	}
+
+	sak, err := config.clientIAM.Projects.ServiceAccounts.Keys.Create(serviceAccount, r).Do()
+	if err != nil {
+		return fmt.Errorf("Error creating service account key: %s", err)
+	}
+
+	if v, ok := d.GetOk("pgp_key"); ok {
+		encryptionKey, err := encryption.RetrieveGPGKey(v.(string))
+		if err != nil {
+			return err
+		}
+
+		fingerprint, encrypted, err := encryption.EncryptValue(encryptionKey, sak.PrivateKeyData, "Google Service Account Key")
+		if err != nil {
+			return err
+		}
+
+		d.Set("private_key_encrypted", encrypted)
+		d.Set("private_key_fingerprint", fingerprint)
+	} else {
+		d.Set("private_key", sak.PrivateKeyData)
+	}
+
+	d.SetId(sak.Name)
+	d.Set("name", sak.Name)
+	d.Set("key_algorithm", sak.KeyAlgorithm)
+	d.Set("private_key_type", sak.PrivateKeyType)
+	d.Set("valid_after", sak.ValidAfterTime)
+	d.Set("valid_before", sak.ValidBeforeTime)
+
+	return nil
+}
+
+func resourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// Confirm the service account key exists
+	sak, err := config.clientIAM.Projects.ServiceAccounts.Keys.Get(d.Id()).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Service Account Key %q", d.Id()))
+	}
+
+	d.SetId(sak.Name)
+	d.Set("name", sak.Name)
+	d.Set("key_algorithm", sak.KeyAlgorithm)
+	d.Set("valid_after", sak.ValidAfterTime)
+	d.Set("valid_before", sak.ValidBeforeTime)
+
+	return nil
+}
+
+func resourceGoogleServiceAccountKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	_, err := config.clientIAM.Projects.ServiceAccounts.Keys.Delete(d.Id()).Do()
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/google/resource_google_service_account_key_test.go
+++ b/google/resource_google_service_account_key_test.go
@@ -1,0 +1,56 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Test that a service account key can be created and destroyed
+func TestAccGoogleServiceAccountKey_basic(t *testing.T) {
+	accountId := "a" + acctest.RandString(10)
+	displayName := "Terraform Test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleServiceAccountKey(accountId, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleServiceAccountKeyExists("google_service_account_key.acceptance"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleServiceAccountKeyExists(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("Not found: %s", r)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		return nil
+	}
+}
+
+func testAccGoogleServiceAccountKey(account, name string) string {
+	t := `resource "google_service_account" "acceptance" {
+	account_id = "%v"
+	display_name = "%v"
+}
+
+resource "google_service_account_key" "acceptance" {
+	service_account_id = "${google_service_account.acceptance.id}"
+}
+ `
+	return fmt.Sprintf(t, account, name)
+}


### PR DESCRIPTION
Adds support for creating and deleting service account keys. Fixes #116 and https://github.com/hashicorp/terraform/issues/15240.

Still a work in progress -- need to finish up acceptance tests and add docs. In the meantime, wanted to get some guidance on an acceptance test issue. When running a test to create a service account with an associated service account key, it fails with the error below. The service account key was successfully created though, but Google is returning an HTTP 404 for the service account key resource when refreshing state inside the test. It seems like the API takes at least a few seconds for get requests to succeed against the key resource. What is the best practice to handle these this kind of waiting for resource to be created or accessible situations?

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccGoogleServiceAccountKey_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccGoogleServiceAccountKey_basic
--- FAIL: TestAccGoogleServiceAccountKey_basic (5.45s)
	testing.go:428: Step 0 error: After applying this step and refreshing, the plan was not empty:
		
		DIFF:
		
		CREATE: google_service_account_key.acceptance
		  key_algorithm:           "" => "KEY_ALG_RSA_2048" (forces new resource)
		  name:                    "" => "<computed>"
		  private_key:             "<sensitive>" => "<sensitive>" (attribute changed)
		  private_key_encrypted:   "" => "<computed>"
		  private_key_fingerprint: "" => "<computed>"
		  private_key_type:        "" => "TYPE_GOOGLE_CREDENTIALS_FILE" (forces new resource)
		  service_account_id:      "" => "projects/terraform-test/serviceAccounts/ae4h8z98l0a@terraform-test.iam.gserviceaccount.com" (forces new resource)
		  valid_after:             "" => "<computed>"
		  valid_before:            "" => "<computed>"
		
		STATE:
		
		google_service_account.acceptance:
		  ID = projects/terraform-test/serviceAccounts/ae4h8z98l0a@terraform-test.iam.gserviceaccount.com
		  account_id = ae4h8z98l0a
		  display_name = Terraform Test
		  email = ae4h8z98l0a@terraform-test.iam.gserviceaccount.com
		  name = projects/terraform-test/serviceAccounts/ae4h8z98l0a@terraform-test.iam.gserviceaccount.com
		  unique_id = 108219597091612926163
FAIL
FAIL	github.com/terraform-providers/terraform-provider-google/google	5.476s
make: *** [testacc] Error 1
```