### PR TITLE
Update expected type of expiration time

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -207,7 +207,7 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 	}
 
 	if v, ok := d.GetOk("expiration_time"); ok {
-		table.ExpirationTime = v.(int64)
+		table.ExpirationTime = int64(v.(int))
 	}
 
 	if v, ok := d.GetOk("friendly_name"); ok {


### PR DESCRIPTION
schema.ResourceData encodes expiration_time as an int, while our Table object expects it as an int64. Unpack appropriately.

Resolves Issue #207