### PR TITLE
Support path-only when referencing ssl certificate in compute_target_https_proxy

### DIFF
--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -7,6 +7,12 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
+	"regexp"
+)
+
+const (
+	sslCertificateRegex             = "projects/(.+)/global/sslCertificates/(.+)$"
+	canonicalSslCertificateTemplate = "https://www.googleapis.com/compute/v1/projects/%s/global/sslCertificates/%s"
 )
 
 func resourceComputeTargetHttpsProxy() *schema.Resource {
@@ -26,7 +32,13 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 			"ssl_certificates": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateRegexp(sslCertificateRegex),
+					StateFunc:    toCanonicalSslCertificate,
+				},
+				MinItems: 1,
+				MaxItems: 1,
 			},
 
 			"url_map": &schema.Schema{
@@ -129,51 +141,12 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.HasChange("ssl_certificates") {
-		proxy, err := config.clientCompute.TargetHttpsProxies.Get(
-			project, d.Id()).Do()
-
-		_old, _new := d.GetChange("ssl_certificates")
-		_oldCerts := _old.([]interface{})
-		_newCerts := _new.([]interface{})
-		current := proxy.SslCertificates
-
-		_oldMap := make(map[string]bool)
-		_newMap := make(map[string]bool)
-
-		for _, v := range _oldCerts {
-			_oldMap[v.(string)] = true
-		}
-
-		for _, v := range _newCerts {
-			_newMap[v.(string)] = true
-		}
-
-		sslCertificates := make([]string, 0)
-		// Only modify certificates in one of our old or new states
-		for _, v := range current {
-			_, okOld := _oldMap[v]
-			_, okNew := _newMap[v]
-
-			// we deleted the certificate
-			if okOld && !okNew {
-				continue
-			}
-
-			sslCertificates = append(sslCertificates, v)
-
-			// Keep track of the fact that we have added this certificate
-			if okNew {
-				delete(_newMap, v)
-			}
-		}
-
-		// Add fresh certificates
-		for k, _ := range _newMap {
-			sslCertificates = append(sslCertificates, k)
-		}
+		// Exactly one ssl certificate must be specified.
+		certs := make([]string, 1)
+		certs[0] = d.Get("ssl_certificates.0").(string)
 
 		cert_ref := &compute.TargetHttpsProxiesSetSslCertificatesRequest{
-			SslCertificates: sslCertificates,
+			SslCertificates: certs,
 		}
 		op, err := config.clientCompute.TargetHttpsProxies.SetSslCertificates(
 			project, d.Id(), cert_ref).Do()
@@ -208,24 +181,7 @@ func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{
 		return handleNotFoundError(err, d, fmt.Sprintf("Target HTTPS proxy %q", d.Get("name").(string)))
 	}
 
-	_certs := d.Get("ssl_certificates").([]interface{})
-	current := proxy.SslCertificates
-
-	_certMap := make(map[string]bool)
-	_newCerts := make([]interface{}, 0)
-
-	for _, v := range _certs {
-		_certMap[v.(string)] = true
-	}
-
-	// Store intersection of server certificates and user defined certificates
-	for _, v := range current {
-		if _, ok := _certMap[v]; ok {
-			_newCerts = append(_newCerts, v)
-		}
-	}
-
-	d.Set("ssl_certificates", _newCerts)
+	d.Set("ssl_certificates", proxy.SslCertificates)
 	d.Set("self_link", proxy.SelfLink)
 	d.Set("id", strconv.FormatUint(proxy.Id, 10))
 
@@ -255,4 +211,15 @@ func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interfac
 
 	d.SetId("")
 	return nil
+}
+
+func toCanonicalSslCertificate(v interface{}) string {
+	value := v.(string)
+
+	m := regexp.MustCompile(sslCertificateRegex).FindStringSubmatch(value)
+	if m == nil {
+		return value
+	}
+
+	return fmt.Sprintf(canonicalSslCertificateTemplate, m[1], m[2])
 }

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -37,8 +37,6 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 					ValidateFunc: validateRegexp(sslCertificateRegex),
 					StateFunc:    toCanonicalSslCertificate,
 				},
-				MinItems: 1,
-				MaxItems: 1,
 			},
 
 			"url_map": &schema.Schema{
@@ -141,10 +139,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.HasChange("ssl_certificates") {
-		// Exactly one ssl certificate must be specified.
-		certs := make([]string, 1)
-		certs[0] = d.Get("ssl_certificates.0").(string)
-
+		certs := convertStringArr(d.Get("ssl_certificates").([]interface{}))
 		cert_ref := &compute.TargetHttpsProxiesSetSslCertificatesRequest{
 			SslCertificates: certs,
 		}
@@ -215,11 +210,7 @@ func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interfac
 
 func toCanonicalSslCertificate(v interface{}) string {
 	value := v.(string)
-
 	m := regexp.MustCompile(sslCertificateRegex).FindStringSubmatch(value)
-	if m == nil {
-		return value
-	}
 
 	return fmt.Sprintf(canonicalSslCertificateTemplate, m[1], m[2])
 }

--- a/google/resource_compute_target_https_proxy_test.go
+++ b/google/resource_compute_target_https_proxy_test.go
@@ -7,9 +7,13 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/compute/v1"
+	"regexp"
 )
 
 func TestAccComputeTargetHttpsProxy_basic(t *testing.T) {
+	var proxy compute.TargetHttpsProxy
+	resourceSuffix := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,10 +21,12 @@ func TestAccComputeTargetHttpsProxy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeTargetHttpsProxyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeTargetHttpsProxy_basic1,
+				Config: testAccComputeTargetHttpsProxy_basic1(resourceSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetHttpsProxyExists(
-						"google_compute_target_https_proxy.foobar"),
+						"google_compute_target_https_proxy.foobar", &proxy),
+					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
+					testAccComputeTargetHttpsProxySslCertificate("httpsproxy-test-cert1-"+resourceSuffix, &proxy),
 				),
 			},
 		},
@@ -28,6 +34,8 @@ func TestAccComputeTargetHttpsProxy_basic(t *testing.T) {
 }
 
 func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
+	var proxy compute.TargetHttpsProxy
+	resourceSuffix := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,19 +43,42 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 		CheckDestroy: testAccCheckComputeTargetHttpsProxyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeTargetHttpsProxy_basic1,
+				Config: testAccComputeTargetHttpsProxy_basic1(resourceSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetHttpsProxyExists(
-						"google_compute_target_https_proxy.foobar"),
+						"google_compute_target_https_proxy.foobar", &proxy),
+					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
+					testAccComputeTargetHttpsProxySslCertificate("httpsproxy-test-cert1-"+resourceSuffix, &proxy),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccComputeTargetHttpsProxy_basic2,
+				Config: testAccComputeTargetHttpsProxy_basic2(resourceSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetHttpsProxyExists(
-						"google_compute_target_https_proxy.foobar"),
+						"google_compute_target_https_proxy.foobar", &proxy),
+					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing (updated)", &proxy),
+					testAccComputeTargetHttpsProxySslCertificate("httpsproxy-test-cert2-"+resourceSuffix, &proxy),
 				),
+			},
+		},
+	})
+}
+
+func TestAccComputeTargetHttpsProxy_invalidCertificate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetHttpsProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: `
+				resource "google_compute_target_https_proxy" "foobar" {
+				name = "httpsproxy-test-%s"
+				url_map = "some-url-map"
+				ssl_certificates = ["invalid-certificate-reference"]
+				}`,
+				ExpectError: regexp.MustCompile("ssl_certificate"),
 			},
 		},
 	})
@@ -71,7 +102,7 @@ func testAccCheckComputeTargetHttpsProxyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeTargetHttpsProxyExists(n string) resource.TestCheckFunc {
+func testAccCheckComputeTargetHttpsProxyExists(n string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -94,122 +125,150 @@ func testAccCheckComputeTargetHttpsProxyExists(n string) resource.TestCheckFunc 
 			return fmt.Errorf("TargetHttpsProxy not found")
 		}
 
+		*proxy = *found
+
 		return nil
 	}
 }
 
-var testAccComputeTargetHttpsProxy_basic1 = fmt.Sprintf(`
-resource "google_compute_target_https_proxy" "foobar" {
-	description = "Resource created for Terraform acceptance testing"
-	name = "httpsproxy-test-%s"
-	url_map = "${google_compute_url_map.foobar.self_link}"
-	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
-}
-
-resource "google_compute_backend_service" "foobar" {
-	name = "httpsproxy-test-%s"
-	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-}
-
-resource "google_compute_http_health_check" "zero" {
-	name = "httpsproxy-test-%s"
-	request_path = "/"
-	check_interval_sec = 1
-	timeout_sec = 1
-}
-
-resource "google_compute_url_map" "foobar" {
-	name = "httpsproxy-test-%s"
-	default_service = "${google_compute_backend_service.foobar.self_link}"
-	host_rule {
-		hosts = ["mysite.com", "myothersite.com"]
-		path_matcher = "boop"
-	}
-	path_matcher {
-		default_service = "${google_compute_backend_service.foobar.self_link}"
-		name = "boop"
-		path_rule {
-			paths = ["/*"]
-			service = "${google_compute_backend_service.foobar.self_link}"
+func testAccComputeTargetHttpsProxyDescription(description string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if proxy.Description != description {
+			return fmt.Errorf("Wrong description: expected '%s' got '%s'", description, proxy.Description)
 		}
-	}
-	test {
-		host = "mysite.com"
-		path = "/*"
-		service = "${google_compute_backend_service.foobar.self_link}"
+		return nil
 	}
 }
 
-resource "google_compute_ssl_certificate" "foobar1" {
-	name = "httpsproxy-test-%s"
-	description = "very descriptive"
-	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-}
+func testAccComputeTargetHttpsProxySslCertificate(cert string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
 
-resource "google_compute_ssl_certificate" "foobar2" {
-	name = "httpsproxy-test-%s"
-	description = "very descriptive"
-	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-}
-`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
-
-var testAccComputeTargetHttpsProxy_basic2 = fmt.Sprintf(`
-resource "google_compute_target_https_proxy" "foobar" {
-	description = "Resource created for Terraform acceptance testing"
-	name = "httpsproxy-test-%s"
-	url_map = "${google_compute_url_map.foobar.self_link}"
-	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
-}
-
-resource "google_compute_backend_service" "foobar" {
-	name = "httpsproxy-test-%s"
-	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-}
-
-resource "google_compute_http_health_check" "zero" {
-	name = "httpsproxy-test-%s"
-	request_path = "/"
-	check_interval_sec = 1
-	timeout_sec = 1
-}
-
-resource "google_compute_url_map" "foobar" {
-	name = "httpsproxy-test-%s"
-	default_service = "${google_compute_backend_service.foobar.self_link}"
-	host_rule {
-		hosts = ["mysite.com", "myothersite.com"]
-		path_matcher = "boop"
-	}
-	path_matcher {
-		default_service = "${google_compute_backend_service.foobar.self_link}"
-		name = "boop"
-		path_rule {
-			paths = ["/*"]
-			service = "${google_compute_backend_service.foobar.self_link}"
+		if len(proxy.SslCertificates) != 1 {
+			return fmt.Errorf("Should have exactly one ssl certificate")
 		}
-	}
-	test {
-		host = "mysite.com"
-		path = "/*"
-		service = "${google_compute_backend_service.foobar.self_link}"
+
+		if certUrl := fmt.Sprintf(canonicalSslCertificateTemplate, config.Project, cert); proxy.SslCertificates[0] != certUrl {
+			return fmt.Errorf("Wrong ssl certificate: expected '%s' got '%s'", certUrl, proxy.SslCertificates[0])
+		}
+		return nil
 	}
 }
 
-resource "google_compute_ssl_certificate" "foobar1" {
-	name = "httpsproxy-test-%s"
-	description = "very descriptive"
-	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+func testAccComputeTargetHttpsProxy_basic1(id string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_target_https_proxy" "foobar" {
+			description = "Resource created for Terraform acceptance testing"
+			name = "httpsproxy-test-%s"
+			url_map = "${google_compute_url_map.foobar.self_link}"
+			ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
+		}
+
+		resource "google_compute_backend_service" "foobar" {
+			name = "httpsproxy-test-backend-%s"
+			health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+		}
+
+		resource "google_compute_http_health_check" "zero" {
+			name = "httpsproxy-test-health-check-%s"
+			request_path = "/"
+			check_interval_sec = 1
+			timeout_sec = 1
+		}
+
+		resource "google_compute_url_map" "foobar" {
+			name = "httpsproxy-test-url-map-%s"
+			default_service = "${google_compute_backend_service.foobar.self_link}"
+			host_rule {
+				hosts = ["mysite.com", "myothersite.com"]
+				path_matcher = "boop"
+			}
+			path_matcher {
+				default_service = "${google_compute_backend_service.foobar.self_link}"
+				name = "boop"
+				path_rule {
+					paths = ["/*"]
+					service = "${google_compute_backend_service.foobar.self_link}"
+				}
+			}
+			test {
+				host = "mysite.com"
+				path = "/*"
+				service = "${google_compute_backend_service.foobar.self_link}"
+			}
+		}
+
+		resource "google_compute_ssl_certificate" "foobar1" {
+			name = "httpsproxy-test-cert1-%s"
+			description = "very descriptive"
+			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+		}
+
+		resource "google_compute_ssl_certificate" "foobar2" {
+			name = "httpsproxy-test-cert2-%s"
+			description = "very descriptive"
+			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+		}
+		`, id, id, id, id, id, id)
 }
 
-resource "google_compute_ssl_certificate" "foobar2" {
-	name = "httpsproxy-test-%s"
-	description = "very descriptive"
-	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+func testAccComputeTargetHttpsProxy_basic2(id string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_target_https_proxy" "foobar" {
+			description = "Resource created for Terraform acceptance testing (updated)"
+			name = "httpsproxy-test-%s"
+			url_map = "${google_compute_url_map.foobar.self_link}"
+			ssl_certificates = ["${google_compute_ssl_certificate.foobar2.self_link}"]
+		}
+
+		resource "google_compute_backend_service" "foobar" {
+			name = "httpsproxy-test-backend-%s"
+			health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+		}
+
+		resource "google_compute_http_health_check" "zero" {
+			name = "httpsproxy-test-health-check-%s"
+			request_path = "/"
+			check_interval_sec = 1
+			timeout_sec = 1
+		}
+
+		resource "google_compute_url_map" "foobar" {
+			name = "httpsproxy-test-url-map-%s"
+			default_service = "${google_compute_backend_service.foobar.self_link}"
+			host_rule {
+				hosts = ["mysite.com", "myothersite.com"]
+				path_matcher = "boop"
+			}
+			path_matcher {
+				default_service = "${google_compute_backend_service.foobar.self_link}"
+				name = "boop"
+				path_rule {
+					paths = ["/*"]
+					service = "${google_compute_backend_service.foobar.self_link}"
+				}
+			}
+			test {
+				host = "mysite.com"
+				path = "/*"
+				service = "${google_compute_backend_service.foobar.self_link}"
+			}
+		}
+
+		resource "google_compute_ssl_certificate" "foobar1" {
+			name = "httpsproxy-test-cert1-%s"
+			description = "very descriptive"
+			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+		}
+
+		resource "google_compute_ssl_certificate" "foobar2" {
+			name = "httpsproxy-test-cert2-%s"
+			description = "very descriptive"
+			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+		}
+		`, id, id, id, id, id, id)
 }
-`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/google/resource_compute_target_https_proxy_test.go
+++ b/google/resource_compute_target_https_proxy_test.go
@@ -66,18 +66,15 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 }
 
 func TestAccComputeTargetHttpsProxy_invalidCertificate(t *testing.T) {
+	resourceSuffix := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeTargetHttpsProxyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: `
-				resource "google_compute_target_https_proxy" "foobar" {
-				name = "httpsproxy-test-%s"
-				url_map = "some-url-map"
-				ssl_certificates = ["invalid-certificate-reference"]
-				}`,
+				Config:      testAccComputeTargetHttpsProxy_invalidCertificate(resourceSuffix),
 				ExpectError: regexp.MustCompile("ssl_certificate"),
 			},
 		},
@@ -157,118 +154,131 @@ func testAccComputeTargetHttpsProxySslCertificate(cert string, proxy *compute.Ta
 
 func testAccComputeTargetHttpsProxy_basic1(id string) string {
 	return fmt.Sprintf(`
-		resource "google_compute_target_https_proxy" "foobar" {
-			description = "Resource created for Terraform acceptance testing"
-			name = "httpsproxy-test-%s"
-			url_map = "${google_compute_url_map.foobar.self_link}"
-			ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
-		}
+resource "google_compute_target_https_proxy" "foobar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "httpsproxy-test-%s"
+	url_map = "${google_compute_url_map.foobar.self_link}"
+	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
+}
 
-		resource "google_compute_backend_service" "foobar" {
-			name = "httpsproxy-test-backend-%s"
-			health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-		}
+resource "google_compute_backend_service" "foobar" {
+	name = "httpsproxy-test-backend-%s"
+	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+}
 
-		resource "google_compute_http_health_check" "zero" {
-			name = "httpsproxy-test-health-check-%s"
-			request_path = "/"
-			check_interval_sec = 1
-			timeout_sec = 1
-		}
+resource "google_compute_http_health_check" "zero" {
+	name = "httpsproxy-test-health-check-%s"
+	request_path = "/"
+	check_interval_sec = 1
+	timeout_sec = 1
+}
 
-		resource "google_compute_url_map" "foobar" {
-			name = "httpsproxy-test-url-map-%s"
-			default_service = "${google_compute_backend_service.foobar.self_link}"
-			host_rule {
-				hosts = ["mysite.com", "myothersite.com"]
-				path_matcher = "boop"
-			}
-			path_matcher {
-				default_service = "${google_compute_backend_service.foobar.self_link}"
-				name = "boop"
-				path_rule {
-					paths = ["/*"]
-					service = "${google_compute_backend_service.foobar.self_link}"
-				}
-			}
-			test {
-				host = "mysite.com"
-				path = "/*"
-				service = "${google_compute_backend_service.foobar.self_link}"
-			}
+resource "google_compute_url_map" "foobar" {
+	name = "httpsproxy-test-url-map-%s"
+	default_service = "${google_compute_backend_service.foobar.self_link}"
+	host_rule {
+		hosts = ["mysite.com", "myothersite.com"]
+		path_matcher = "boop"
+	}
+	path_matcher {
+		default_service = "${google_compute_backend_service.foobar.self_link}"
+		name = "boop"
+		path_rule {
+			paths = ["/*"]
+			service = "${google_compute_backend_service.foobar.self_link}"
 		}
+	}
+	test {
+		host = "mysite.com"
+		path = "/*"
+		service = "${google_compute_backend_service.foobar.self_link}"
+	}
+}
 
-		resource "google_compute_ssl_certificate" "foobar1" {
-			name = "httpsproxy-test-cert1-%s"
-			description = "very descriptive"
-			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-		}
+resource "google_compute_ssl_certificate" "foobar1" {
+	name = "httpsproxy-test-cert1-%s"
+	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
 
-		resource "google_compute_ssl_certificate" "foobar2" {
-			name = "httpsproxy-test-cert2-%s"
-			description = "very descriptive"
-			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-		}
-		`, id, id, id, id, id, id)
+resource "google_compute_ssl_certificate" "foobar2" {
+	name = "httpsproxy-test-cert2-%s"
+	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+`, id, id, id, id, id, id)
 }
 
 func testAccComputeTargetHttpsProxy_basic2(id string) string {
 	return fmt.Sprintf(`
-		resource "google_compute_target_https_proxy" "foobar" {
-			description = "Resource created for Terraform acceptance testing (updated)"
-			name = "httpsproxy-test-%s"
-			url_map = "${google_compute_url_map.foobar.self_link}"
-			ssl_certificates = ["${google_compute_ssl_certificate.foobar2.self_link}"]
-		}
+resource "google_compute_target_https_proxy" "foobar" {
+	description = "Resource created for Terraform acceptance testing (updated)"
+	name = "httpsproxy-test-%s"
+	url_map = "${google_compute_url_map.foobar.self_link}"
+	ssl_certificates = [
+		"${google_compute_ssl_certificate.foobar1.self_link}",
+		"${google_compute_ssl_certificate.foobar2.self_link}",
+	]
+}
 
-		resource "google_compute_backend_service" "foobar" {
-			name = "httpsproxy-test-backend-%s"
-			health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-		}
+resource "google_compute_backend_service" "foobar" {
+	name = "httpsproxy-test-backend-%s"
+	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+}
 
-		resource "google_compute_http_health_check" "zero" {
-			name = "httpsproxy-test-health-check-%s"
-			request_path = "/"
-			check_interval_sec = 1
-			timeout_sec = 1
-		}
+resource "google_compute_http_health_check" "zero" {
+	name = "httpsproxy-test-health-check-%s"
+	request_path = "/"
+	check_interval_sec = 1
+	timeout_sec = 1
+}
 
-		resource "google_compute_url_map" "foobar" {
-			name = "httpsproxy-test-url-map-%s"
-			default_service = "${google_compute_backend_service.foobar.self_link}"
-			host_rule {
-				hosts = ["mysite.com", "myothersite.com"]
-				path_matcher = "boop"
-			}
-			path_matcher {
-				default_service = "${google_compute_backend_service.foobar.self_link}"
-				name = "boop"
-				path_rule {
-					paths = ["/*"]
-					service = "${google_compute_backend_service.foobar.self_link}"
-				}
-			}
-			test {
-				host = "mysite.com"
-				path = "/*"
-				service = "${google_compute_backend_service.foobar.self_link}"
-			}
+resource "google_compute_url_map" "foobar" {
+	name = "httpsproxy-test-url-map-%s"
+	default_service = "${google_compute_backend_service.foobar.self_link}"
+	host_rule {
+		hosts = ["mysite.com", "myothersite.com"]
+		path_matcher = "boop"
+	}
+	path_matcher {
+		default_service = "${google_compute_backend_service.foobar.self_link}"
+		name = "boop"
+		path_rule {
+			paths = ["/*"]
+			service = "${google_compute_backend_service.foobar.self_link}"
 		}
+	}
+	test {
+		host = "mysite.com"
+		path = "/*"
+		service = "${google_compute_backend_service.foobar.self_link}"
+	}
+}
 
-		resource "google_compute_ssl_certificate" "foobar1" {
-			name = "httpsproxy-test-cert1-%s"
-			description = "very descriptive"
-			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-		}
+resource "google_compute_ssl_certificate" "foobar1" {
+	name = "httpsproxy-test-cert1-%s"
+	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
 
-		resource "google_compute_ssl_certificate" "foobar2" {
-			name = "httpsproxy-test-cert2-%s"
-			description = "very descriptive"
-			private_key = "${file("test-fixtures/ssl_cert/test.key")}"
-			certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
-		}
-		`, id, id, id, id, id, id)
+resource "google_compute_ssl_certificate" "foobar2" {
+	name = "httpsproxy-test-cert2-%s"
+	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+`, id, id, id, id, id, id)
+}
+
+func testAccComputeTargetHttpsProxy_invalidCertificate(id string) string {
+	return fmt.Sprintf(`
+resource "google_compute_target_https_proxy" "foobar" {
+name = "httpsproxy-test-%s"
+url_map = "some-url-map"
+ssl_certificates = ["invalid-certificate-reference"]
+}
+`, id)
 }

--- a/website/docs/r/compute_target_https_proxy.html.markdown
+++ b/website/docs/r/compute_target_https_proxy.html.markdown
@@ -78,8 +78,7 @@ The following arguments are supported:
     this forces a new resource to be created.
 
 * `ssl_certificates` - (Required) The URLs of the SSL Certificate resources that
-    authenticate connections between users and load balancing. Currently exactly
-    one must be specified.
+    authenticate connections between users and load balancing.
 
 * `url_map` - (Required) The URL of a URL Map resource that defines the mapping
     from the URL to the BackendService.


### PR DESCRIPTION
issue #47 

* Added support for both `full url` and `path-only` when referencing ssl certificate in * compute_target_https_proxy. This means both `https://www.googleapis.com/compute/v1/projects/MY-PROJECT/global/sslCertificates/MY_CERT` and `projects/MY-PROJECT/global/sslCertificates/MY_CERT` are valid.
* Simplified the read/update logic for ssl certificate since a proxy must have exactly one ssl certificate.
* Added more assertions to acceptance test
* Added schema validation of ssl certificate field

cc/ @danawillow @rileykarson 