### PR TITLE
Schema Generator script

### DIFF
--- a/scripts/schemagen.go
+++ b/scripts/schemagen.go
@@ -87,7 +87,7 @@ func main() {
 
 	fmtd, err := format.Source(buf.Bytes())
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Formatting error: %s", err)
 	}
 
 	if _, err := f.Write(fmtd); err != nil {

--- a/scripts/schemagen.go
+++ b/scripts/schemagen.go
@@ -1,0 +1,277 @@
+// Generates an initial version of a schema for a new resource type.
+//
+// This script draws heavily from https://github.com/radeksimko/terraform-gen,
+// but uses GCP's discovery API instead of the struct definition to generate
+// the schemas.
+//
+// This is not meant to be a definitive source of truth for resource schemas,
+// just a starting point. It has some notable deficiencies, such as:
+// 	* No way to differentiate between fields that are/are not updateable.
+// 	* Required/Optional/Computed are set based on keywords in the description.
+//
+// Usage example (from root dir):
+//
+//   go run ./scripts/schemagen.go -api pubsub -resource Subscription -version v1
+//
+// This will output a file in the directory from which the script is run named `gen_resource_[api]_[resource].go`.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/discovery/v1"
+)
+
+func main() {
+	api := flag.String("api", "", "api to query")
+	resource := flag.String("resource", "", "resource to generate")
+	version := flag.String("version", "v1", "api version to query")
+	flag.Parse()
+
+	if *api == "" || *resource == "" {
+		log.Fatal("usage: go run schemagen.go -api $API -resource $RESOURCE -version $VERSION")
+	}
+
+	// Discovery API doesn't need authentication
+	client, err := google.DefaultClient(oauth2.NoContext, []string{}...)
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error creating client: %v", err))
+	}
+
+	discoveryService, err := discovery.New(client)
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error creating service: %v", err))
+	}
+
+	resp, err := discoveryService.Apis.GetRest(*api, *version).Fields("schemas").Do()
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error reading API: %v", err))
+	}
+
+	fileName := fmt.Sprintf("gen_resource_%s_%s.go", *api, underscore(*resource))
+	f, err := os.Create(fileName)
+	defer f.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fields := generateFields(resp.Schemas, *resource)
+
+	err = googleTemplate.Execute(f, struct {
+		TypeName string
+		Fields   map[string]string
+	}{
+		// Capitalize the first letter of the api name, then concatenate the resource name onto it.
+		// e.g. compute, instance -> ComputeInstance
+		TypeName: strings.ToUpper((*api)[0:1]) + (*api)[1:] + *resource,
+		Fields:   fields,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = exec.Command("gofmt", "-w", fileName).Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func generateFields(schemas map[string]discovery.JsonSchema, property string) map[string]string {
+	fields := make(map[string]string, 0)
+
+	for k, v := range schemas[property].Properties {
+		content, err := generateField(schemas, k, v, false)
+		if err != nil {
+			log.Printf("ERROR: %s", err)
+		} else {
+			fields[underscore(k)] = content
+		}
+	}
+
+	return fields
+}
+
+func generateField(schemas map[string]discovery.JsonSchema, field string, v discovery.JsonSchema, isNested bool) (string, error) {
+	s := &schema.Schema{
+		Description: v.Description,
+	}
+	if field != "" {
+		setProperties(v, s)
+	}
+
+	// JSON field types: https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1
+	switch v.Type {
+	case "integer":
+		s.Type = schema.TypeInt
+	case "number":
+		s.Type = schema.TypeFloat
+	case "string":
+		s.Type = schema.TypeString
+	case "boolean":
+		s.Type = schema.TypeBool
+	case "array":
+		s.Type = schema.TypeList
+		elem, err := generateField(schemas, "", *v.Items, true)
+		if err != nil {
+			return "", fmt.Errorf("Unable to generate Elem for %q: %s", field, err)
+		}
+		s.Elem = elem
+	case "object":
+		s.Type = schema.TypeMap
+	case "":
+		s.Type = schema.TypeList
+		s.MaxItems = 1
+
+		elem := "&schema.Resource{\nSchema: map[string]*schema.Schema{\n"
+		m := generateFields(schemas, v.Ref)
+		fieldNames := []string{}
+		for k, _ := range m {
+			fieldNames = append(fieldNames, k)
+		}
+		sort.Strings(fieldNames)
+		for _, k := range fieldNames {
+			elem += fmt.Sprintf("%q: %s,\n", k, m[k])
+		}
+		elem += "},\n}"
+
+		if isNested {
+			return elem, nil
+		}
+		s.Elem = elem
+	default:
+		return "", fmt.Errorf("Unable to process: %s %s", field, v.Type)
+	}
+
+	return schemaCode(s, isNested)
+}
+
+func setProperties(v discovery.JsonSchema, s *schema.Schema) {
+	if v.ReadOnly || strings.HasPrefix(v.Description, "Output-only") {
+		s.Computed = true
+	} else {
+		if v.Required || strings.HasPrefix(v.Description, "Required") {
+			s.Required = true
+		} else {
+			s.Optional = true
+		}
+	}
+
+	s.ForceNew = true
+}
+
+func schemaCode(s *schema.Schema, isNested bool) (string, error) {
+	buf := bytes.NewBuffer([]byte{})
+	err := schemaTemplate.Execute(buf, struct {
+		Schema   *schema.Schema
+		IsNested bool
+	}{
+		Schema:   s,
+		IsNested: isNested,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// shamelessly borrowed from https://github.com/radeksimko/terraform-gen/blob/master/internal/util/util.go
+func underscore(name string) string {
+	var words []string
+	var camelCase = regexp.MustCompile("(^[^A-Z]*|[A-Z]*)([A-Z][^A-Z]+|$)")
+
+	for _, submatch := range camelCase.FindAllStringSubmatch(name, -1) {
+		if submatch[1] != "" {
+			words = append(words, submatch[1])
+		}
+		if submatch[2] != "" {
+			words = append(words, submatch[2])
+		}
+	}
+
+	return strings.ToLower(strings.Join(words, "_"))
+}
+
+var schemaTemplate = template.Must(template.New("schema").Parse(`{{if .IsNested}}&schema.Schema{{end}}{{"{"}}{{if not .IsNested}}
+{{end}}Type: schema.{{.Schema.Type}},{{if ne .Schema.Description ""}}
+Description: {{printf "%q" .Schema.Description}},{{end}}{{if .Schema.Required}}
+Required: {{.Schema.Required}},{{end}}{{if .Schema.Optional}}
+Optional: {{.Schema.Optional}},{{end}}{{if .Schema.ForceNew}}
+ForceNew: {{.Schema.ForceNew}},{{end}}{{if .Schema.Computed}}
+Computed: {{.Schema.Computed}},{{end}}{{if gt .Schema.MaxItems 0}}
+MaxItems: {{.Schema.MaxItems}},{{end}}{{if .Schema.Elem}}
+Elem: {{.Schema.Elem}},{{end}}{{if not .IsNested}}
+{{end}}{{"}"}}`))
+
+var googleTemplate = template.Must(template.New("google").Parse(`package google
+
+import(
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resource{{.TypeName}}() *schema.Resource {
+	return &schema.Resource{
+		Create: resource{{.TypeName}}Create,
+		Read:   resource{{.TypeName}}Read,
+		Update: resource{{.TypeName}}Update,
+		Delete: resource{{.TypeName}}Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{ {{range $name, $schema := .Fields}}
+			"{{ $name }}": {{ $schema }},
+{{end}}
+		},
+	}
+}
+
+func resource{{.TypeName}}Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+}
+
+func resource{{.TypeName}}Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+}
+
+func resource{{.TypeName}}Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+}
+
+func resource{{.TypeName}}Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+}
+`))

--- a/scripts/schemagen_test.go
+++ b/scripts/schemagen_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/api/discovery/v1"
+)
+
+func TestGenerateFields_primitive(t *testing.T) {
+	schema := map[string]discovery.JsonSchema{
+		"Resource": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"stringField": {
+					Type:        "string",
+					Description: "string field",
+				},
+				"numberField": {
+					Type:        "number",
+					Description: "number field",
+				},
+				"intField": {
+					Type:        "integer",
+					Description: "integer field",
+				},
+				"boolField": {
+					Type:        "boolean",
+					Description: "boolean field",
+				},
+				"mapField": {
+					Type:        "object",
+					Description: "object field",
+				},
+			},
+		},
+	}
+
+	generated := generateFields(schema, "Resource")
+
+	expected := map[string]string{
+		"string_field": "{\nType: schema.TypeString,\nDescription: \"string field\",\nOptional: true,\nForceNew: true,\n}",
+		"number_field": "{\nType: schema.TypeFloat,\nDescription: \"number field\",\nOptional: true,\nForceNew: true,\n}",
+		"int_field":    "{\nType: schema.TypeInt,\nDescription: \"integer field\",\nOptional: true,\nForceNew: true,\n}",
+		"bool_field":   "{\nType: schema.TypeBool,\nDescription: \"boolean field\",\nOptional: true,\nForceNew: true,\n}",
+		"map_field":    "{\nType: schema.TypeMap,\nDescription: \"object field\",\nOptional: true,\nForceNew: true,\n}",
+	}
+
+	if !reflect.DeepEqual(generated, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	}
+}
+
+func TestGenerateFields_listOfPrimitives(t *testing.T) {
+	schema := map[string]discovery.JsonSchema{
+		"Resource": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"stringsField": {
+					Type: "array",
+					Items: &discovery.JsonSchema{
+						Type: "string",
+					},
+				},
+				"numbersField": {
+					Type: "array",
+					Items: &discovery.JsonSchema{
+						Type: "number",
+					},
+				},
+				"intsField": {
+					Type: "array",
+					Items: &discovery.JsonSchema{
+						Type: "integer",
+					},
+				},
+				"boolsField": {
+					Type: "array",
+					Items: &discovery.JsonSchema{
+						Type: "boolean",
+					},
+				},
+			},
+		},
+	}
+
+	generated := generateFields(schema, "Resource")
+
+	expected := map[string]string{
+		"strings_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeString,},\n}",
+		"numbers_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeFloat,},\n}",
+		"ints_field":    "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeInt,},\n}",
+		"bools_field":   "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeBool,},\n}",
+	}
+
+	if !reflect.DeepEqual(generated, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	}
+}
+
+func TestGenerateFields_nested(t *testing.T) {
+	schema := map[string]discovery.JsonSchema{
+		"Resource": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"nestedField": {
+					Ref: "OtherThing",
+				},
+			},
+		},
+		"OtherThing": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"intField": {
+					Type: "integer",
+				},
+				"stringField": {
+					Type: "string",
+				},
+			},
+		},
+	}
+
+	generated := generateFields(schema, "Resource")
+
+	expected := map[string]string{
+		"nested_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nMaxItems: 1,\nElem: &schema.Resource{\nSchema: map[string]*schema.Schema{\n\"int_field\": {\nType: schema.TypeInt,\nOptional: true,\nForceNew: true,\n},\n\"string_field\": {\nType: schema.TypeString,\nOptional: true,\nForceNew: true,\n},\n},\n},\n}",
+	}
+
+	if !reflect.DeepEqual(generated, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	}
+}
+
+func TestGenerateFields_nestedList(t *testing.T) {
+	schema := map[string]discovery.JsonSchema{
+		"Resource": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"nestedField": {
+					Type: "array",
+					Items: &discovery.JsonSchema{
+						Ref: "OtherThing",
+					},
+				},
+			},
+		},
+		"OtherThing": {
+			Type: "object",
+			Properties: map[string]discovery.JsonSchema{
+				"intField": {
+					Type: "integer",
+				},
+				"stringField": {
+					Type: "string",
+				},
+			},
+		},
+	}
+
+	generated := generateFields(schema, "Resource")
+
+	expected := map[string]string{
+		"nested_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Resource{\nSchema: map[string]*schema.Schema{\n\"int_field\": {\nType: schema.TypeInt,\nOptional: true,\nForceNew: true,\n},\n\"string_field\": {\nType: schema.TypeString,\nOptional: true,\nForceNew: true,\n},\n},\n},\n}",
+	}
+
+	if !reflect.DeepEqual(generated, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	}
+}

--- a/scripts/schemagen_test.go
+++ b/scripts/schemagen_test.go
@@ -168,3 +168,22 @@ func TestGenerateFields_nestedList(t *testing.T) {
 		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
 	}
 }
+
+func TestUnderscore(t *testing.T) {
+	testCases := map[string]string{
+		"camelCase":           "camel_case",
+		"CamelCase":           "camel_case",
+		"HTTPResponseCode":    "http_response_code",
+		"HTTPResponseCodeXYZ": "http_response_code_xyz",
+		"getHTTPResponseCode": "get_http_response_code",
+		"ISCSI":               "iscsi",
+		"externalIPs":         "external_ips",
+	}
+
+	for from, to := range testCases {
+		converted := underscore(from)
+		if converted != to {
+			t.Fatalf("Expected %q after conversion, given: %q", to, converted)
+		}
+	}
+}

--- a/scripts/schemagen_test.go
+++ b/scripts/schemagen_test.go
@@ -18,7 +18,7 @@ func TestGenerateFields_primitive(t *testing.T) {
 				},
 				"numberField": {
 					Type:        "number",
-					Description: "number field",
+					Description: "Required. number field",
 				},
 				"intField": {
 					Type:        "integer",
@@ -26,7 +26,7 @@ func TestGenerateFields_primitive(t *testing.T) {
 				},
 				"boolField": {
 					Type:        "boolean",
-					Description: "boolean field",
+					Description: "Output-only. boolean field",
 				},
 				"mapField": {
 					Type:        "object",
@@ -36,18 +36,30 @@ func TestGenerateFields_primitive(t *testing.T) {
 		},
 	}
 
-	generated := generateFields(schema, "Resource")
+	reqFields, optFields, comFields := generateFields(schema, "Resource")
 
-	expected := map[string]string{
+	expectedReq := map[string]string{
+		"number_field": "{\nType: schema.TypeFloat,\nDescription: \"Required. number field\",\nRequired: true,\nForceNew: true,\n}",
+	}
+
+	expectedOpt := map[string]string{
 		"string_field": "{\nType: schema.TypeString,\nDescription: \"string field\",\nOptional: true,\nForceNew: true,\n}",
-		"number_field": "{\nType: schema.TypeFloat,\nDescription: \"number field\",\nOptional: true,\nForceNew: true,\n}",
 		"int_field":    "{\nType: schema.TypeInt,\nDescription: \"integer field\",\nOptional: true,\nForceNew: true,\n}",
-		"bool_field":   "{\nType: schema.TypeBool,\nDescription: \"boolean field\",\nOptional: true,\nForceNew: true,\n}",
 		"map_field":    "{\nType: schema.TypeMap,\nDescription: \"object field\",\nOptional: true,\nForceNew: true,\n}",
 	}
 
-	if !reflect.DeepEqual(generated, expected) {
-		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	expectedCom := map[string]string{
+		"bool_field": "{\nType: schema.TypeBool,\nDescription: \"Output-only. boolean field\",\nForceNew: true,\nComputed: true,\n}",
+	}
+
+	if !reflect.DeepEqual(reqFields, expectedReq) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expectedReq, reqFields)
+	}
+	if !reflect.DeepEqual(optFields, expectedOpt) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expectedOpt, optFields)
+	}
+	if !reflect.DeepEqual(comFields, expectedCom) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expectedCom, comFields)
 	}
 }
 
@@ -84,7 +96,7 @@ func TestGenerateFields_listOfPrimitives(t *testing.T) {
 		},
 	}
 
-	generated := generateFields(schema, "Resource")
+	_, optFields, _ := generateFields(schema, "Resource")
 
 	expected := map[string]string{
 		"strings_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeString,},\n}",
@@ -93,8 +105,8 @@ func TestGenerateFields_listOfPrimitives(t *testing.T) {
 		"bools_field":   "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Schema{Type: schema.TypeBool,},\n}",
 	}
 
-	if !reflect.DeepEqual(generated, expected) {
-		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	if !reflect.DeepEqual(optFields, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, optFields)
 	}
 }
 
@@ -121,14 +133,14 @@ func TestGenerateFields_nested(t *testing.T) {
 		},
 	}
 
-	generated := generateFields(schema, "Resource")
+	_, optFields, _ := generateFields(schema, "Resource")
 
 	expected := map[string]string{
 		"nested_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nMaxItems: 1,\nElem: &schema.Resource{\nSchema: map[string]*schema.Schema{\n\"int_field\": {\nType: schema.TypeInt,\nOptional: true,\nForceNew: true,\n},\n\"string_field\": {\nType: schema.TypeString,\nOptional: true,\nForceNew: true,\n},\n},\n},\n}",
 	}
 
-	if !reflect.DeepEqual(generated, expected) {
-		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	if !reflect.DeepEqual(optFields, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, optFields)
 	}
 }
 
@@ -158,14 +170,14 @@ func TestGenerateFields_nestedList(t *testing.T) {
 		},
 	}
 
-	generated := generateFields(schema, "Resource")
+	_, optFields, _ := generateFields(schema, "Resource")
 
 	expected := map[string]string{
 		"nested_field": "{\nType: schema.TypeList,\nOptional: true,\nForceNew: true,\nElem: &schema.Resource{\nSchema: map[string]*schema.Schema{\n\"int_field\": {\nType: schema.TypeInt,\nOptional: true,\nForceNew: true,\n},\n\"string_field\": {\nType: schema.TypeString,\nOptional: true,\nForceNew: true,\n},\n},\n},\n}",
 	}
 
-	if !reflect.DeepEqual(generated, expected) {
-		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, generated)
+	if !reflect.DeepEqual(optFields, expected) {
+		t.Fatalf("Expected: %+v\n\nGiven: %+v\n", expected, optFields)
 	}
 }
 

--- a/vendor/google.golang.org/api/discovery/v1/discovery-api.json
+++ b/vendor/google.golang.org/api/discovery/v1/discovery-api.json
@@ -1,0 +1,685 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "\"YWOzh2SDasdU84ArJnpYek-OMdg/Pyg0A4J33Dq212hoe9BYpSm0dl4\"",
+ "discoveryVersion": "v1",
+ "id": "discovery:v1",
+ "name": "discovery",
+ "version": "v1",
+ "title": "APIs Discovery Service",
+ "description": "Provides information about other Google APIs, such as what APIs are available, the resource, and method details for each API.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "http://www.google.com/images/icons/feature/filing_cabinet_search-g16.png",
+  "x32": "http://www.google.com/images/icons/feature/filing_cabinet_search-g32.png"
+ },
+ "documentationLink": "https://developers.google.com/discovery/",
+ "protocol": "rest",
+ "baseUrl": "https://www.googleapis.com/discovery/v1/",
+ "basePath": "/discovery/v1/",
+ "rootUrl": "https://www.googleapis.com/",
+ "servicePath": "discovery/v1/",
+ "batchPath": "batch",
+ "parameters": {
+  "alt": {
+   "type": "string",
+   "description": "Data format for the response.",
+   "default": "json",
+   "enum": [
+    "json"
+   ],
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json"
+   ],
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+   "location": "query"
+  },
+  "userIp": {
+   "type": "string",
+   "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+   "location": "query"
+  }
+ },
+ "schemas": {
+  "DirectoryList": {
+   "id": "DirectoryList",
+   "type": "object",
+   "properties": {
+    "discoveryVersion": {
+     "type": "string",
+     "description": "Indicate the version of the Discovery API used to generate this doc.",
+     "default": "v1"
+    },
+    "items": {
+     "type": "array",
+     "description": "The individual directory entries. One entry per api/version pair.",
+     "items": {
+      "type": "object",
+      "properties": {
+       "description": {
+        "type": "string",
+        "description": "The description of this API."
+       },
+       "discoveryLink": {
+        "type": "string",
+        "description": "A link to the discovery document."
+       },
+       "discoveryRestUrl": {
+        "type": "string",
+        "description": "The URL for the discovery REST document."
+       },
+       "documentationLink": {
+        "type": "string",
+        "description": "A link to human readable documentation for the API."
+       },
+       "icons": {
+        "type": "object",
+        "description": "Links to 16x16 and 32x32 icons representing the API.",
+        "properties": {
+         "x16": {
+          "type": "string",
+          "description": "The URL of the 16x16 icon."
+         },
+         "x32": {
+          "type": "string",
+          "description": "The URL of the 32x32 icon."
+         }
+        }
+       },
+       "id": {
+        "type": "string",
+        "description": "The id of this API."
+       },
+       "kind": {
+        "type": "string",
+        "description": "The kind for this response.",
+        "default": "discovery#directoryItem"
+       },
+       "labels": {
+        "type": "array",
+        "description": "Labels for the status of this API, such as labs or deprecated.",
+        "items": {
+         "type": "string"
+        }
+       },
+       "name": {
+        "type": "string",
+        "description": "The name of the API."
+       },
+       "preferred": {
+        "type": "boolean",
+        "description": "True if this version is the preferred version to use."
+       },
+       "title": {
+        "type": "string",
+        "description": "The title of this API."
+       },
+       "version": {
+        "type": "string",
+        "description": "The version of the API."
+       }
+      }
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind for this response.",
+     "default": "discovery#directoryList"
+    }
+   }
+  },
+  "JsonSchema": {
+   "id": "JsonSchema",
+   "type": "object",
+   "properties": {
+    "$ref": {
+     "type": "string",
+     "description": "A reference to another schema. The value of this property is the \"id\" of another schema."
+    },
+    "additionalProperties": {
+     "$ref": "JsonSchema",
+     "description": "If this is a schema for an object, this property is the schema for any additional properties with dynamic keys on this object."
+    },
+    "annotations": {
+     "type": "object",
+     "description": "Additional information about this property.",
+     "properties": {
+      "required": {
+       "type": "array",
+       "description": "A list of methods for which this property is required on requests.",
+       "items": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "default": {
+     "type": "string",
+     "description": "The default value of this property (if one exists)."
+    },
+    "description": {
+     "type": "string",
+     "description": "A description of this object."
+    },
+    "enum": {
+     "type": "array",
+     "description": "Values this parameter may take (if it is an enum).",
+     "items": {
+      "type": "string"
+     }
+    },
+    "enumDescriptions": {
+     "type": "array",
+     "description": "The descriptions for the enums. Each position maps to the corresponding value in the \"enum\" array.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "format": {
+     "type": "string",
+     "description": "An additional regular expression or key that helps constrain the value. For more details see: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23"
+    },
+    "id": {
+     "type": "string",
+     "description": "Unique identifier for this schema."
+    },
+    "items": {
+     "$ref": "JsonSchema",
+     "description": "If this is a schema for an array, this property is the schema for each element in the array."
+    },
+    "location": {
+     "type": "string",
+     "description": "Whether this parameter goes in the query or the path for REST requests."
+    },
+    "maximum": {
+     "type": "string",
+     "description": "The maximum value of this parameter."
+    },
+    "minimum": {
+     "type": "string",
+     "description": "The minimum value of this parameter."
+    },
+    "pattern": {
+     "type": "string",
+     "description": "The regular expression this parameter must conform to. Uses Java 6 regex format: http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html"
+    },
+    "properties": {
+     "type": "object",
+     "description": "If this is a schema for an object, list the schema for each property of this object.",
+     "additionalProperties": {
+      "$ref": "JsonSchema",
+      "description": "A single property of this object. The value is itself a JSON Schema object describing this property."
+     }
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "The value is read-only, generated by the service. The value cannot be modified by the client. If the value is included in a POST, PUT, or PATCH request, it is ignored by the service."
+    },
+    "repeated": {
+     "type": "boolean",
+     "description": "Whether this parameter may appear multiple times."
+    },
+    "required": {
+     "type": "boolean",
+     "description": "Whether the parameter is required."
+    },
+    "type": {
+     "type": "string",
+     "description": "The value type for this schema. A list of values can be found here: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1"
+    },
+    "variant": {
+     "type": "object",
+     "description": "In a variant data type, the value of one property is used to determine how to interpret the entire entity. Its value must exist in a map of descriminant values to schema names.",
+     "properties": {
+      "discriminant": {
+       "type": "string",
+       "description": "The name of the type discriminant property."
+      },
+      "map": {
+       "type": "array",
+       "description": "The map of discriminant value to schema to use for parsing..",
+       "items": {
+        "type": "object",
+        "properties": {
+         "$ref": {
+          "type": "string"
+         },
+         "type_value": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "RestDescription": {
+   "id": "RestDescription",
+   "type": "object",
+   "properties": {
+    "auth": {
+     "type": "object",
+     "description": "Authentication information.",
+     "properties": {
+      "oauth2": {
+       "type": "object",
+       "description": "OAuth 2.0 authentication information.",
+       "properties": {
+        "scopes": {
+         "type": "object",
+         "description": "Available OAuth 2.0 scopes.",
+         "additionalProperties": {
+          "type": "object",
+          "description": "The scope value.",
+          "properties": {
+           "description": {
+            "type": "string",
+            "description": "Description of scope."
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    },
+    "basePath": {
+     "type": "string",
+     "description": "[DEPRECATED] The base path for REST requests."
+    },
+    "baseUrl": {
+     "type": "string",
+     "description": "[DEPRECATED] The base URL for REST requests."
+    },
+    "batchPath": {
+     "type": "string",
+     "description": "The path for REST batch requests.",
+     "default": "batch"
+    },
+    "canonicalName": {
+     "type": "string",
+     "description": "Indicates how the API name should be capitalized and split into various parts. Useful for generating pretty class names."
+    },
+    "description": {
+     "type": "string",
+     "description": "The description of this API."
+    },
+    "discoveryVersion": {
+     "type": "string",
+     "description": "Indicate the version of the Discovery API used to generate this doc.",
+     "default": "v1"
+    },
+    "documentationLink": {
+     "type": "string",
+     "description": "A link to human readable documentation for the API."
+    },
+    "etag": {
+     "type": "string",
+     "description": "The ETag for this response.",
+     "readOnly": true
+    },
+    "exponentialBackoffDefault": {
+     "type": "boolean",
+     "description": "Enable exponential backoff for suitable methods in the generated clients."
+    },
+    "features": {
+     "type": "array",
+     "description": "A list of supported features for this API.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "icons": {
+     "type": "object",
+     "description": "Links to 16x16 and 32x32 icons representing the API.",
+     "properties": {
+      "x16": {
+       "type": "string",
+       "description": "The URL of the 16x16 icon."
+      },
+      "x32": {
+       "type": "string",
+       "description": "The URL of the 32x32 icon."
+      }
+     }
+    },
+    "id": {
+     "type": "string",
+     "description": "The ID of this API."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind for this response.",
+     "default": "discovery#restDescription"
+    },
+    "labels": {
+     "type": "array",
+     "description": "Labels for the status of this API, such as labs or deprecated.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "methods": {
+     "type": "object",
+     "description": "API-level methods for this API.",
+     "additionalProperties": {
+      "$ref": "RestMethod",
+      "description": "An individual method description."
+     }
+    },
+    "name": {
+     "type": "string",
+     "description": "The name of this API."
+    },
+    "ownerDomain": {
+     "type": "string",
+     "description": "The domain of the owner of this API. Together with the ownerName and a packagePath values, this can be used to generate a library for this API which would have a unique fully qualified name."
+    },
+    "ownerName": {
+     "type": "string",
+     "description": "The name of the owner of this API. See ownerDomain."
+    },
+    "packagePath": {
+     "type": "string",
+     "description": "The package of the owner of this API. See ownerDomain."
+    },
+    "parameters": {
+     "type": "object",
+     "description": "Common parameters that apply across all apis.",
+     "additionalProperties": {
+      "$ref": "JsonSchema",
+      "description": "Description of a single parameter."
+     }
+    },
+    "protocol": {
+     "type": "string",
+     "description": "The protocol described by this document.",
+     "default": "rest"
+    },
+    "resources": {
+     "type": "object",
+     "description": "The resources in this API.",
+     "additionalProperties": {
+      "$ref": "RestResource",
+      "description": "An individual resource description. Contains methods and sub-resources related to this resource."
+     }
+    },
+    "revision": {
+     "type": "string",
+     "description": "The version of this API."
+    },
+    "rootUrl": {
+     "type": "string",
+     "description": "The root URL under which all API services live."
+    },
+    "schemas": {
+     "type": "object",
+     "description": "The schemas for this API.",
+     "additionalProperties": {
+      "$ref": "JsonSchema",
+      "description": "An individual schema description."
+     }
+    },
+    "servicePath": {
+     "type": "string",
+     "description": "The base path for all REST requests."
+    },
+    "title": {
+     "type": "string",
+     "description": "The title of this API."
+    },
+    "version": {
+     "type": "string",
+     "description": "The version of this API."
+    },
+    "version_module": {
+     "type": "boolean"
+    }
+   }
+  },
+  "RestMethod": {
+   "id": "RestMethod",
+   "type": "object",
+   "properties": {
+    "description": {
+     "type": "string",
+     "description": "Description of this method."
+    },
+    "etagRequired": {
+     "type": "boolean",
+     "description": "Whether this method requires an ETag to be specified. The ETag is sent as an HTTP If-Match or If-None-Match header."
+    },
+    "httpMethod": {
+     "type": "string",
+     "description": "HTTP method used by this method."
+    },
+    "id": {
+     "type": "string",
+     "description": "A unique ID for this method. This property can be used to match methods between different versions of Discovery."
+    },
+    "mediaUpload": {
+     "type": "object",
+     "description": "Media upload parameters.",
+     "properties": {
+      "accept": {
+       "type": "array",
+       "description": "MIME Media Ranges for acceptable media uploads to this method.",
+       "items": {
+        "type": "string"
+       }
+      },
+      "maxSize": {
+       "type": "string",
+       "description": "Maximum size of a media upload, such as \"1MB\", \"2GB\" or \"3TB\"."
+      },
+      "protocols": {
+       "type": "object",
+       "description": "Supported upload protocols.",
+       "properties": {
+        "resumable": {
+         "type": "object",
+         "description": "Supports the Resumable Media Upload protocol.",
+         "properties": {
+          "multipart": {
+           "type": "boolean",
+           "description": "True if this endpoint supports uploading multipart media.",
+           "default": "true"
+          },
+          "path": {
+           "type": "string",
+           "description": "The URI path to be used for upload. Should be used in conjunction with the basePath property at the api-level."
+          }
+         }
+        },
+        "simple": {
+         "type": "object",
+         "description": "Supports uploading as a single HTTP request.",
+         "properties": {
+          "multipart": {
+           "type": "boolean",
+           "description": "True if this endpoint supports upload multipart media.",
+           "default": "true"
+          },
+          "path": {
+           "type": "string",
+           "description": "The URI path to be used for upload. Should be used in conjunction with the basePath property at the api-level."
+          }
+         }
+        }
+       }
+      }
+     }
+    },
+    "parameterOrder": {
+     "type": "array",
+     "description": "Ordered list of required parameters, serves as a hint to clients on how to structure their method signatures. The array is ordered such that the \"most-significant\" parameter appears first.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "parameters": {
+     "type": "object",
+     "description": "Details for all parameters in this method.",
+     "additionalProperties": {
+      "$ref": "JsonSchema",
+      "description": "Details for a single parameter in this method."
+     }
+    },
+    "path": {
+     "type": "string",
+     "description": "The URI path of this REST method. Should be used in conjunction with the basePath property at the api-level."
+    },
+    "request": {
+     "type": "object",
+     "description": "The schema for the request.",
+     "properties": {
+      "$ref": {
+       "type": "string",
+       "description": "Schema ID for the request schema."
+      },
+      "parameterName": {
+       "type": "string",
+       "description": "parameter name."
+      }
+     }
+    },
+    "response": {
+     "type": "object",
+     "description": "The schema for the response.",
+     "properties": {
+      "$ref": {
+       "type": "string",
+       "description": "Schema ID for the response schema."
+      }
+     }
+    },
+    "scopes": {
+     "type": "array",
+     "description": "OAuth 2.0 scopes applicable to this method.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "supportsMediaDownload": {
+     "type": "boolean",
+     "description": "Whether this method supports media downloads."
+    },
+    "supportsMediaUpload": {
+     "type": "boolean",
+     "description": "Whether this method supports media uploads."
+    },
+    "supportsSubscription": {
+     "type": "boolean",
+     "description": "Whether this method supports subscriptions."
+    },
+    "useMediaDownloadService": {
+     "type": "boolean",
+     "description": "Indicates that downloads from this method should use the download service URL (i.e. \"/download\"). Only applies if the method supports media download."
+    }
+   }
+  },
+  "RestResource": {
+   "id": "RestResource",
+   "type": "object",
+   "properties": {
+    "methods": {
+     "type": "object",
+     "description": "Methods on this resource.",
+     "additionalProperties": {
+      "$ref": "RestMethod",
+      "description": "Description for any methods on this resource."
+     }
+    },
+    "resources": {
+     "type": "object",
+     "description": "Sub-resources on this resource.",
+     "additionalProperties": {
+      "$ref": "RestResource",
+      "description": "Description for any sub-resources on this resource."
+     }
+    }
+   }
+  }
+ },
+ "resources": {
+  "apis": {
+   "methods": {
+    "getRest": {
+     "id": "discovery.apis.getRest",
+     "path": "apis/{api}/{version}/rest",
+     "httpMethod": "GET",
+     "description": "Retrieve the description of a particular version of an api.",
+     "parameters": {
+      "api": {
+       "type": "string",
+       "description": "The name of the API.",
+       "required": true,
+       "location": "path"
+      },
+      "version": {
+       "type": "string",
+       "description": "The version of the API.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "api",
+      "version"
+     ],
+     "response": {
+      "$ref": "RestDescription"
+     }
+    },
+    "list": {
+     "id": "discovery.apis.list",
+     "path": "apis",
+     "httpMethod": "GET",
+     "description": "Retrieve the list of APIs supported at this endpoint.",
+     "parameters": {
+      "name": {
+       "type": "string",
+       "description": "Only include APIs with the given name.",
+       "location": "query"
+      },
+      "preferred": {
+       "type": "boolean",
+       "description": "Return only the preferred version of an API.",
+       "default": "false",
+       "location": "query"
+      }
+     },
+     "response": {
+      "$ref": "DirectoryList"
+     }
+    }
+   }
+  }
+ }
+}

--- a/vendor/google.golang.org/api/discovery/v1/discovery-gen.go
+++ b/vendor/google.golang.org/api/discovery/v1/discovery-gen.go
@@ -1,0 +1,1234 @@
+// Package discovery provides access to the APIs Discovery Service.
+//
+// See https://developers.google.com/discovery/
+//
+// Usage example:
+//
+//   import "google.golang.org/api/discovery/v1"
+//   ...
+//   discoveryService, err := discovery.New(oauthHttpClient)
+package discovery // import "google.golang.org/api/discovery/v1"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "discovery:v1"
+const apiName = "discovery"
+const apiVersion = "v1"
+const basePath = "https://www.googleapis.com/discovery/v1/"
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.Apis = NewApisService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Apis *ApisService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewApisService(s *Service) *ApisService {
+	rs := &ApisService{s: s}
+	return rs
+}
+
+type ApisService struct {
+	s *Service
+}
+
+type DirectoryList struct {
+	// DiscoveryVersion: Indicate the version of the Discovery API used to
+	// generate this doc.
+	DiscoveryVersion string `json:"discoveryVersion,omitempty"`
+
+	// Items: The individual directory entries. One entry per api/version
+	// pair.
+	Items []*DirectoryListItems `json:"items,omitempty"`
+
+	// Kind: The kind for this response.
+	Kind string `json:"kind,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "DiscoveryVersion") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DiscoveryVersion") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DirectoryList) MarshalJSON() ([]byte, error) {
+	type noMethod DirectoryList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type DirectoryListItems struct {
+	// Description: The description of this API.
+	Description string `json:"description,omitempty"`
+
+	// DiscoveryLink: A link to the discovery document.
+	DiscoveryLink string `json:"discoveryLink,omitempty"`
+
+	// DiscoveryRestUrl: The URL for the discovery REST document.
+	DiscoveryRestUrl string `json:"discoveryRestUrl,omitempty"`
+
+	// DocumentationLink: A link to human readable documentation for the
+	// API.
+	DocumentationLink string `json:"documentationLink,omitempty"`
+
+	// Icons: Links to 16x16 and 32x32 icons representing the API.
+	Icons *DirectoryListItemsIcons `json:"icons,omitempty"`
+
+	// Id: The id of this API.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind for this response.
+	Kind string `json:"kind,omitempty"`
+
+	// Labels: Labels for the status of this API, such as labs or
+	// deprecated.
+	Labels []string `json:"labels,omitempty"`
+
+	// Name: The name of the API.
+	Name string `json:"name,omitempty"`
+
+	// Preferred: True if this version is the preferred version to use.
+	Preferred bool `json:"preferred,omitempty"`
+
+	// Title: The title of this API.
+	Title string `json:"title,omitempty"`
+
+	// Version: The version of the API.
+	Version string `json:"version,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DirectoryListItems) MarshalJSON() ([]byte, error) {
+	type noMethod DirectoryListItems
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DirectoryListItemsIcons: Links to 16x16 and 32x32 icons representing
+// the API.
+type DirectoryListItemsIcons struct {
+	// X16: The URL of the 16x16 icon.
+	X16 string `json:"x16,omitempty"`
+
+	// X32: The URL of the 32x32 icon.
+	X32 string `json:"x32,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "X16") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "X16") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DirectoryListItemsIcons) MarshalJSON() ([]byte, error) {
+	type noMethod DirectoryListItemsIcons
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type JsonSchema struct {
+	// Ref: A reference to another schema. The value of this property is the
+	// "id" of another schema.
+	Ref string `json:"$ref,omitempty"`
+
+	// AdditionalProperties: If this is a schema for an object, this
+	// property is the schema for any additional properties with dynamic
+	// keys on this object.
+	AdditionalProperties *JsonSchema `json:"additionalProperties,omitempty"`
+
+	// Annotations: Additional information about this property.
+	Annotations *JsonSchemaAnnotations `json:"annotations,omitempty"`
+
+	// Default: The default value of this property (if one exists).
+	Default string `json:"default,omitempty"`
+
+	// Description: A description of this object.
+	Description string `json:"description,omitempty"`
+
+	// Enum: Values this parameter may take (if it is an enum).
+	Enum []string `json:"enum,omitempty"`
+
+	// EnumDescriptions: The descriptions for the enums. Each position maps
+	// to the corresponding value in the "enum" array.
+	EnumDescriptions []string `json:"enumDescriptions,omitempty"`
+
+	// Format: An additional regular expression or key that helps constrain
+	// the value. For more details see:
+	// http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23
+	Format string `json:"format,omitempty"`
+
+	// Id: Unique identifier for this schema.
+	Id string `json:"id,omitempty"`
+
+	// Items: If this is a schema for an array, this property is the schema
+	// for each element in the array.
+	Items *JsonSchema `json:"items,omitempty"`
+
+	// Location: Whether this parameter goes in the query or the path for
+	// REST requests.
+	Location string `json:"location,omitempty"`
+
+	// Maximum: The maximum value of this parameter.
+	Maximum string `json:"maximum,omitempty"`
+
+	// Minimum: The minimum value of this parameter.
+	Minimum string `json:"minimum,omitempty"`
+
+	// Pattern: The regular expression this parameter must conform to. Uses
+	// Java 6 regex format:
+	// http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html
+	Pattern string `json:"pattern,omitempty"`
+
+	// Properties: If this is a schema for an object, list the schema for
+	// each property of this object.
+	Properties map[string]JsonSchema `json:"properties,omitempty"`
+
+	// ReadOnly: The value is read-only, generated by the service. The value
+	// cannot be modified by the client. If the value is included in a POST,
+	// PUT, or PATCH request, it is ignored by the service.
+	ReadOnly bool `json:"readOnly,omitempty"`
+
+	// Repeated: Whether this parameter may appear multiple times.
+	Repeated bool `json:"repeated,omitempty"`
+
+	// Required: Whether the parameter is required.
+	Required bool `json:"required,omitempty"`
+
+	// Type: The value type for this schema. A list of values can be found
+	// here: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1
+	Type string `json:"type,omitempty"`
+
+	// Variant: In a variant data type, the value of one property is used to
+	// determine how to interpret the entire entity. Its value must exist in
+	// a map of descriminant values to schema names.
+	Variant *JsonSchemaVariant `json:"variant,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Ref") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Ref") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JsonSchema) MarshalJSON() ([]byte, error) {
+	type noMethod JsonSchema
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JsonSchemaAnnotations: Additional information about this property.
+type JsonSchemaAnnotations struct {
+	// Required: A list of methods for which this property is required on
+	// requests.
+	Required []string `json:"required,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Required") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Required") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JsonSchemaAnnotations) MarshalJSON() ([]byte, error) {
+	type noMethod JsonSchemaAnnotations
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JsonSchemaVariant: In a variant data type, the value of one property
+// is used to determine how to interpret the entire entity. Its value
+// must exist in a map of descriminant values to schema names.
+type JsonSchemaVariant struct {
+	// Discriminant: The name of the type discriminant property.
+	Discriminant string `json:"discriminant,omitempty"`
+
+	// Map: The map of discriminant value to schema to use for parsing..
+	Map []*JsonSchemaVariantMap `json:"map,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Discriminant") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Discriminant") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JsonSchemaVariant) MarshalJSON() ([]byte, error) {
+	type noMethod JsonSchemaVariant
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type JsonSchemaVariantMap struct {
+	Ref string `json:"$ref,omitempty"`
+
+	TypeValue string `json:"type_value,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Ref") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Ref") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JsonSchemaVariantMap) MarshalJSON() ([]byte, error) {
+	type noMethod JsonSchemaVariantMap
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type RestDescription struct {
+	// Auth: Authentication information.
+	Auth *RestDescriptionAuth `json:"auth,omitempty"`
+
+	// BasePath: [DEPRECATED] The base path for REST requests.
+	BasePath string `json:"basePath,omitempty"`
+
+	// BaseUrl: [DEPRECATED] The base URL for REST requests.
+	BaseUrl string `json:"baseUrl,omitempty"`
+
+	// BatchPath: The path for REST batch requests.
+	BatchPath string `json:"batchPath,omitempty"`
+
+	// CanonicalName: Indicates how the API name should be capitalized and
+	// split into various parts. Useful for generating pretty class names.
+	CanonicalName string `json:"canonicalName,omitempty"`
+
+	// Description: The description of this API.
+	Description string `json:"description,omitempty"`
+
+	// DiscoveryVersion: Indicate the version of the Discovery API used to
+	// generate this doc.
+	DiscoveryVersion string `json:"discoveryVersion,omitempty"`
+
+	// DocumentationLink: A link to human readable documentation for the
+	// API.
+	DocumentationLink string `json:"documentationLink,omitempty"`
+
+	// Etag: The ETag for this response.
+	Etag string `json:"etag,omitempty"`
+
+	// ExponentialBackoffDefault: Enable exponential backoff for suitable
+	// methods in the generated clients.
+	ExponentialBackoffDefault bool `json:"exponentialBackoffDefault,omitempty"`
+
+	// Features: A list of supported features for this API.
+	Features []string `json:"features,omitempty"`
+
+	// Icons: Links to 16x16 and 32x32 icons representing the API.
+	Icons *RestDescriptionIcons `json:"icons,omitempty"`
+
+	// Id: The ID of this API.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind for this response.
+	Kind string `json:"kind,omitempty"`
+
+	// Labels: Labels for the status of this API, such as labs or
+	// deprecated.
+	Labels []string `json:"labels,omitempty"`
+
+	// Methods: API-level methods for this API.
+	Methods map[string]RestMethod `json:"methods,omitempty"`
+
+	// Name: The name of this API.
+	Name string `json:"name,omitempty"`
+
+	// OwnerDomain: The domain of the owner of this API. Together with the
+	// ownerName and a packagePath values, this can be used to generate a
+	// library for this API which would have a unique fully qualified name.
+	OwnerDomain string `json:"ownerDomain,omitempty"`
+
+	// OwnerName: The name of the owner of this API. See ownerDomain.
+	OwnerName string `json:"ownerName,omitempty"`
+
+	// PackagePath: The package of the owner of this API. See ownerDomain.
+	PackagePath string `json:"packagePath,omitempty"`
+
+	// Parameters: Common parameters that apply across all apis.
+	Parameters map[string]JsonSchema `json:"parameters,omitempty"`
+
+	// Protocol: The protocol described by this document.
+	Protocol string `json:"protocol,omitempty"`
+
+	// Resources: The resources in this API.
+	Resources map[string]RestResource `json:"resources,omitempty"`
+
+	// Revision: The version of this API.
+	Revision string `json:"revision,omitempty"`
+
+	// RootUrl: The root URL under which all API services live.
+	RootUrl string `json:"rootUrl,omitempty"`
+
+	// Schemas: The schemas for this API.
+	Schemas map[string]JsonSchema `json:"schemas,omitempty"`
+
+	// ServicePath: The base path for all REST requests.
+	ServicePath string `json:"servicePath,omitempty"`
+
+	// Title: The title of this API.
+	Title string `json:"title,omitempty"`
+
+	// Version: The version of this API.
+	Version string `json:"version,omitempty"`
+
+	VersionModule bool `json:"version_module,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Auth") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Auth") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestDescription) MarshalJSON() ([]byte, error) {
+	type noMethod RestDescription
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestDescriptionAuth: Authentication information.
+type RestDescriptionAuth struct {
+	// Oauth2: OAuth 2.0 authentication information.
+	Oauth2 *RestDescriptionAuthOauth2 `json:"oauth2,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Oauth2") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Oauth2") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestDescriptionAuth) MarshalJSON() ([]byte, error) {
+	type noMethod RestDescriptionAuth
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestDescriptionAuthOauth2: OAuth 2.0 authentication information.
+type RestDescriptionAuthOauth2 struct {
+	// Scopes: Available OAuth 2.0 scopes.
+	Scopes map[string]RestDescriptionAuthOauth2Scopes `json:"scopes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Scopes") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Scopes") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestDescriptionAuthOauth2) MarshalJSON() ([]byte, error) {
+	type noMethod RestDescriptionAuthOauth2
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestDescriptionAuthOauth2Scopes: The scope value.
+type RestDescriptionAuthOauth2Scopes struct {
+	// Description: Description of scope.
+	Description string `json:"description,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestDescriptionAuthOauth2Scopes) MarshalJSON() ([]byte, error) {
+	type noMethod RestDescriptionAuthOauth2Scopes
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestDescriptionIcons: Links to 16x16 and 32x32 icons representing the
+// API.
+type RestDescriptionIcons struct {
+	// X16: The URL of the 16x16 icon.
+	X16 string `json:"x16,omitempty"`
+
+	// X32: The URL of the 32x32 icon.
+	X32 string `json:"x32,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "X16") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "X16") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestDescriptionIcons) MarshalJSON() ([]byte, error) {
+	type noMethod RestDescriptionIcons
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type RestMethod struct {
+	// Description: Description of this method.
+	Description string `json:"description,omitempty"`
+
+	// EtagRequired: Whether this method requires an ETag to be specified.
+	// The ETag is sent as an HTTP If-Match or If-None-Match header.
+	EtagRequired bool `json:"etagRequired,omitempty"`
+
+	// HttpMethod: HTTP method used by this method.
+	HttpMethod string `json:"httpMethod,omitempty"`
+
+	// Id: A unique ID for this method. This property can be used to match
+	// methods between different versions of Discovery.
+	Id string `json:"id,omitempty"`
+
+	// MediaUpload: Media upload parameters.
+	MediaUpload *RestMethodMediaUpload `json:"mediaUpload,omitempty"`
+
+	// ParameterOrder: Ordered list of required parameters, serves as a hint
+	// to clients on how to structure their method signatures. The array is
+	// ordered such that the "most-significant" parameter appears first.
+	ParameterOrder []string `json:"parameterOrder,omitempty"`
+
+	// Parameters: Details for all parameters in this method.
+	Parameters map[string]JsonSchema `json:"parameters,omitempty"`
+
+	// Path: The URI path of this REST method. Should be used in conjunction
+	// with the basePath property at the api-level.
+	Path string `json:"path,omitempty"`
+
+	// Request: The schema for the request.
+	Request *RestMethodRequest `json:"request,omitempty"`
+
+	// Response: The schema for the response.
+	Response *RestMethodResponse `json:"response,omitempty"`
+
+	// Scopes: OAuth 2.0 scopes applicable to this method.
+	Scopes []string `json:"scopes,omitempty"`
+
+	// SupportsMediaDownload: Whether this method supports media downloads.
+	SupportsMediaDownload bool `json:"supportsMediaDownload,omitempty"`
+
+	// SupportsMediaUpload: Whether this method supports media uploads.
+	SupportsMediaUpload bool `json:"supportsMediaUpload,omitempty"`
+
+	// SupportsSubscription: Whether this method supports subscriptions.
+	SupportsSubscription bool `json:"supportsSubscription,omitempty"`
+
+	// UseMediaDownloadService: Indicates that downloads from this method
+	// should use the download service URL (i.e. "/download"). Only applies
+	// if the method supports media download.
+	UseMediaDownloadService bool `json:"useMediaDownloadService,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethod) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethod
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodMediaUpload: Media upload parameters.
+type RestMethodMediaUpload struct {
+	// Accept: MIME Media Ranges for acceptable media uploads to this
+	// method.
+	Accept []string `json:"accept,omitempty"`
+
+	// MaxSize: Maximum size of a media upload, such as "1MB", "2GB" or
+	// "3TB".
+	MaxSize string `json:"maxSize,omitempty"`
+
+	// Protocols: Supported upload protocols.
+	Protocols *RestMethodMediaUploadProtocols `json:"protocols,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Accept") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Accept") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodMediaUpload) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodMediaUpload
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodMediaUploadProtocols: Supported upload protocols.
+type RestMethodMediaUploadProtocols struct {
+	// Resumable: Supports the Resumable Media Upload protocol.
+	Resumable *RestMethodMediaUploadProtocolsResumable `json:"resumable,omitempty"`
+
+	// Simple: Supports uploading as a single HTTP request.
+	Simple *RestMethodMediaUploadProtocolsSimple `json:"simple,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Resumable") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Resumable") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodMediaUploadProtocols) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodMediaUploadProtocols
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodMediaUploadProtocolsResumable: Supports the Resumable Media
+// Upload protocol.
+type RestMethodMediaUploadProtocolsResumable struct {
+	// Multipart: True if this endpoint supports uploading multipart media.
+	//
+	// Default: true
+	Multipart *bool `json:"multipart,omitempty"`
+
+	// Path: The URI path to be used for upload. Should be used in
+	// conjunction with the basePath property at the api-level.
+	Path string `json:"path,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Multipart") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Multipart") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodMediaUploadProtocolsResumable) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodMediaUploadProtocolsResumable
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodMediaUploadProtocolsSimple: Supports uploading as a single
+// HTTP request.
+type RestMethodMediaUploadProtocolsSimple struct {
+	// Multipart: True if this endpoint supports upload multipart media.
+	//
+	// Default: true
+	Multipart *bool `json:"multipart,omitempty"`
+
+	// Path: The URI path to be used for upload. Should be used in
+	// conjunction with the basePath property at the api-level.
+	Path string `json:"path,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Multipart") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Multipart") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodMediaUploadProtocolsSimple) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodMediaUploadProtocolsSimple
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodRequest: The schema for the request.
+type RestMethodRequest struct {
+	// Ref: Schema ID for the request schema.
+	Ref string `json:"$ref,omitempty"`
+
+	// ParameterName: parameter name.
+	ParameterName string `json:"parameterName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Ref") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Ref") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodRequest) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RestMethodResponse: The schema for the response.
+type RestMethodResponse struct {
+	// Ref: Schema ID for the response schema.
+	Ref string `json:"$ref,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Ref") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Ref") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestMethodResponse) MarshalJSON() ([]byte, error) {
+	type noMethod RestMethodResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type RestResource struct {
+	// Methods: Methods on this resource.
+	Methods map[string]RestMethod `json:"methods,omitempty"`
+
+	// Resources: Sub-resources on this resource.
+	Resources map[string]RestResource `json:"resources,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Methods") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Methods") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RestResource) MarshalJSON() ([]byte, error) {
+	type noMethod RestResource
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// method id "discovery.apis.getRest":
+
+type ApisGetRestCall struct {
+	s            *Service
+	api          string
+	version      string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// GetRest: Retrieve the description of a particular version of an api.
+func (r *ApisService) GetRest(api string, version string) *ApisGetRestCall {
+	c := &ApisGetRestCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.api = api
+	c.version = version
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ApisGetRestCall) Fields(s ...googleapi.Field) *ApisGetRestCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ApisGetRestCall) IfNoneMatch(entityTag string) *ApisGetRestCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ApisGetRestCall) Context(ctx context.Context) *ApisGetRestCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ApisGetRestCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ApisGetRestCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "apis/{api}/{version}/rest")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"api":     c.api,
+		"version": c.version,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "discovery.apis.getRest" call.
+// Exactly one of *RestDescription or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *RestDescription.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ApisGetRestCall) Do(opts ...googleapi.CallOption) (*RestDescription, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &RestDescription{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieve the description of a particular version of an api.",
+	//   "httpMethod": "GET",
+	//   "id": "discovery.apis.getRest",
+	//   "parameterOrder": [
+	//     "api",
+	//     "version"
+	//   ],
+	//   "parameters": {
+	//     "api": {
+	//       "description": "The name of the API.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "version": {
+	//       "description": "The version of the API.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "apis/{api}/{version}/rest",
+	//   "response": {
+	//     "$ref": "RestDescription"
+	//   }
+	// }
+
+}
+
+// method id "discovery.apis.list":
+
+type ApisListCall struct {
+	s            *Service
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Retrieve the list of APIs supported at this endpoint.
+func (r *ApisService) List() *ApisListCall {
+	c := &ApisListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	return c
+}
+
+// Name sets the optional parameter "name": Only include APIs with the
+// given name.
+func (c *ApisListCall) Name(name string) *ApisListCall {
+	c.urlParams_.Set("name", name)
+	return c
+}
+
+// Preferred sets the optional parameter "preferred": Return only the
+// preferred version of an API.
+func (c *ApisListCall) Preferred(preferred bool) *ApisListCall {
+	c.urlParams_.Set("preferred", fmt.Sprint(preferred))
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ApisListCall) Fields(s ...googleapi.Field) *ApisListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ApisListCall) IfNoneMatch(entityTag string) *ApisListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ApisListCall) Context(ctx context.Context) *ApisListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ApisListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ApisListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "apis")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "discovery.apis.list" call.
+// Exactly one of *DirectoryList or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *DirectoryList.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ApisListCall) Do(opts ...googleapi.CallOption) (*DirectoryList, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &DirectoryList{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieve the list of APIs supported at this endpoint.",
+	//   "httpMethod": "GET",
+	//   "id": "discovery.apis.list",
+	//   "parameters": {
+	//     "name": {
+	//       "description": "Only include APIs with the given name.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "preferred": {
+	//       "default": "false",
+	//       "description": "Return only the preferred version of an API.",
+	//       "location": "query",
+	//       "type": "boolean"
+	//     }
+	//   },
+	//   "path": "apis",
+	//   "response": {
+	//     "$ref": "DirectoryList"
+	//   }
+	// }
+
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -827,6 +827,12 @@
 			"revisionTime": "2017-02-23T23:41:36Z"
 		},
 		{
+			"checksumSHA1": "wv8+a9dOWrdJEIt1mva9qLlTSfo=",
+			"path": "google.golang.org/api/discovery/v1",
+			"revision": "295e4bb0ade057ae2cfb9876ab0b54635dbfcea4",
+			"revisionTime": "2017-07-18T13:06:16Z"
+		},
+		{
 			"checksumSHA1": "JYl35km48fLrIx7YUtzcgd4J7Rk=",
 			"path": "google.golang.org/api/dns/v1",
 			"revision": "3cc2e591b550923a2c5f0ab5a803feda924d5823",


### PR DESCRIPTION
Provides a script that can be used to generate a schema for a new GCP resource.

This script is based on https://github.com/radeksimko/terraform-gen, but uses GCP's discovery service, which has more information about the various types than can be gathered from just the structs.

Example output for `go run ./scripts/schemagen.go -api dataproc -resource Cluster`: https://gist.github.com/danawillow/f937d1009b1ced785da7d3d09ced7e3d

```
$ go test ./scripts/
ok  	github.com/terraform-providers/terraform-provider-google/scripts	0.095s
```

@selmanj @rileykarson @rosbo @radeksimko 