### PR TITLE
google_compute_ssl_certificate: mark private_key as sensitive

### DIFF
--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -48,9 +48,10 @@ func resourceComputeSslCertificate() *schema.Resource {
 			},
 
 			"private_key": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 
 			"description": &schema.Schema{


### PR DESCRIPTION
This prevents the private key to be displayed in `terraform plan` and `terraform apply`.
It does not impact anything else.

I considered marking `certificate` sensitive as well to avoid displaying a full certificate (+ intermediates) as it clutters the output and does not bring very readable information, but as it is not really sensitive data I did not do it. Feel free to tell me if you think this is a good idea.