### PR TITLE
Support BigQuery Views in Terraform

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -238,6 +238,12 @@ func resourceBigQueryDatasetRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("dataset_id", res.DatasetReference.DatasetId)
 	d.Set("default_table_expiration_ms", res.DefaultTableExpirationMs)
 
+	// Older Tables in BigQuery have no Location set in the API response. We can safely assume that these tables
+	// are in the US.
+	if res.Location == "" {
+		d.Set("location", "US")
+	}
+
 	return nil
 }
 
@@ -274,3 +280,18 @@ func resourceBigQueryDatasetDelete(d *schema.ResourceData, meta interface{}) err
 	d.SetId("")
 	return nil
 }
+
+//
+//func resourceBigQueryDatasetImport(d *schema.ResourceData, m interface{}) ([]*ResourceData, error) {
+//	x := schema.ImportStatePassthrough(d, m)
+//
+//	//
+//	//
+//	//	// HACK(jmcgill)
+//	//
+//	//	return []*ResourceData{d}, nil
+//	//}
+//	//	test := &schema.ResourceImporter{
+//	//                        State: schema.ImportStatePassthrough,
+//	//                },
+//}

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -207,7 +207,7 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 	}
 
 	if v, ok := d.GetOk("expiration_time"); ok {
-		table.ExpirationTime = v.(int64)
+		table.ExpirationTime = int64(v.(int))
 	}
 
 	if v, ok := d.GetOk("friendly_name"); ok {

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -92,6 +92,23 @@ func resourceBigQueryTable() *schema.Resource {
 				},
 			},
 
+			// View: [Experimental] If specified, configures this table as a view.
+			"view": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Type: [Required] The only type supported is DAY, which will generate
+						// one partition per day based on data loading time.
+						"query": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			// TimePartitioning: [Experimental] If specified, configures time-based
 			// partitioning for this table.
 			"time_partitioning": &schema.Schema{
@@ -200,6 +217,11 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 			TableId:   d.Get("table_id").(string),
 			ProjectId: project,
 		},
+	}
+
+	// TODO(jmcgill): How do I do nested objects in a terraform configuration.
+	if v, ok := d.GetOk("view"); ok {
+		table.View = expandView(v)
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -317,6 +339,11 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("schema", schema)
 	}
 
+	if res.View != nil {
+		view := flattenView(res.View)
+		d.Set("view", view)
+	}
+
 	return nil
 }
 
@@ -392,5 +419,17 @@ func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interfa
 		result["expiration_ms"] = tp.ExpirationMs
 	}
 
+	return []map[string]interface{}{result}
+}
+
+func expandView(configured interface{}) *bigquery.ViewDefinition {
+	raw := configured.([]interface{})[0].(map[string]interface{})
+	vd := &bigquery.ViewDefinition{Query: raw["query"].(string)}
+
+	return vd
+}
+
+func flattenView(v *bigquery.ViewDefinition) []map[string]interface{} {
+	result := map[string]interface{}{"query": v.Query}
 	return []map[string]interface{}{result}
 }


### PR DESCRIPTION
Add naive support for BigQuery Views in Terraform. Views are a specialization of a Table which contains a View.Query field and does *not* contain a schema.

Also work around a bug in which location is not set in API responses for datasets which were created before multiple locations (US and EU) were available in BigQuery. 