### PR TITLE
Mark google_sql_database.{charset,collation} as computed instead of having defaults

### DIFF
--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -46,13 +46,13 @@ func resourceSqlDatabase() *schema.Resource {
 			"charset": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "utf8",
+				Computed: true,
 			},
 
 			"collation": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "utf8_general_ci",
+				Computed: true,
 			},
 		},
 	}

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -44,10 +44,9 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `charset` - (Optional) The MySQL charset value (default "utf8").
+* `charset` - (Optional) The MySQL charset value.
 
-* `collation` - (Optional) The MySQL collation value (default
-    "utf8_general_ci").
+* `collation` - (Optional) The MySQL collation value.
 
 ## Attributes Reference
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -44,9 +44,19 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `charset` - (Optional) The MySQL charset value.
+* `charset` - (Optional) The charset value. See MySQL's [Supported Character
+    Sets and
+    Collations](https://dev.mysql.com/doc/refman/5.6/en/charset-charsets.html)
+    and PostgreSQL's [Character Set
+    Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
+    for more details and supported values.
 
-* `collation` - (Optional) The MySQL collation value.
+* `collation` - (Optional) The collation value. See MySQL's [Supported Character
+    Sets and
+    Collations](https://dev.mysql.com/doc/refman/5.6/en/charset-charsets.html)
+    and PostgreSQL's [Collation
+    Support](https://www.postgresql.org/docs/9.6/static/collation.html) for
+    more details and supported values.
 
 ## Attributes Reference
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -46,14 +46,14 @@ The following arguments are supported:
 
 * `charset` - (Optional) The charset value. See MySQL's [Supported Character
     Sets and
-    Collations](https://dev.mysql.com/doc/refman/5.6/en/charset-charsets.html)
+    Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and PostgreSQL's [Character Set
     Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
     for more details and supported values.
 
 * `collation` - (Optional) The collation value. See MySQL's [Supported Character
     Sets and
-    Collations](https://dev.mysql.com/doc/refman/5.6/en/charset-charsets.html)
+    Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and PostgreSQL's [Collation
     Support](https://www.postgresql.org/docs/9.6/static/collation.html) for
     more details and supported values.

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -49,14 +49,18 @@ The following arguments are supported:
     Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and PostgreSQL's [Character Set
     Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
-    for more details and supported values.
+    for more details and supported values. Note that Cloud SQL's beta
+    offering for PostgreSQL databases currently only supports the charset value
+    `UTF8`.
 
 * `collation` - (Optional) The collation value. See MySQL's [Supported Character
     Sets and
     Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and PostgreSQL's [Collation
     Support](https://www.postgresql.org/docs/9.6/static/collation.html) for
-    more details and supported values.
+    more details and supported values. Note that Cloud SQL's beta
+    offering for PostgreSQL databases currently only supports the collation
+    value `en_US.UTF8`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This change is required to avoid the following scenario:
When upgrading from a previous version of the Google provider, TF will change
the charset/collation of existing (TF-managed) databases to utf8/utf8_general_ci
(if the user hasn't added different config values before running TF apply),
potentially overriding any non-default settings that the user my have applied
through the Cloud SQL admin API. This violates POLA.

This is an addendum to PR #183 and issue #179.