### PR TITLE
google_compute_instance reads `scheduling` fields from GCP.

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1170,11 +1170,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if val, ok := d.GetOk(prefix + ".automatic_restart"); ok {
 			scheduling.AutomaticRestart = googleapi.Bool(val.(bool))
 		}
-		// The Preemptible field cannot be updated. The instance must be recreated.
+		if val, ok := d.GetOk(prefix + ".preemptible"); ok {
+			scheduling.Preemptible = val.(bool)
+		}
 		if val, ok := d.GetOk(prefix + ".on_host_maintenance"); ok {
 			scheduling.OnHostMaintenance = val.(string)
 		}
-		scheduling.ForceSendFields = []string{"AutomaticRestart"}
+		scheduling.ForceSendFields = []string{"AutomaticRestart", "Preemptible"}
 
 		op, err := config.clientCompute.Instances.SetScheduling(project,
 			zone, d.Id(), scheduling).Do()


### PR DESCRIPTION
issue #211 

Marked `preemptible` as ForceNew because this field can only be set at the creation of an instance.
Reads `scheduling` fields from GCP. Make sure this does not introduce a diff.
There should be at most one `scheduling` block. Enforcing it with MaxItems=1

cc/ @selmanj @danawillow 