### PR TITLE
Remove Compute Operation WaitGlobal. 

### DIFF
--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -78,20 +78,6 @@ func computeOperationWaitTime(config *Config, op *compute.Operation, project, ac
 	return waitComputeOperationWaiter(w, timeoutMin, activity)
 }
 
-func computeOperationWaitGlobal(config *Config, op *compute.Operation, project, activity string) error {
-	return computeOperationWaitGlobalTime(config, op, project, activity, 4)
-}
-
-func computeOperationWaitGlobalTime(config *Config, op *compute.Operation, project, activity string, timeoutMin int) error {
-	w := &ComputeOperationWaiter{
-		Service: config.clientCompute,
-		Op:      op,
-		Project: project,
-	}
-
-	return waitComputeOperationWaiter(w, timeoutMin, activity)
-}
-
 func computeOperationWaitRegion(config *Config, op *compute.Operation, project string, region, activity string) error {
 	return computeOperationWaitRegionTime(config, op, project, region, 4, activity)
 }

--- a/google/resource_compute_backend_bucket.go
+++ b/google/resource_compute_backend_bucket.go
@@ -87,7 +87,7 @@ func resourceComputeBackendBucketCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(bucket.Name)
 
 	// Wait for the operation to complete
-	waitErr := computeOperationWaitGlobal(config, op, project, "Creating Backend Bucket")
+	waitErr := computeOperationWait(config, op, project, "Creating Backend Bucket")
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -150,7 +150,7 @@ func resourceComputeBackendBucketUpdate(d *schema.ResourceData, meta interface{}
 
 	d.SetId(bucket.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Backend Bucket")
+	err = computeOperationWait(config, op, project, "Updating Backend Bucket")
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func resourceComputeBackendBucketDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting backend bucket: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Backend Bucket")
+	err = computeOperationWait(config, op, project, "Deleting Backend Bucket")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -213,7 +213,7 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 	d.SetId(service.Name)
 
 	// Wait for the operation to complete
-	waitErr := computeOperationWaitGlobal(config, op, project, "Creating Backend Service")
+	waitErr := computeOperationWait(config, op, project, "Creating Backend Service")
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -316,7 +316,7 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 
 	d.SetId(service.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Backend Service")
+	err = computeOperationWait(config, op, project, "Updating Backend Service")
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func resourceComputeBackendServiceDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting backend service: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Backend Service")
+	err = computeOperationWait(config, op, project, "Deleting Backend Service")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -139,7 +139,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 	// It probably maybe worked, so store the ID now
 	d.SetId(firewall.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Firewall")
+	err = computeOperationWait(config, op, project, "Creating Firewall")
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error updating firewall: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Firewall")
+	err = computeOperationWait(config, op, project, "Updating Firewall")
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error deleting firewall: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Firewall")
+	err = computeOperationWait(config, op, project, "Deleting Firewall")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -61,7 +61,7 @@ func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}
 	// It probably maybe worked, so store the ID now
 	d.SetId(addr.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Global Address")
+	err = computeOperationWait(config, op, project, "Creating Global Address")
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func resourceComputeGlobalAddressDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting address: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Global Address")
+	err = computeOperationWait(config, op, project, "Deleting Global Address")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -100,7 +100,7 @@ func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta inte
 	// It probably maybe worked, so store the ID now
 	d.SetId(frule.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Global Fowarding Rule")
+	err = computeOperationWait(config, op, project, "Creating Global Fowarding Rule")
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func resourceComputeGlobalForwardingRuleUpdate(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, project, "Updating Global Forwarding Rule")
+		err = computeOperationWait(config, op, project, "Updating Global Forwarding Rule")
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func resourceComputeGlobalForwardingRuleDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error deleting GlobalForwardingRule: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting GlobalForwarding Rule")
+	err = computeOperationWait(config, op, project, "Deleting GlobalForwarding Rule")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_health_check.go
+++ b/google/resource_compute_health_check.go
@@ -302,7 +302,7 @@ func resourceComputeHealthCheckCreate(d *schema.ResourceData, meta interface{}) 
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Health Check")
+	err = computeOperationWait(config, op, project, "Creating Health Check")
 	if err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Health Check")
+	err = computeOperationWait(config, op, project, "Updating Health Check")
 	if err != nil {
 		return err
 	}
@@ -475,7 +475,7 @@ func resourceComputeHealthCheckDelete(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error deleting HealthCheck: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Health Check")
+	err = computeOperationWait(config, op, project, "Deleting Health Check")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_http_health_check.go
+++ b/google/resource_compute_http_health_check.go
@@ -134,7 +134,7 @@ func resourceComputeHttpHealthCheckCreate(d *schema.ResourceData, meta interface
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Http Health Check")
+	err = computeOperationWait(config, op, project, "Creating Http Health Check")
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func resourceComputeHttpHealthCheckUpdate(d *schema.ResourceData, meta interface
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Http Health Check")
+	err = computeOperationWait(config, op, project, "Updating Http Health Check")
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func resourceComputeHttpHealthCheckDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error deleting HttpHealthCheck: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Http Health Check")
+	err = computeOperationWait(config, op, project, "Deleting Http Health Check")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_https_health_check.go
+++ b/google/resource_compute_https_health_check.go
@@ -133,7 +133,7 @@ func resourceComputeHttpsHealthCheckCreate(d *schema.ResourceData, meta interfac
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Https Health Check")
+	err = computeOperationWait(config, op, project, "Creating Https Health Check")
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func resourceComputeHttpsHealthCheckUpdate(d *schema.ResourceData, meta interfac
 	// It probably maybe worked, so store the ID now
 	d.SetId(hchk.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Updating Https Health Check")
+	err = computeOperationWait(config, op, project, "Updating Https Health Check")
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func resourceComputeHttpsHealthCheckDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting HttpsHealthCheck: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Https Health Check")
+	err = computeOperationWait(config, op, project, "Deleting Https Health Check")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -150,7 +150,7 @@ func resourceComputeImageCreate(d *schema.ResourceData, meta interface{}) error 
 	// Store the ID
 	d.SetId(image.Name)
 
-	err = computeOperationWaitGlobalTime(config, op, project, "Creating Image", createTimeout)
+	err = computeOperationWaitTime(config, op, project, "Creating Image", createTimeout)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func resourceComputeImageDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting image: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting image")
+	err = computeOperationWait(config, op, project, "Deleting image")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -602,7 +602,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	// Store the ID now
 	d.SetId(instanceTemplate.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Instance Template")
+	err = computeOperationWait(config, op, project, "Creating Instance Template")
 	if err != nil {
 		return err
 	}
@@ -821,7 +821,7 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting instance template: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Instance Template")
+	err = computeOperationWait(config, op, project, "Deleting Instance Template")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -112,7 +112,7 @@ func resourceComputeNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	// It probably maybe worked, so store the ID now
 	d.SetId(network.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Network")
+	err = computeOperationWait(config, op, project, "Creating Network")
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Network")
+	err = computeOperationWait(config, op, project, "Deleting Network")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -76,7 +76,7 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 
 		log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 
-		return computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
+		return computeOperationWait(config, op, project.Name, "SetCommonMetadata")
 	}
 
 	err = MetadataRetryWrapper(createMD)
@@ -147,7 +147,7 @@ func resourceComputeProjectMetadataUpdate(d *schema.ResourceData, meta interface
 			// Optimistic locking requires the fingerprint received to match
 			// the fingerprint we send the server, if there is a mismatch then we
 			// are working on old data, and must retry
-			return computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
+			return computeOperationWait(config, op, project.Name, "SetCommonMetadata")
 		}
 
 		err := MetadataRetryWrapper(updateMD)
@@ -189,7 +189,7 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 
-	err = computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")
+	err = computeOperationWait(config, op, project.Name, "SetCommonMetadata")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -172,7 +172,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	// It probably maybe worked, so store the ID now
 	d.SetId(route.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Route")
+	err = computeOperationWait(config, op, project, "Creating Route")
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func resourceComputeRouteDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting route: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Route")
+	err = computeOperationWait(config, op, project, "Deleting Route")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -169,7 +169,7 @@ func resourceComputeSnapshotDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error deleting snapshot: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Snapshot")
+	err = computeOperationWait(config, op, project, "Deleting Snapshot")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -114,7 +114,7 @@ func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating ssl certificate: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating SslCertificate")
+	err = computeOperationWait(config, op, project, "Creating SslCertificate")
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func resourceComputeSslCertificateDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting ssl certificate: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting SslCertificate")
+	err = computeOperationWait(config, op, project, "Deleting SslCertificate")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -77,7 +77,7 @@ func resourceComputeTargetHttpProxyCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating TargetHttpProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Target Http Proxy")
+	err = computeOperationWait(config, op, project, "Creating Target Http Proxy")
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func resourceComputeTargetHttpProxyUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, project, "Updating Target Http Proxy")
+		err = computeOperationWait(config, op, project, "Updating Target Http Proxy")
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func resourceComputeTargetHttpProxyDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error deleting TargetHttpProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Target Http Proxy")
+	err = computeOperationWait(config, op, project, "Deleting Target Http Proxy")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -101,7 +101,7 @@ func resourceComputeTargetHttpsProxyCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating TargetHttpsProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Target Https Proxy")
+	err = computeOperationWait(config, op, project, "Creating Target Https Proxy")
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error updating Target HTTPS proxy URL map: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, project, "Updating Target Https Proxy URL Map")
+		err = computeOperationWait(config, op, project, "Updating Target Https Proxy URL Map")
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func resourceComputeTargetHttpsProxyUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error updating Target Https Proxy SSL Certificates: %s", err)
 		}
 
-		err = computeOperationWaitGlobal(config, op, project, "Updating Target Https Proxy SSL certificates")
+		err = computeOperationWait(config, op, project, "Updating Target Https Proxy SSL certificates")
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting TargetHttpsProxy: %s", err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Deleting Target Https Proxy")
+	err = computeOperationWait(config, op, project, "Deleting Target Https Proxy")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_url_map.go
+++ b/google/resource_compute_url_map.go
@@ -288,7 +288,7 @@ func resourceComputeUrlMapCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to insert Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Insert Url Map")
+	err = computeOperationWait(config, op, project, "Insert Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to insert Url Map %s: %s", name, err)
@@ -642,7 +642,7 @@ func resourceComputeUrlMapUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to update Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Update Url Map")
+	err = computeOperationWait(config, op, project, "Update Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to update Url Map %s: %s", name, err)
@@ -667,7 +667,7 @@ func resourceComputeUrlMapDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error, failed to delete Url Map %s: %s", name, err)
 	}
 
-	err = computeOperationWaitGlobal(config, op, project, "Delete Url Map")
+	err = computeOperationWait(config, op, project, "Delete Url Map")
 
 	if err != nil {
 		return fmt.Errorf("Error, failed waitng to delete Url Map %s: %s", name, err)


### PR DESCRIPTION
Followup to #191.

Remove every occurrence of `computeOperationWaitGlobal`, `computeOperationWaitGlobalTime`, migrating them to `computeOperationWait` and `computeOperationWaitGlobalTime`.

I tested across several modified resources using some basic and some update tests.

Basic:
```
TF_ACC=1 go test ./google -v -run=TestAccComputeBackendBucket_basic -timeout 120m
=== RUN   TestAccComputeBackendBucket_basic
--- PASS: TestAccComputeBackendBucket_basic (27.96s)
=== RUN   TestAccComputeBackendBucket_basicModified
--- PASS: TestAccComputeBackendBucket_basicModified (43.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	71.391s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeBackendService_basic -timeout 120m
=== RUN   TestAccComputeBackendService_basic
--- PASS: TestAccComputeBackendService_basic (69.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	69.552s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeFirewall_basic -timeout 120m
=== RUN   TestAccComputeFirewall_basic
--- PASS: TestAccComputeFirewall_basic (52.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	52.515s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeInstanceTemplate_basic -timeout 120m
=== RUN   TestAccComputeInstanceTemplate_basic
--- PASS: TestAccComputeInstanceTemplate_basic (23.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	23.866s
```

Update:
```
TF_ACC=1 go test ./google -v -run=TestAccComputeUrlMap_update_path_matcher -timeout 120m
=== RUN   TestAccComputeUrlMap_update_path_matcher
--- PASS: TestAccComputeUrlMap_update_path_matcher (79.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	79.278s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeHttpsHealthCheck_update -timeout 120m
=== RUN   TestAccComputeHttpsHealthCheck_update
--- PASS: TestAccComputeHttpsHealthCheck_update (34.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	34.491s
```