### PR TITLE
Migrate WaitRegion/WaitRegionTime to universal wait.

### DIFF
--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -78,20 +78,6 @@ func computeOperationWaitTime(config *Config, op *compute.Operation, project, ac
 	return waitComputeOperationWaiter(w, timeoutMin, activity)
 }
 
-func computeOperationWaitRegion(config *Config, op *compute.Operation, project string, region, activity string) error {
-	return computeOperationWaitRegionTime(config, op, project, region, 4, activity)
-}
-
-func computeOperationWaitRegionTime(config *Config, op *compute.Operation, project, region string, timeoutMin int, activity string) error {
-	w := &ComputeOperationWaiter{
-		Service: config.clientCompute,
-		Op:      op,
-		Project: project,
-	}
-
-	return waitComputeOperationWaiter(w, timeoutMin, activity)
-}
-
 func computeOperationWaitZone(config *Config, op *compute.Operation, project, zone, activity string) error {
 	return computeOperationWaitZoneTime(config, op, project, zone, 4, activity)
 }

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -72,7 +72,7 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 	// It probably maybe worked, so store the ID now
 	d.SetId(addr.Name)
 
-	err = computeOperationWaitRegion(config, op, project, region, "Creating Address")
+	err = computeOperationWait(config, op, project, "Creating Address")
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting address: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Address")
+	err = computeOperationWait(config, op, project, "Deleting Address")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -164,7 +164,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	// It probably maybe worked, so store the ID now
 	d.SetId(frule.Name)
 
-	err = computeOperationWaitRegion(config, op, project, region, "Creating Fowarding Rule")
+	err = computeOperationWait(config, op, project, "Creating Fowarding Rule")
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func resourceComputeForwardingRuleUpdate(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error updating target: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Forwarding Rule")
+		err = computeOperationWait(config, op, project, "Updating Forwarding Rule")
 		if err != nil {
 			return err
 		}
@@ -266,7 +266,7 @@ func resourceComputeForwardingRuleDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting ForwardingRule: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Forwarding Rule")
+	err = computeOperationWait(config, op, project, "Deleting Forwarding Rule")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -171,7 +171,7 @@ func resourceComputeRegionBackendServiceCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(service.Name)
 
-	err = computeOperationWaitRegion(config, op, project, region, "Creating Region Backend Service")
+	err = computeOperationWait(config, op, project, "Creating Region Backend Service")
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func resourceComputeRegionBackendServiceUpdate(d *schema.ResourceData, meta inte
 
 	d.SetId(service.Name)
 
-	err = computeOperationWaitRegion(config, op, project, region, "Updating Backend Service")
+	err = computeOperationWait(config, op, project, "Updating Backend Service")
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func resourceComputeRegionBackendServiceDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error deleting backend service: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Backend Service")
+	err = computeOperationWait(config, op, project, "Deleting Backend Service")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_router.go
+++ b/google/resource_compute_router.go
@@ -130,7 +130,7 @@ func resourceComputeRouterCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error Inserting Router %s into network %s: %s", name, network, err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s", region, name))
-	err = computeOperationWaitRegion(config, op, project, region, "Inserting Router")
+	err = computeOperationWait(config, op, project, "Inserting Router")
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error Waiting to Insert Router %s into network %s: %s", name, network, err)
@@ -208,7 +208,7 @@ func resourceComputeRouterDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error Reading Router %s: %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Router")
+	err = computeOperationWait(config, op, project, "Deleting Router")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Delete Router %s: %s", name, err)
 	}

--- a/google/resource_compute_router_interface.go
+++ b/google/resource_compute_router_interface.go
@@ -126,7 +126,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, ifaceName))
-	err = computeOperationWaitRegion(config, op, project, region, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
@@ -246,7 +246,7 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
 	}

--- a/google/resource_compute_router_peer.go
+++ b/google/resource_compute_router_peer.go
@@ -148,7 +148,7 @@ func resourceComputeRouterPeerCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, peerName))
-	err = computeOperationWaitRegion(config, op, project, region, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
@@ -267,7 +267,7 @@ func resourceComputeRouterPeerDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
 	}

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -130,7 +130,7 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 	subnetwork.Region = region
 	d.SetId(createSubnetID(subnetwork))
 
-	err = computeOperationWaitRegion(config, op, project, region, "Creating Subnetwork")
+	err = computeOperationWait(config, op, project, "Creating Subnetwork")
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func resourceComputeSubnetworkUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating subnetwork PrivateIpGoogleAccess: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Subnetwork PrivateIpGoogleAccess")
+		err = computeOperationWait(config, op, project, "Updating Subnetwork PrivateIpGoogleAccess")
 		if err != nil {
 			return err
 		}
@@ -230,7 +230,7 @@ func resourceComputeSubnetworkDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting subnetwork: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Subnetwork")
+	err = computeOperationWait(config, op, project, "Deleting Subnetwork")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_target_pool.go
+++ b/google/resource_compute_target_pool.go
@@ -170,7 +170,7 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(tpool.Name)
 
-	err = computeOperationWaitRegion(config, op, project, region, "Creating Target Pool")
+	err = computeOperationWait(config, op, project, "Creating Target Pool")
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -299,7 +299,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -314,7 +314,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -332,7 +332,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating backup_pool: %s", err)
 		}
 
-		err = computeOperationWaitRegion(config, op, project, region, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -425,7 +425,7 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting TargetPool: %s", err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting Target Pool")
+	err = computeOperationWait(config, op, project, "Deleting Target Pool")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_vpn_gateway.go
+++ b/google/resource_compute_vpn_gateway.go
@@ -90,7 +90,7 @@ func resourceComputeVpnGatewayCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error Inserting VPN Gateway %s into network %s: %s", name, network, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Inserting VPN Gateway")
+	err = computeOperationWait(config, op, project, "Inserting VPN Gateway")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Insert VPN Gateway %s into network %s: %s", name, network, err)
 	}
@@ -148,7 +148,7 @@ func resourceComputeVpnGatewayDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error Reading VPN Gateway %s: %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting VPN Gateway")
+	err = computeOperationWait(config, op, project, "Deleting VPN Gateway")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Delete VPN Gateway %s: %s", name, err)
 	}

--- a/google/resource_compute_vpn_tunnel.go
+++ b/google/resource_compute_vpn_tunnel.go
@@ -176,7 +176,7 @@ func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error Inserting VPN Tunnel %s : %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Inserting VPN Tunnel")
+	err = computeOperationWait(config, op, project, "Inserting VPN Tunnel")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Insert VPN Tunnel %s: %s", name, err)
 	}
@@ -248,7 +248,7 @@ func resourceComputeVpnTunnelDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error Reading VPN Tunnel %s: %s", name, err)
 	}
 
-	err = computeOperationWaitRegion(config, op, project, region, "Deleting VPN Tunnel")
+	err = computeOperationWait(config, op, project, "Deleting VPN Tunnel")
 	if err != nil {
 		return fmt.Errorf("Error Waiting to Delete VPN Tunnel %s: %s", name, err)
 	}


### PR DESCRIPTION
2nd followup to #191.

Tests:

```
TF_ACC=1 go test ./google -v -run=TestAccComputeAddress -timeout 120m
=== RUN   TestAccComputeAddress_importBasic
--- PASS: TestAccComputeAddress_importBasic (23.99s)
=== RUN   TestAccComputeAddress_basic
--- PASS: TestAccComputeAddress_basic (24.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	48.509s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeForwardingRule -timeout 120m
=== RUN   TestAccComputeForwardingRule_importBasic
--- PASS: TestAccComputeForwardingRule_importBasic (46.12s)
=== RUN   TestAccComputeForwardingRule_basic
--- PASS: TestAccComputeForwardingRule_basic (46.04s)
=== RUN   TestAccComputeForwardingRule_singlePort
--- PASS: TestAccComputeForwardingRule_singlePort (45.73s)
=== RUN   TestAccComputeForwardingRule_ip
--- PASS: TestAccComputeForwardingRule_ip (45.86s)
=== RUN   TestAccComputeForwardingRule_internalLoadBalancing
--- PASS: TestAccComputeForwardingRule_internalLoadBalancing (68.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	251.969s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeRouter_basic -timeout 120m
=== RUN   TestAccComputeRouter_basic
--- PASS: TestAccComputeRouter_basic (78.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	78.749s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeVpnGateway_basic -timeout 120m
=== RUN   TestAccComputeVpnGateway_basic
--- PASS: TestAccComputeVpnGateway_basic (47.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	48.132s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeSubnetwork_update -timeout 120m
=== RUN   TestAccComputeSubnetwork_update
--- PASS: TestAccComputeSubnetwork_update (72.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	72.581s
```