### PR TITLE
Add Beta support & Beta feature ip_version to google_compute_global_address

### DIFF
--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -5,6 +5,25 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+func computeSharedOperationWait(config *Config, op interface{}, project string, activity string) error {
+	return computeSharedOperationWaitTime(config, op, project, 4, activity)
+}
+
+func computeSharedOperationWaitTime(config *Config, op interface{}, project string, minutes int, activity string) error {
+	if op == nil {
+		panic("Attempted to wait on an Operation that was nil.")
+	}
+
+	switch op.(type) {
+	case *compute.Operation:
+		return computeOperationWaitTime(config, op.(*compute.Operation), project, activity, minutes)
+	case *computeBeta.Operation:
+		return computeBetaOperationWaitGlobalTime(config, op.(*computeBeta.Operation), project, activity, minutes)
+	default:
+		panic("Attempted to wait on an Operation of unknown type.")
+	}
+}
+
 func computeSharedOperationWaitZone(config *Config, op interface{}, project string, zone, activity string) error {
 	return computeSharedOperationWaitZoneTime(config, op, project, zone, 4, activity)
 }

--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -5,8 +5,13 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
+
+var GlobalAddressBaseApiVersion = v1
+var GlobalAddressVersionedFeatures = []Feature{}
 
 func resourceComputeGlobalAddress() *schema.Resource {
 	return &schema.Resource{
@@ -16,6 +21,7 @@ func resourceComputeGlobalAddress() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -43,6 +49,7 @@ func resourceComputeGlobalAddress() *schema.Resource {
 }
 
 func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalAddressBaseApiVersion, GlobalAddressVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -51,17 +58,38 @@ func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	// Build the address parameter
-	addr := &compute.Address{Name: d.Get("name").(string)}
-	op, err := config.clientCompute.GlobalAddresses.Insert(
-		project, addr).Do()
-	if err != nil {
-		return fmt.Errorf("Error creating address: %s", err)
+	addr := &computeBeta.Address{Name: d.Get("name").(string)}
+
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		v1Addr := &compute.Address{}
+		err = Convert(addr, v1Addr)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientCompute.GlobalAddresses.Insert(project, v1Addr).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating address: %s", err)
+		}
+	case v0beta:
+		v0BetaAddr := &computeBeta.Address{}
+		err = Convert(addr, v0BetaAddr)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientComputeBeta.GlobalAddresses.Insert(project, v0BetaAddr).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating address: %s", err)
+		}
 	}
 
 	// It probably maybe worked, so store the ID now
 	d.SetId(addr.Name)
 
-	err = computeOperationWait(config, op, project, "Creating Global Address")
+	err = computeSharedOperationWait(config, op, project, "Creating Global Address")
 	if err != nil {
 		return err
 	}
@@ -70,6 +98,7 @@ func resourceComputeGlobalAddressCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalAddressBaseApiVersion, GlobalAddressVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -77,10 +106,28 @@ func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	addr, err := config.clientCompute.GlobalAddresses.Get(
-		project, d.Id()).Do()
-	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("Global Address %q", d.Get("name").(string)))
+	addr := &computeBeta.Address{}
+	switch computeApiVersion {
+	case v1:
+		v1Addr, err := config.clientCompute.GlobalAddresses.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Global Address %q", d.Get("name").(string)))
+		}
+
+		err = Convert(v1Addr, addr)
+		if err != nil {
+			return err
+		}
+	case v0beta:
+		v0BetaAddr, err := config.clientComputeBeta.GlobalAddresses.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Global Address %q", d.Get("name").(string)))
+		}
+
+		err = Convert(v0BetaAddr, addr)
+		if err != nil {
+			return err
+		}
 	}
 
 	d.Set("address", addr.Address)
@@ -91,6 +138,7 @@ func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceComputeGlobalAddressDelete(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalAddressBaseApiVersion, GlobalAddressVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -100,13 +148,21 @@ func resourceComputeGlobalAddressDelete(d *schema.ResourceData, meta interface{}
 
 	// Delete the address
 	log.Printf("[DEBUG] address delete request")
-	op, err := config.clientCompute.GlobalAddresses.Delete(
-		project, d.Id()).Do()
-	if err != nil {
-		return fmt.Errorf("Error deleting address: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		op, err = config.clientCompute.GlobalAddresses.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting address: %s", err)
+		}
+	case v0beta:
+		op, err = config.clientComputeBeta.GlobalAddresses.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting address: %s", err)
+		}
 	}
 
-	err = computeOperationWait(config, op, project, "Deleting Global Address")
+	err = computeSharedOperationWait(config, op, project, "Deleting Global Address")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -25,6 +25,7 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
+					testAccCheckComputeBetaGlobalAddressIPV4("google_compute_global_address.foobar"),
 				),
 			},
 		},
@@ -44,14 +45,11 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeBetaGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
+					testAccCheckComputeBetaGlobalAddressIPV6("google_compute_global_address.foobar"),
 				),
 			},
 		},
 	})
-
-	if addr.IpVersion != "IPV6" {
-		t.Errorf("Expected IP version to be IPV6, got %s", addr.IpVersion)
-	}
 }
 
 func testAccCheckComputeGlobalAddressDestroy(s *terraform.State) error {
@@ -124,6 +122,58 @@ func testAccCheckComputeBetaGlobalAddressExists(n string, addr *computeBeta.Addr
 		}
 
 		*addr = *found
+
+		return nil
+	}
+}
+
+func testAccCheckComputeBetaGlobalAddressIPV4(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		addr, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if addr.IpVersion != "IPV4" {
+			fmt.Errorf("Expected IP version to be IPV4, got %s", addr.IpVersion)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeBetaGlobalAddressIPV6(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		addr, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if addr.IpVersion != "IPV6" {
+			fmt.Errorf("Expected IP version to be IPV6, got %s", addr.IpVersion)
+		}
 
 		return nil
 	}

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -25,7 +25,9 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
-					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", "IPV4"),
+
+					// implicitly IPV4
+					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", ""),
 				),
 			},
 		},

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -26,7 +26,7 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
 
-					// implicitly IPV4
+					// implicitly IPV4 - if we don't send an ip_version, we don't get one back even when using Beta apis
 					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", ""),
 				),
 			},

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -27,6 +29,29 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
+	var addr computeBeta.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeGlobalAddressDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeGlobalAddress_ipv6,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaGlobalAddressExists(
+						"google_compute_global_address.foobar", &addr),
+				),
+			},
+		},
+	})
+
+	if addr.IpVersion != "IPV6" {
+		t.Errorf("Expected IP version to be IPV6, got %s", addr.IpVersion)
+	}
 }
 
 func testAccCheckComputeGlobalAddressDestroy(s *terraform.State) error {
@@ -76,7 +101,41 @@ func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) res
 	}
 }
 
+func testAccCheckComputeBetaGlobalAddressExists(n string, addr *computeBeta.Address) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Addr not found")
+		}
+
+		*addr = *found
+
+		return nil
+	}
+}
+
 var testAccComputeGlobalAddress_basic = fmt.Sprintf(`
 resource "google_compute_global_address" "foobar" {
 	name = "address-test-%s"
+}`, acctest.RandString(10))
+
+var testAccComputeGlobalAddress_ipv6 = fmt.Sprintf(`
+resource "google_compute_global_address" "foobar" {
+	name = "address-test-%s"
+	ip_version = "IPV6"
 }`, acctest.RandString(10))

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -146,7 +146,7 @@ func testAccCheckComputeBetaGlobalAddressIpVersion(n, version string) resource.T
 		}
 
 		if addr.IpVersion != version {
-			fmt.Errorf("Expected IP version to be %s, got %s", version, addr.IpVersion)
+			return fmt.Errorf("Expected IP version to be %s, got %s", version, addr.IpVersion)
 		}
 
 		return nil

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -25,7 +25,7 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
-					testAccCheckComputeBetaGlobalAddressIPV4("google_compute_global_address.foobar"),
+					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", "IPV4"),
 				),
 			},
 		},
@@ -45,7 +45,7 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeBetaGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
-					testAccCheckComputeBetaGlobalAddressIPV6("google_compute_global_address.foobar"),
+					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", "IPV6"),
 				),
 			},
 		},
@@ -127,7 +127,7 @@ func testAccCheckComputeBetaGlobalAddressExists(n string, addr *computeBeta.Addr
 	}
 }
 
-func testAccCheckComputeBetaGlobalAddressIPV4(n string) resource.TestCheckFunc {
+func testAccCheckComputeBetaGlobalAddressIpVersion(n, version string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -145,34 +145,8 @@ func testAccCheckComputeBetaGlobalAddressIPV4(n string) resource.TestCheckFunc {
 			return err
 		}
 
-		if addr.IpVersion != "IPV4" {
-			fmt.Errorf("Expected IP version to be IPV4, got %s", addr.IpVersion)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckComputeBetaGlobalAddressIPV6(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		addr, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if addr.IpVersion != "IPV6" {
-			fmt.Errorf("Expected IP version to be IPV6, got %s", addr.IpVersion)
+		if addr.IpVersion != version {
+			fmt.Errorf("Expected IP version to be %s, got %s", version, addr.IpVersion)
 		}
 
 		return nil

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -33,6 +33,11 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
 is not provided, the provider project is used.
 
+- - -
+
+* `ip_version` - (Optional, Beta) The IP Version that will be used by this address.
+One of `"IPV4"` or `"IPV6"`.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
Waiting on #249 to merge, but otherwise able to be reviewed.

- Convert `google_compute_global_address` to a versioned resource with Beta support.
- Add support for the Beta field `ip_version` to `google_compute_global_address`

Explicitly setting `IPV4` on a `v1` resource forces a recreate as you're going from `""` to `IPV4` and this resource can't update; this is working as expected based on #185. We don't have enough information at refresh time to perform the read at `v0beta`.

Part 1/2 of #245.
Related to #93 