### PR TITLE
Removed the Compute Operation Wait Zone and migrated to universal wait.

### DIFF
--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -75,25 +75,6 @@ func computeOperationWaitTime(config *Config, op *compute.Operation, project, ac
 		Project: project,
 	}
 
-	return waitComputeOperationWaiter(w, timeoutMin, activity)
-}
-
-func computeOperationWaitZone(config *Config, op *compute.Operation, project, zone, activity string) error {
-	return computeOperationWaitZoneTime(config, op, project, zone, 4, activity)
-}
-
-func computeOperationWaitZoneTime(config *Config, op *compute.Operation, project, zone string, timeoutMin int, activity string) error {
-	w := &ComputeOperationWaiter{
-		Service: config.clientCompute,
-		Op:      op,
-		Project: project,
-	}
-
-	return waitComputeOperationWaiter(w, timeoutMin, activity)
-}
-
-// TODO: Inline this to computeOperationWaitTime when the old wait methods are eliminated.
-func waitComputeOperationWaiter(w *ComputeOperationWaiter, timeoutMin int, activity string) error {
 	state := w.Conf()
 	state.Delay = 10 * time.Second
 	state.Timeout = time.Duration(timeoutMin) * time.Minute
@@ -103,9 +84,9 @@ func waitComputeOperationWaiter(w *ComputeOperationWaiter, timeoutMin int, activ
 		return fmt.Errorf("Error waiting for %s: %s", activity, err)
 	}
 
-	op := opRaw.(*compute.Operation)
-	if op.Error != nil {
-		return ComputeOperationError(*op.Error)
+	resultOp := opRaw.(*compute.Operation)
+	if resultOp.Error != nil {
+		return ComputeOperationError(*resultOp.Error)
 	}
 
 	return nil

--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -12,7 +12,7 @@ func computeSharedOperationWaitZone(config *Config, op interface{}, project stri
 func computeSharedOperationWaitZoneTime(config *Config, op interface{}, project string, zone string, minutes int, activity string) error {
 	switch op.(type) {
 	case *compute.Operation:
-		return computeOperationWaitZoneTime(config, op.(*compute.Operation), project, zone, minutes, activity)
+		return computeOperationWaitTime(config, op.(*compute.Operation), project, activity, minutes)
 	case *computeBeta.Operation:
 		return computeBetaOperationWaitZoneTime(config, op.(*computeBeta.Operation), project, zone, minutes, activity)
 	case nil:

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -236,7 +236,7 @@ func resourceComputeAutoscalerCreate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(scaler.Name)
 
-	err = computeOperationWaitZone(config, op, project, zone.Name, "Creating Autoscaler")
+	err = computeOperationWait(config, op, project, "Creating Autoscaler")
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) e
 	// It probably maybe worked, so store the ID now
 	d.SetId(scaler.Name)
 
-	err = computeOperationWaitZone(config, op, project, zone, "Updating Autoscaler")
+	err = computeOperationWait(config, op, project, "Updating Autoscaler")
 	if err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func resourceComputeAutoscalerDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting autoscaler: %s", err)
 	}
 
-	err = computeOperationWaitZone(config, op, project, zone, "Deleting Autoscaler")
+	err = computeOperationWait(config, op, project, "Deleting Autoscaler")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -337,7 +337,6 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting disk: %s", err)
 	}
 
-	zone := d.Get("zone").(string)
 	err = computeOperationWait(config, op, project, "Deleting Disk")
 	if err != nil {
 		return err

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -180,7 +180,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	// It probably maybe worked, so store the ID now
 	d.SetId(disk.Name)
 
-	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating Disk")
+	err = computeOperationWait(config, op, project, "Creating Disk")
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error resizing disk: %s", err)
 		}
-		err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Resizing Disk")
+		err = computeOperationWait(config, op, project, "Resizing Disk")
 		if err != nil {
 			return err
 		}
@@ -316,7 +316,7 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Error detaching disk %s from instance %s/%s/%s: %s", call.deviceName, call.project,
 					call.zone, call.instance, err.Error())
 			}
-			err = computeOperationWaitZone(config, op, call.project, call.zone,
+			err = computeOperationWait(config, op, call.project,
 				fmt.Sprintf("Detaching disk from %s/%s/%s", call.project, call.zone, call.instance))
 			if err != nil {
 				return err
@@ -338,7 +338,7 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	zone := d.Get("zone").(string)
-	err = computeOperationWaitZone(config, op, project, zone, "Deleting Disk")
+	err = computeOperationWait(config, op, project, "Deleting Disk")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -825,7 +825,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(instance.Name)
 
 	// Wait for the operation to complete
-	waitErr := computeOperationWaitZoneTime(config, op, project, zone.Name, createTimeout, "instance to create")
+	waitErr := computeOperationWaitTime(config, op, project, "instance to create", createTimeout)
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -1107,7 +1107,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Error updating metadata: %s", err)
 			}
 
-			opErr := computeOperationWaitZone(config, op, project, zone, "metadata to update")
+			opErr := computeOperationWait(config, op, project, "metadata to update")
 			if opErr != nil {
 				return opErr
 			}
@@ -1127,7 +1127,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeOperationWaitZone(config, op, project, zone, "tags to update")
+		opErr := computeOperationWait(config, op, project, "tags to update")
 		if opErr != nil {
 			return opErr
 		}
@@ -1145,7 +1145,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := computeOperationWaitZone(config, op, project, zone, "labels to update")
+		opErr := computeOperationWait(config, op, project, "labels to update")
 		if opErr != nil {
 			return opErr
 		}
@@ -1176,8 +1176,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating scheduling policy: %s", err)
 		}
 
-		opErr := computeOperationWaitZone(config, op, project, zone,
-			"scheduling policy update")
+		opErr := computeOperationWait(config, op, project, "scheduling policy update")
 		if opErr != nil {
 			return opErr
 		}
@@ -1218,8 +1217,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					if err != nil {
 						return fmt.Errorf("Error deleting old access_config: %s", err)
 					}
-					opErr := computeOperationWaitZone(config, op, project, zone,
-						"old access_config to delete")
+					opErr := computeOperationWait(config, op, project, "old access_config to delete")
 					if opErr != nil {
 						return opErr
 					}
@@ -1238,8 +1236,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					if err != nil {
 						return fmt.Errorf("Error adding new access_config: %s", err)
 					}
-					opErr := computeOperationWaitZone(config, op, project, zone,
-						"new access_config to add")
+					opErr := computeOperationWait(config, op, project, "new access_config to add")
 					if opErr != nil {
 						return opErr
 					}
@@ -1270,7 +1267,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Wait for the operation to complete
-	opErr := computeOperationWaitZone(config, op, project, zone, "instance to delete")
+	opErr := computeOperationWait(config, op, project, "instance to delete")
 	if opErr != nil {
 		return opErr
 	}

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -153,7 +153,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(fmt.Sprintf("%s/%s", zone, name))
 
 	// Wait for the operation to complete
-	err = computeOperationWaitZone(config, op, project, zone, "Creating InstanceGroup")
+	err = computeOperationWait(config, op, project, "Creating InstanceGroup")
 	if err != nil {
 		d.SetId("")
 		return err
@@ -177,7 +177,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		// Wait for the operation to complete
-		err = computeOperationWaitZone(config, op, project, zone, "Adding instances to InstanceGroup")
+		err = computeOperationWait(config, op, project, "Adding instances to InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 				}
 			} else {
 				// Wait for the operation to complete
-				err = computeOperationWaitZone(config, removeOp, project, zone, "Updating InstanceGroup")
+				err = computeOperationWait(config, removeOp, project, "Updating InstanceGroup")
 				if err != nil {
 					return err
 				}
@@ -302,7 +302,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWaitZone(config, addOp, project, zone, "Updating InstanceGroup")
+			err = computeOperationWait(config, addOp, project, "Updating InstanceGroup")
 			if err != nil {
 				return err
 			}
@@ -325,7 +325,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
 		}
 
-		err = computeOperationWaitZone(config, op, project, zone, "Updating InstanceGroup")
+		err = computeOperationWait(config, op, project, "Updating InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -352,7 +352,7 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}
 
-	err = computeOperationWaitZone(config, op, project, zone, "Deleting InstanceGroup")
+	err = computeOperationWait(config, op, project, "Deleting InstanceGroup")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -668,7 +668,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
-		err = computeOperationWaitZone(config, op, config.Project, rs.Primary.Attributes["zone"], "Waiting on stop")
+		err = computeOperationWait(config, op, config.Project, "Waiting on stop")
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -682,7 +682,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}
-		err = computeOperationWaitZone(config, op, config.Project, rs.Primary.Attributes["zone"], "Waiting machine type change")
+		err = computeOperationWait(config, op, config.Project, "Waiting machine type change")
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -112,7 +112,7 @@ func resourceComputeSnapshotCreate(d *schema.ResourceData, meta interface{}) err
 	// It probably maybe worked, so store the ID now
 	d.SetId(snapshot.Name)
 
-	err = computeOperationWaitZone(config, op, project, d.Get("zone").(string), "Creating Snapshot")
+	err = computeOperationWait(config, op, project, "Creating Snapshot")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Third and final followup to #191.

Removed the last old set of wait methods for `compute_operation.go` and used the universal wait method.

Tests:

```
TF_ACC=1 go test ./google -v -run=TestAccComputeInstanceGroup_basic -timeout 120m
=== RUN   TestAccComputeInstanceGroup_basic
--- PASS: TestAccComputeInstanceGroup_basic (81.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	81.871s
```

```
TF_ACC=1 go test ./google -v -run=TestAccInstanceGroupManager_basic -timeout 120m
=== RUN   TestAccInstanceGroupManager_basic
--- PASS: TestAccInstanceGroupManager_basic (212.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	212.805s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeInstance_b -timeout 120m
=== RUN   TestAccComputeInstance_basic_deprecated_network
--- PASS: TestAccComputeInstance_basic_deprecated_network (62.67s)
=== RUN   TestAccComputeInstance_basic1
--- PASS: TestAccComputeInstance_basic1 (62.02s)
=== RUN   TestAccComputeInstance_basic2
--- PASS: TestAccComputeInstance_basic2 (52.93s)
=== RUN   TestAccComputeInstance_basic3
--- PASS: TestAccComputeInstance_basic3 (59.43s)
=== RUN   TestAccComputeInstance_basic4
--- PASS: TestAccComputeInstance_basic4 (52.03s)
=== RUN   TestAccComputeInstance_basic5
--- PASS: TestAccComputeInstance_basic5 (49.07s)
=== RUN   TestAccComputeInstance_bootDisk_source
--- PASS: TestAccComputeInstance_bootDisk_source (74.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	413.048s
```

```
TF_ACC=1 go test ./google -v -run=TestAccComputeInstance_forceChangeMachineTypeManually -timeout 120m
=== RUN   TestAccComputeInstance_forceChangeMachineTypeManually
--- PASS: TestAccComputeInstance_forceChangeMachineTypeManually (75.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	75.357s
```

