### PR TITLE
Document that TF falls back to using the application default credentials.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -36,11 +36,10 @@ The following keys can be used to configure the provider.
 
 * `credentials` - (Optional) Contents of the JSON file used to describe your
   account credentials, downloaded from Google Cloud Console. More details on
-  retrieving this file are below. Credentials may be blank if you are running
-  Terraform from a GCE instance with a properly-configured [Compute Engine
-  Service Account](https://cloud.google.com/compute/docs/authentication). This
-  can also be specified using any of the following environment variables
-  (listed in order of precedence):
+  retrieving this file are below.
+
+  Credentials can also be specified using any of the following environment
+  variables (listed in order of precedence):
 
     * `GOOGLE_CREDENTIALS`
     * `GOOGLE_CLOUD_KEYFILE_JSON`
@@ -49,6 +48,17 @@ The following keys can be used to configure the provider.
     The [`GOOGLE_APPLICATION_CREDENTIALS`](https://developers.google.com/identity/protocols/application-default-credentials#howtheywork)
     environment variable can also contain the path of a file to obtain credentials
     from.
+
+  If no credentials are specified, the provider will fall back to using the
+  [Google Application Default
+  Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+  If you are running Terraform from a GCE instance, see [Creating and Enabling
+  Service Accounts for
+  Instances](https://cloud.google.com/compute/docs/authentication) for
+  details. On your computer, if you have made your identity available as the
+  Application Default Credentials by running [`gcloud auth application-default
+  login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login),
+  the provider will use your identity.
 
 * `project` - (Required) The ID of the project to apply any resources to.  This
   can be specified using any of the following environment variables (listed in


### PR DESCRIPTION
Document that the Terraform Google Provider will fall back to using the Application Default Credentials. In particular, it will use the user's identify if the user has made his credentials available by running gcloud auth application-default login.

This came up in https://github.com/terraform-providers/terraform-provider-google/pull/136#issuecomment-318504119.