### PR TITLE
Add Beta support & Beta feature ip_version to google_compute_global_forwarding_rule

### DIFF
--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -5,6 +5,25 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+func computeSharedOperationWait(config *Config, op interface{}, project string, activity string) error {
+	return computeSharedOperationWaitTime(config, op, project, 4, activity)
+}
+
+func computeSharedOperationWaitTime(config *Config, op interface{}, project string, minutes int, activity string) error {
+	if op == nil {
+		panic("Attempted to wait on an Operation that was nil.")
+	}
+
+	switch op.(type) {
+	case *compute.Operation:
+		return computeOperationWaitTime(config, op.(*compute.Operation), project, activity, minutes)
+	case *computeBeta.Operation:
+		return computeBetaOperationWaitGlobalTime(config, op.(*computeBeta.Operation), project, activity, minutes)
+	default:
+		panic("Attempted to wait on an Operation of unknown type.")
+	}
+}
+
 func computeSharedOperationWaitZone(config *Config, op interface{}, project string, zone, activity string) error {
 	return computeSharedOperationWaitZoneTime(config, op, project, zone, 4, activity)
 }

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -29,8 +29,9 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			},
 
 			"target": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 
 			"description": &schema.Schema{

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -5,8 +5,13 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
+
+var GlobalForwardingRuleBaseApiVersion = v1
+var GlobalForwardingRuleVersionedFeatures = []Feature{}
 
 func resourceComputeGlobalForwardingRule() *schema.Resource {
 	return &schema.Resource{
@@ -75,6 +80,7 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 }
 
 func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalForwardingRuleBaseApiVersion, GlobalForwardingRuleVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -82,7 +88,7 @@ func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	frule := &compute.ForwardingRule{
+	frule := &computeBeta.ForwardingRule{
 		IPAddress:   d.Get("ip_address").(string),
 		IPProtocol:  d.Get("ip_protocol").(string),
 		Description: d.Get("description").(string),
@@ -91,16 +97,36 @@ func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta inte
 		Target:      d.Get("target").(string),
 	}
 
-	op, err := config.clientCompute.GlobalForwardingRules.Insert(
-		project, frule).Do()
-	if err != nil {
-		return fmt.Errorf("Error creating Global Forwarding Rule: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		v1Frule := &compute.ForwardingRule{}
+		err = Convert(frule, v1Frule)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientCompute.GlobalForwardingRules.Insert(project, v1Frule).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating Global Forwarding Rule: %s", err)
+		}
+	case v0beta:
+		v0BetaFrule := &computeBeta.ForwardingRule{}
+		err = Convert(frule, v0BetaFrule)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientComputeBeta.GlobalForwardingRules.Insert(project, v0BetaFrule).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating Global Forwarding Rule: %s", err)
+		}
 	}
 
 	// It probably maybe worked, so store the ID now
 	d.SetId(frule.Name)
 
-	err = computeOperationWait(config, op, project, "Creating Global Fowarding Rule")
+	err = computeSharedOperationWait(config, op, project, "Creating Global Fowarding Rule")
 	if err != nil {
 		return err
 	}
@@ -109,6 +135,7 @@ func resourceComputeGlobalForwardingRuleCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceComputeGlobalForwardingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersionUpdate(d, GlobalForwardingRuleBaseApiVersion, GlobalForwardingRuleVersionedFeatures, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -119,15 +146,38 @@ func resourceComputeGlobalForwardingRuleUpdate(d *schema.ResourceData, meta inte
 	d.Partial(true)
 
 	if d.HasChange("target") {
-		target_name := d.Get("target").(string)
-		target_ref := &compute.TargetReference{Target: target_name}
-		op, err := config.clientCompute.GlobalForwardingRules.SetTarget(
-			project, d.Id(), target_ref).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating target: %s", err)
+		target := d.Get("target").(string)
+		targetRef := &computeBeta.TargetReference{Target: target}
+
+		var op interface{}
+		switch computeApiVersion {
+		case v1:
+			v1TargetRef := &compute.TargetReference{}
+			err = Convert(targetRef, v1TargetRef)
+			if err != nil {
+				return err
+			}
+
+			op, err = config.clientCompute.GlobalForwardingRules.SetTarget(
+				project, d.Id(), v1TargetRef).Do()
+			if err != nil {
+				return fmt.Errorf("Error updating target: %s", err)
+			}
+		case v0beta:
+			v0BetaTargetRef := &compute.TargetReference{}
+			err = Convert(targetRef, v0BetaTargetRef)
+			if err != nil {
+				return err
+			}
+
+			op, err = config.clientCompute.GlobalForwardingRules.SetTarget(
+				project, d.Id(), v0BetaTargetRef).Do()
+			if err != nil {
+				return fmt.Errorf("Error updating target: %s", err)
+			}
 		}
 
-		err = computeOperationWait(config, op, project, "Updating Global Forwarding Rule")
+		err = computeSharedOperationWait(config, op, project, "Updating Global Forwarding Rule")
 		if err != nil {
 			return err
 		}
@@ -141,6 +191,7 @@ func resourceComputeGlobalForwardingRuleUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalForwardingRuleBaseApiVersion, GlobalForwardingRuleVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -148,10 +199,28 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	frule, err := config.clientCompute.GlobalForwardingRules.Get(
-		project, d.Id()).Do()
-	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("Global Forwarding Rule %q", d.Get("name").(string)))
+	frule := &computeBeta.ForwardingRule{}
+	switch computeApiVersion {
+	case v1:
+		v1Frule, err := config.clientCompute.GlobalForwardingRules.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Global Forwarding Rule %q", d.Get("name").(string)))
+		}
+
+		err = Convert(v1Frule, frule)
+		if err != nil {
+			return err
+		}
+	case v0beta:
+		v0BetaFrule, err := config.clientComputeBeta.GlobalForwardingRules.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Global Forwarding Rule %q", d.Get("name").(string)))
+		}
+
+		err = Convert(v0BetaFrule, frule)
+		if err != nil {
+			return err
+		}
 	}
 
 	d.Set("ip_address", frule.IPAddress)
@@ -162,6 +231,7 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 }
 
 func resourceComputeGlobalForwardingRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, GlobalForwardingRuleBaseApiVersion, GlobalForwardingRuleVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -171,13 +241,21 @@ func resourceComputeGlobalForwardingRuleDelete(d *schema.ResourceData, meta inte
 
 	// Delete the GlobalForwardingRule
 	log.Printf("[DEBUG] GlobalForwardingRule delete request")
-	op, err := config.clientCompute.GlobalForwardingRules.Delete(
-		project, d.Id()).Do()
-	if err != nil {
-		return fmt.Errorf("Error deleting GlobalForwardingRule: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		op, err = config.clientCompute.GlobalForwardingRules.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting GlobalForwardingRule: %s", err)
+		}
+	case v0beta:
+		op, err = config.clientComputeBeta.GlobalForwardingRules.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting GlobalForwardingRule: %s", err)
+		}
 	}
 
-	err = computeOperationWait(config, op, project, "Deleting GlobalForwarding Rule")
+	err = computeSharedOperationWait(config, op, project, "Deleting GlobalForwarding Rule")
 	if err != nil {
 		return err
 	}

--- a/google/resource_compute_global_forwarding_rule_test.go
+++ b/google/resource_compute_global_forwarding_rule_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
 )
 
 func TestAccComputeGlobalForwardingRule_basic(t *testing.T) {
@@ -65,6 +67,36 @@ func TestAccComputeGlobalForwardingRule_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeGlobalForwardingRule_ipv6(t *testing.T) {
+	var frule computeBeta.ForwardingRule
+
+	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	proxy1 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	proxy2 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	backend := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	urlmap := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeGlobalForwardingRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeGlobalForwardingRule_ipv6(fr, proxy1, proxy2, backend, hc, urlmap),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaGlobalForwardingRuleExists(
+						"google_compute_global_forwarding_rule.foobar", &frule),
+				),
+			},
+		},
+	})
+
+	if frule.IpVersion != "IPV6" {
+		t.Errorf("Expected IP version to be IPV6, got %s", frule.IpVersion)
+	}
+}
+
 func testAccCheckComputeGlobalForwardingRuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -105,6 +137,35 @@ func testAccCheckComputeGlobalForwardingRuleExists(n string) resource.TestCheckF
 		if found.Name != rs.Primary.ID {
 			return fmt.Errorf("Global Forwarding Rule not found")
 		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeBetaGlobalForwardingRuleExists(n string, frule *computeBeta.ForwardingRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientComputeBeta.GlobalForwardingRules.Get(
+			config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Global Forwarding Rule not found")
+		}
+
+		*frule = *found
 
 		return nil
 	}
@@ -175,6 +236,64 @@ func testAccComputeGlobalForwardingRule_basic2(fr, proxy1, proxy2, backend, hc, 
 		name = "%s"
 		port_range = "80"
 		target = "${google_compute_target_http_proxy.foobar2.self_link}"
+	}
+
+	resource "google_compute_target_http_proxy" "foobar1" {
+		description = "Resource created for Terraform acceptance testing"
+		name = "%s"
+		url_map = "${google_compute_url_map.foobar.self_link}"
+	}
+
+	resource "google_compute_target_http_proxy" "foobar2" {
+		description = "Resource created for Terraform acceptance testing"
+		name = "%s"
+		url_map = "${google_compute_url_map.foobar.self_link}"
+	}
+
+	resource "google_compute_backend_service" "foobar" {
+		name = "%s"
+		health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+	}
+
+	resource "google_compute_http_health_check" "zero" {
+		name = "%s"
+		request_path = "/"
+		check_interval_sec = 1
+		timeout_sec = 1
+	}
+
+	resource "google_compute_url_map" "foobar" {
+		name = "%s"
+		default_service = "${google_compute_backend_service.foobar.self_link}"
+		host_rule {
+			hosts = ["mysite.com", "myothersite.com"]
+			path_matcher = "boop"
+		}
+		path_matcher {
+			default_service = "${google_compute_backend_service.foobar.self_link}"
+			name = "boop"
+			path_rule {
+				paths = ["/*"]
+				service = "${google_compute_backend_service.foobar.self_link}"
+			}
+		}
+		test {
+			host = "mysite.com"
+			path = "/*"
+			service = "${google_compute_backend_service.foobar.self_link}"
+		}
+	}`, fr, proxy1, proxy2, backend, hc, urlmap)
+}
+
+func testAccComputeGlobalForwardingRule_ipv6(fr, proxy1, proxy2, backend, hc, urlmap string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_global_forwarding_rule" "foobar" {
+		description = "Resource created for Terraform acceptance testing"
+		ip_protocol = "TCP"
+		name = "%s"
+		port_range = "80"
+		target = "${google_compute_target_http_proxy.foobar1.self_link}"
+		ip_version = "IPV6"
 	}
 
 	resource "google_compute_target_http_proxy" "foobar1" {

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -96,6 +96,11 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
+- - -
+
+* `ip_version` - (Optional, Beta) The IP Version that will be used by this address.
+One of `"IPV4"` or `"IPV6"`.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
Waiting on #249 to merge, but otherwise able to be reviewed.
The third commit duplicates some code in #250. I'm either going to base it into the first commit if this merges first, or merge #250 first.

- Convert `google_compute_global_forwarding_rule` to a versioned resource with Beta support.
- Add support for the Beta field `ip_version` to `google_compute_global_forwarding_rule`

Explicitly setting `IPV4` on a `v1` resource forces a recreate as you're going from `""` to `IPV4` and this resource can't update; this is working as expected based on #185. We don't have enough information at refresh time to perform the read at `v0beta`.

Part 2/2 of #245.
Related to #93 