### PR TITLE
Add google_compute_network_peering docs page to the sidebar and fix the labels for all resources

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_instance"
-sidebar_current: "docs-google-compute-instance"
+sidebar_current: "docs-google-compute-instance-x"
 description: |-
   Manages a VM instance resource within GCE.
 ---

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_instance_group"
-sidebar_current: "docs-google-compute-instance-group"
+sidebar_current: "docs-google-compute-instance-group-x"
 description: |-
   Manages an Instance Group within GCE.
 ---

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_network"
-sidebar_current: "docs-google-compute-network"
+sidebar_current: "docs-google-compute-network-x"
 description: |-
   Manages a network within GCE.
 ---

--- a/website/docs/r/compute_route.html.markdown
+++ b/website/docs/r/compute_route.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_route"
-sidebar_current: "docs-google-compute-route"
+sidebar_current: "docs-google-compute-route-x"
 description: |-
   Manages a network route within GCE.
 ---

--- a/website/docs/r/compute_router.html.markdown
+++ b/website/docs/r/compute_router.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_router"
-sidebar_current: "docs-google-compute-router"
+sidebar_current: "docs-google-compute-router-x"
 description: |-
   Manages a Cloud Router resource.
 ---

--- a/website/docs/r/google_project.html.markdown
+++ b/website/docs/r/google_project.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_project"
-sidebar_current: "docs-google-project"
+sidebar_current: "docs-google-project-x"
 description: |-
  Allows management of a Google Cloud Platform project.
 ---

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_sql_database"
-sidebar_current: "docs-google-sql-database"
+sidebar_current: "docs-google-sql-database-x"
 description: |-
   Creates a new SQL database in Google Cloud SQL.
 ---

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_storage_bucket"
-sidebar_current: "docs-google-storage-bucket"
+sidebar_current: "docs-google-storage-bucket-x"
 description: |-
   Creates a new bucket in Google Cloud Storage.
 ---

--- a/website/google.erb
+++ b/website/google.erb
@@ -62,7 +62,7 @@
     <li<%= sidebar_current("docs-google-(project|service)") %>>
     <a href="#">Google Cloud Platform Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-project") %>>
+      <li<%= sidebar_current("docs-google-project-x") %>>
       <a href="/docs/providers/google/r/google_project.html">google_project</a>
             </li>
             <li<%= sidebar_current("docs-google-project-iam-binding") %>>
@@ -138,11 +138,11 @@
       <a href="/docs/providers/google/r/compute_image.html">google_compute_image</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance") %>>
+      <li<%= sidebar_current("docs-google-compute-instance-x") %>>
       <a href="/docs/providers/google/r/compute_instance.html">google_compute_instance</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-group") %>>
+      <li<%= sidebar_current("docs-google-compute-instance-group-x") %>>
       <a href="/docs/providers/google/r/compute_instance_group.html">google_compute_instance_group</a>
       </li>
 
@@ -174,11 +174,11 @@
       <a href="/docs/providers/google/r/compute_region_backend_service.html">google_compute_region_backend_service</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-route") %>>
+      <li<%= sidebar_current("docs-google-compute-route-x") %>>
       <a href="/docs/providers/google/r/compute_route.html">google_compute_route</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-router") %>>
+      <li<%= sidebar_current("docs-google-compute-router-x") %>>
       <a href="/docs/providers/google/r/compute_router.html">google_compute_router</a>
       </li>
 
@@ -270,7 +270,7 @@
     <li<%= sidebar_current("docs-google-sql") %>>
     <a href="#">Google SQL Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-sql-database") %>>
+      <li<%= sidebar_current("docs-google-sql-database-x") %>>
       <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
       </li>
 
@@ -287,7 +287,7 @@
     <li<%= sidebar_current("docs-google-storage") %>>
     <a href="#">Google Storage Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-storage-bucket") %>>
+      <li<%= sidebar_current("docs-google-storage-bucket-x") %>>
       <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
       </li>
 

--- a/website/google.erb
+++ b/website/google.erb
@@ -154,6 +154,10 @@
       <a href="/docs/providers/google/r/compute_instance_template.html">google_compute_instance_template</a>
       </li>
 
+      <li<%= sidebar_current("docs-google-compute-network-peering") %>>
+      <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
+      </li>
+
       <li<%= sidebar_current("docs-google-compute-network") %>>
       <a href="/docs/providers/google/r/compute_network.html">google_compute_network</a>
       </li>

--- a/website/google.erb
+++ b/website/google.erb
@@ -158,7 +158,7 @@
       <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-network") %>>
+      <li<%= sidebar_current("docs-google-compute-network-x") %>>
       <a href="/docs/providers/google/r/compute_network.html">google_compute_network</a>
       </li>
 


### PR DESCRIPTION
Forgot to update the sidebar menu earlier when adding the docs for the new `google_compute_network_peering` resource.

cc/ @rileykarson 