### PR TITLE
Fix disk type’Malformed URL’ error

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1375,7 +1375,7 @@ func expandBootDisk(d *schema.ResourceData, config *Config, zone *compute.Zone, 
 			if err != nil {
 				return nil, fmt.Errorf("Error loading disk type '%s': %s", diskTypeName, err)
 			}
-			disk.InitializeParams.DiskType = diskType.Name
+			disk.InitializeParams.DiskType = diskType.SelfLink
 		}
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.image"); ok {


### PR DESCRIPTION
The API expects the disk type to be a SelfLink URL, but the disk type 
name was being used (e.g. “pd-ssd”). This resulted in the following error:

```
Error applying plan:

1 error(s) occurred:

* google_compute_instance.foo: 1 error(s) occurred:

* google_compute_instance.foo: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.diskType': 'pd-ssd'. The URL is malformed., invalid
```