### PR TITLE
Add Beta support & Beta feature deny to google_compute_firewall

### DIFF
--- a/google/compute_shared_operation.go
+++ b/google/compute_shared_operation.go
@@ -5,6 +5,25 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+func computeSharedOperationWait(config *Config, op interface{}, project string, activity string) error {
+	return computeSharedOperationWaitTime(config, op, project, 4, activity)
+}
+
+func computeSharedOperationWaitTime(config *Config, op interface{}, project string, minutes int, activity string) error {
+	if op == nil {
+		panic("Attempted to wait on an Operation that was nil.")
+	}
+
+	switch op.(type) {
+	case *compute.Operation:
+		return computeOperationWaitTime(config, op.(*compute.Operation), project, activity, minutes)
+	case *computeBeta.Operation:
+		return computeBetaOperationWaitGlobalTime(config, op.(*computeBeta.Operation), project, activity, minutes)
+	default:
+		panic("Attempted to wait on an Operation of unknown type.")
+	}
+}
+
 func computeSharedOperationWaitZone(config *Config, op interface{}, project string, zone, activity string) error {
 	return computeSharedOperationWaitZoneTime(config, op, project, zone, 4, activity)
 }

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -71,12 +71,14 @@ func resourceComputeFirewall() *schema.Resource {
 						"protocol": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"ports": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+							ForceNew: true,
 						},
 					},
 				},

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -360,32 +360,9 @@ func resourceFirewall(d *schema.ResourceData, meta interface{}, computeApiVersio
 	config := meta.(*Config)
 	project, _ := getProject(d, config)
 
-	network := &computeBeta.Network{}
-	switch computeApiVersion {
-	case v1:
-		// Look up the network to attach the firewall to
-		networkV1, err := config.clientCompute.Networks.Get(
-			project, d.Get("network").(string)).Do()
-		if err != nil {
-			return nil, fmt.Errorf("Error reading network: %s", err)
-		}
-
-		err = Convert(networkV1, network)
-		if err != nil {
-			return nil, err
-		}
-	case v0beta:
-		// Look up the network to attach the firewall to
-		networkV0Beta, err := config.clientComputeBeta.Networks.Get(
-			project, d.Get("network").(string)).Do()
-		if err != nil {
-			return nil, fmt.Errorf("Error reading network: %s", err)
-		}
-
-		err = Convert(networkV0Beta, network)
-		if err != nil {
-			return nil, err
-		}
+	network, err := config.clientCompute.Networks.Get(project, d.Get("network").(string)).Do()
+	if err != nil {
+		return nil, fmt.Errorf("Error reading network: %s", err)
 	}
 
 	// Build up the list of allowed entries

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -80,7 +80,7 @@ func resourceComputeFirewall() *schema.Resource {
 						},
 					},
 				},
-				Set:      resourceComputeFirewallRuleHash,
+				Set: resourceComputeFirewallRuleHash,
 
 				// Unlike allow, deny can't be updated upstream
 				ForceNew: true,

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
+
+var FirewallBaseApiVersion = v1
+var FirewallVersionedFeatures = []Feature{}
 
 func resourceComputeFirewall() *schema.Resource {
 	return &schema.Resource{
@@ -118,6 +123,7 @@ func resourceComputeFirewallAllowHash(v interface{}) int {
 }
 
 func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, FirewallBaseApiVersion, FirewallVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -125,21 +131,41 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	firewall, err := resourceFirewall(d, meta)
+	firewall, err := resourceFirewall(d, meta, computeApiVersion)
 	if err != nil {
 		return err
 	}
 
-	op, err := config.clientCompute.Firewalls.Insert(
-		project, firewall).Do()
-	if err != nil {
-		return fmt.Errorf("Error creating firewall: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		firewallV1 := &compute.Firewall{}
+		err := Convert(firewall, firewallV1)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientCompute.Firewalls.Insert(project, firewallV1).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating firewall: %s", err)
+		}
+	case v0beta:
+		firewallV0Beta := &computeBeta.Firewall{}
+		err := Convert(firewall, firewallV0Beta)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientComputeBeta.Firewalls.Insert(project, firewallV0Beta).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating firewall: %s", err)
+		}
 	}
 
 	// It probably maybe worked, so store the ID now
 	d.SetId(firewall.Name)
 
-	err = computeOperationWait(config, op, project, "Creating Firewall")
+	err = computeSharedOperationWait(config, op, project, "Creating Firewall")
 	if err != nil {
 		return err
 	}
@@ -147,7 +173,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceComputeFirewallRead(d, meta)
 }
 
-func flattenAllowed(allowed []*compute.FirewallAllowed) []map[string]interface{} {
+func flattenAllowed(allowed []*computeBeta.FirewallAllowed) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(allowed))
 	for _, allow := range allowed {
 		allowMap := make(map[string]interface{})
@@ -160,6 +186,7 @@ func flattenAllowed(allowed []*compute.FirewallAllowed) []map[string]interface{}
 }
 
 func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, FirewallBaseApiVersion, FirewallVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -167,14 +194,32 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	firewall, err := config.clientCompute.Firewalls.Get(
-		project, d.Id()).Do()
-	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("Firewall %q", d.Get("name").(string)))
+	firewall := &computeBeta.Firewall{}
+	switch computeApiVersion {
+	case v1:
+		firewallV1, err := config.clientCompute.Firewalls.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Firewall %q", d.Get("name").(string)))
+		}
+
+		err = Convert(firewallV1, firewall)
+		if err != nil {
+			return err
+		}
+	case v0beta:
+		firewallV0Beta, err := config.clientComputeBeta.Firewalls.Get(project, d.Id()).Do()
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("Firewall %q", d.Get("name").(string)))
+		}
+
+		err = Convert(firewallV0Beta, firewall)
+		if err != nil {
+			return err
+		}
 	}
 
 	networkUrl := strings.Split(firewall.Network, "/")
-	d.Set("self_link", firewall.SelfLink)
+	d.Set("self_link", ConvertSelfLinkToV1(firewall.SelfLink))
 	d.Set("name", firewall.Name)
 	d.Set("network", networkUrl[len(networkUrl)-1])
 	d.Set("description", firewall.Description)
@@ -187,6 +232,7 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersionUpdate(d, FirewallBaseApiVersion, FirewallVersionedFeatures, []Feature{})
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -196,18 +242,38 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 
 	d.Partial(true)
 
-	firewall, err := resourceFirewall(d, meta)
+	firewall, err := resourceFirewall(d, meta, computeApiVersion)
 	if err != nil {
 		return err
 	}
 
-	op, err := config.clientCompute.Firewalls.Update(
-		project, d.Id(), firewall).Do()
-	if err != nil {
-		return fmt.Errorf("Error updating firewall: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		firewallV1 := &compute.Firewall{}
+		err := Convert(firewall, firewallV1)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientCompute.Firewalls.Update(project, d.Id(), firewallV1).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating firewall: %s", err)
+		}
+	case v0beta:
+		firewallV0Beta := &computeBeta.Firewall{}
+		err := Convert(firewall, firewallV0Beta)
+		if err != nil {
+			return err
+		}
+
+		op, err = config.clientComputeBeta.Firewalls.Update(project, d.Id(), firewallV0Beta).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating firewall: %s", err)
+		}
 	}
 
-	err = computeOperationWait(config, op, project, "Updating Firewall")
+	err = computeSharedOperationWait(config, op, project, "Updating Firewall")
 	if err != nil {
 		return err
 	}
@@ -218,6 +284,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+	computeApiVersion := getComputeApiVersion(d, FirewallBaseApiVersion, FirewallVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -226,13 +293,21 @@ func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Delete the firewall
-	op, err := config.clientCompute.Firewalls.Delete(
-		project, d.Id()).Do()
-	if err != nil {
-		return fmt.Errorf("Error deleting firewall: %s", err)
+	var op interface{}
+	switch computeApiVersion {
+	case v1:
+		op, err = config.clientCompute.Firewalls.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting firewall: %s", err)
+		}
+	case v0beta:
+		op, err = config.clientComputeBeta.Firewalls.Delete(project, d.Id()).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting firewall: %s", err)
+		}
 	}
 
-	err = computeOperationWait(config, op, project, "Deleting Firewall")
+	err = computeSharedOperationWait(config, op, project, "Deleting Firewall")
 	if err != nil {
 		return err
 	}
@@ -241,24 +316,42 @@ func resourceComputeFirewallDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceFirewall(
-	d *schema.ResourceData,
-	meta interface{}) (*compute.Firewall, error) {
+func resourceFirewall(d *schema.ResourceData, meta interface{}, computeApiVersion ComputeApiVersion) (*computeBeta.Firewall, error) {
 	config := meta.(*Config)
-
 	project, _ := getProject(d, config)
 
-	// Look up the network to attach the firewall to
-	network, err := config.clientCompute.Networks.Get(
-		project, d.Get("network").(string)).Do()
-	if err != nil {
-		return nil, fmt.Errorf("Error reading network: %s", err)
+	network := &computeBeta.Network{}
+	switch computeApiVersion {
+	case v1:
+		// Look up the network to attach the firewall to
+		networkV1, err := config.clientCompute.Networks.Get(
+			project, d.Get("network").(string)).Do()
+		if err != nil {
+			return nil, fmt.Errorf("Error reading network: %s", err)
+		}
+
+		err = Convert(networkV1, network)
+		if err != nil {
+			return nil, err
+		}
+	case v0beta:
+		// Look up the network to attach the firewall to
+		networkV0Beta, err := config.clientComputeBeta.Networks.Get(
+			project, d.Get("network").(string)).Do()
+		if err != nil {
+			return nil, fmt.Errorf("Error reading network: %s", err)
+		}
+
+		err = Convert(networkV0Beta, network)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Build up the list of allowed entries
-	var allowed []*compute.FirewallAllowed
+	var allowed []*computeBeta.FirewallAllowed
 	if v := d.Get("allow").(*schema.Set); v.Len() > 0 {
-		allowed = make([]*compute.FirewallAllowed, 0, v.Len())
+		allowed = make([]*computeBeta.FirewallAllowed, 0, v.Len())
 		for _, v := range v.List() {
 			m := v.(map[string]interface{})
 
@@ -270,7 +363,7 @@ func resourceFirewall(
 				}
 			}
 
-			allowed = append(allowed, &compute.FirewallAllowed{
+			allowed = append(allowed, &computeBeta.FirewallAllowed{
 				IPProtocol: m["protocol"].(string),
 				Ports:      ports,
 			})
@@ -302,7 +395,7 @@ func resourceFirewall(
 	}
 
 	// Build the firewall parameter
-	return &compute.Firewall{
+	return &computeBeta.Firewall{
 		Name:         d.Get("name").(string),
 		Description:  d.Get("description").(string),
 		Network:      network.SelfLink,

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -61,7 +61,6 @@ The following arguments are supported:
 
 - - -
 
-
 * `deny` - (Optional, Beta) Can be specified multiple times for each deny
     rule. Each deny block supports fields documented below. Can be specified
     instead of allow.

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -59,7 +59,21 @@ The following arguments are supported:
 
 * `target_tags` - (Optional) A list of target tags for this firewall.
 
+- - -
+
+
+* `deny` - (Optional, Beta) Can be specified multiple times for each deny
+    rule. Each deny block supports fields documented below. Can be specified
+    instead of allow.
+
 The `allow` block supports:
+
+* `protocol` - (Required) The name of the protocol to allow.
+
+* `ports` - (Optional) List of ports and/or port ranges to allow. This can
+    only be specified if the protocol is TCP or UDP.
+
+The `deny` block supports:
 
 * `protocol` - (Required) The name of the protocol to allow.
 


### PR DESCRIPTION
- Convert `google_compute_firewall` to a versioned resource with Beta support.
- Add support for the Beta field `deny` to `google_compute_firewall`

`deny` is not able to be updated by the API yet.

I'm not sure what to do here docs-wise where a Beta feature makes a GA field no longer Required; one of `allow` or `deny` is, so I kept `allow` required in docs and said `deny` can replace it. Let me know your thoughts.

Fixes #148.
Related to #93 