### PR TITLE
Add a test that multiple nics work in google_compute_instance.

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 * `zone` - (Required) The zone that the machine should be created in.
 
 * `network_interface` - (Required) Networks to attach to the instance. This can
-    be specified multiple times. Structure is documented below.
+    be specified multiple times; multiple `network_interface` support is in Beta. Structure is documented below.
 
 - - -
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -71,8 +71,7 @@ The following arguments are supported:
 * `zone` - (Required) The zone that the machine should be created in.
 
 * `network_interface` - (Required) Networks to attach to the instance. This can
-    be specified multiple times for multiple networks, but GCE is currently
-    limited to just 1. Structure is documented below.
+    be specified multiple times. Structure is documented below.
 
 - - -
 


### PR DESCRIPTION
It looks like our code already supports multiple `network_interface` fields on `google_compute_instance`. 
Let's document that the API accepts multiple interfaces, although it is a Beta feature.

Fixes #82 