### PR TITLE
Allow upgrading GKE versions and provide better error message handling

### DIFF
--- a/google/container_operation.go
+++ b/google/container_operation.go
@@ -33,6 +33,10 @@ func (w *ContainerOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
 			return nil, "", err
 		}
 
+		if resp.StatusMessage != "" {
+			return resp, resp.Status, fmt.Errorf(resp.StatusMessage)
+		}
+
 		log.Printf("[DEBUG] Progress of operation %q: %q", w.Op.Name, resp.Status)
 
 		return resp, resp.Status, err

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -576,7 +576,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return waitErr
 		}
 
-		log.Printf("[INFO] GKE cluster %s has been updated to %s", d.Id(),
+		log.Printf("[INFO] GKE cluster %s: master has been updated to %s", d.Id(),
 			desiredNodeVersion)
 
 		// Update the nodes
@@ -597,7 +597,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return waitErr
 		}
 
-		log.Printf("[INFO] GKE cluster %s has been updated to %s", d.Id(),
+		log.Printf("[INFO] GKE cluster %s: nodes have been updated to %s", d.Id(),
 			desiredNodeVersion)
 
 		d.SetPartial("node_version")

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -120,13 +120,41 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 }
 
 func TestAccContainerCluster_withVersion(t *testing.T) {
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withVersion,
+				Config: testAccContainerCluster_withVersion(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerCluster(
+						"google_container_cluster.with_version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_updateVersion(t *testing.T) {
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withLowerVersion(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerCluster(
+						"google_container_cluster.with_version"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_withVersion(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_version"),
@@ -571,7 +599,8 @@ resource "google_container_cluster" "with_legacy_abac" {
 }`, clusterName)
 }
 
-var testAccContainerCluster_withVersion = fmt.Sprintf(`
+func testAccContainerCluster_withVersion(clusterName string) string {
+	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
 	zone = "us-central1-a"
 }
@@ -586,7 +615,27 @@ resource "google_container_cluster" "with_version" {
 		username = "mr.yoda"
 		password = "adoy.rm"
 	}
-}`, acctest.RandString(10))
+}`, clusterName)
+}
+
+func testAccContainerCluster_withLowerVersion(clusterName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+	zone = "us-central1-a"
+}
+
+resource "google_container_cluster" "with_version" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	node_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	initial_node_count = 1
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+}`, clusterName)
+}
 
 var testAccContainerCluster_withNodeConfig = fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {


### PR DESCRIPTION
When a GKE operation fails, it doesn't actually populate the error return value. Instead, it sets StatusMessage to some value (see https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.operations). If `statusMessage` is set, we know an error has occurred.

The error message that was getting hidden in #223 was that you can't upgrade a node past the master version. This fix upgrades the master and then the node upon update. If it seems useful in the future, we can separate node/master version fields.

Fixes #223.