### PR TITLE
Remove ConflictsWith for network and subnetwork.

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -284,7 +284,6 @@ func resourceComputeInstance() *schema.Resource {
 							Computed:         true,
 							ForceNew:         true,
 							DiffSuppressFunc: linkDiffSuppress,
-							ConflictsWith:    []string{"network_interface.0.subnetwork", "network_interface.0.subnetwork_project"},
 						},
 
 						"subnetwork": &schema.Schema{
@@ -711,10 +710,13 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			prefix := fmt.Sprintf("network_interface.%d", i)
 			// Load up the name of this network_interface
 			networkName := d.Get(prefix + ".network").(string)
+			subnetworkName := d.Get(prefix + ".subnetwork").(string)
 			address := d.Get(prefix + ".address").(string)
 			var networkLink, subnetworkLink string
 
-			if networkName != "" {
+			if networkName != "" && subnetworkName != "" {
+				return fmt.Errorf("Cannot specify both network and subnetwork values.")
+			} else if networkName != "" {
 				networkLink, err = getNetworkLink(d, config, prefix+".network")
 				if err != nil {
 					return fmt.Errorf(


### PR DESCRIPTION
We support more than one network_interface. 
ConflictsWith doesn't support this case. 

I added the ConflictsWith an hour ago and I assumed for some reason that network_interface had always a size of 1. See #290. This is wrong, network_interface size is greater than one. @rileykarson added a test that will prevent regression on this in #289.

@danawillow @rileykarson 