### PR TITLE
Add Beta support for egress/direction to google_compute_firewall.

### DIFF
--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -53,9 +53,9 @@ The following arguments are supported:
     is not provided, the provider project is used.
 
 * `source_ranges` - (Optional) A list of source CIDR ranges that this
-   firewall applies to.
+   firewall applies to. Can't be used for `EGRESS`.
 
-* `source_tags` - (Optional) A list of source tags for this firewall.
+* `source_tags` - (Optional) A list of source tags for this firewall. Can't be used for `EGRESS`.
 
 * `target_tags` - (Optional) A list of target tags for this firewall.
 
@@ -64,6 +64,12 @@ The following arguments are supported:
 * `deny` - (Optional, Beta) Can be specified multiple times for each deny
     rule. Each deny block supports fields documented below. Can be specified
     instead of allow.
+
+* `direction` - (Optional, Beta) Direction of traffic to which this firewall applies;
+    One of `INGRESS` or `EGRESS`. Defaults to `INGRESS`.
+
+* `destination_ranges` - (Optional, Beta) A list of destination CIDR ranges that this
+   firewall applies to. Can't be used for `INGRESS`.
 
 The `allow` block supports:
 


### PR DESCRIPTION
- Add support for the Beta fields `direction`, `destination_ranges`  to `google_compute_firewall`

Neither is updateable by the API yet.

`direction` always has a value in the API even when a null is sent; we need to conditionally read it as a result. This contrasts `ip_version` in #250, #265, which only has one when set explicitly.

Fixes #283.
Relates to #93.