### PR TITLE
Convert old validation functions to use IntAtLeast from helper/validation.

### DIFF
--- a/google/node_config.go
+++ b/google/node_config.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -23,18 +23,18 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"disk_size_gb": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(10),
 			},
 
 			"local_ssd_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 			},
 

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 var schemaNodeConfig = &schema.Schema{
@@ -26,15 +27,7 @@ var schemaNodeConfig = &schema.Schema{
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-
-					if value < 10 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be less than 10", k))
-					}
-					return
-				},
+				ValidateFunc: validation.IntAtLeast(10),
 			},
 
 			"local_ssd_count": {
@@ -42,15 +35,7 @@ var schemaNodeConfig = &schema.Schema{
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-
-					if value < 0 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be negative", k))
-					}
-					return
-				},
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 
 			"oauth_scopes": {

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -48,7 +48,7 @@ func resourceBigtableInstance() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      3,
-				ValidateFunc: IntAtLeast(3),
+				ValidateFunc: validation.IntAtLeast(3),
 			},
 
 			"storage_type": {
@@ -171,23 +171,4 @@ func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) e
 	d.SetId("")
 
 	return nil
-}
-
-// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
-// is of type int and is above min (inclusive)
-func IntAtLeast(min int) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (s []string, es []error) {
-		v, ok := i.(int)
-		if !ok {
-			es = append(es, fmt.Errorf("expected type of %s to be int", k))
-			return
-		}
-
-		if v < min {
-			es = append(es, fmt.Errorf("expected %s to be at least %d, got %d", k, min, v))
-			return
-		}
-
-		return
-	}
 }

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -72,13 +72,7 @@ func resourceComputeInstance() *schema.Resource {
 										Type:     schema.TypeInt,
 										Optional: true,
 										ForceNew: true,
-										ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-											if v.(int) < 1 {
-												errors = append(errors, fmt.Errorf(
-													"%q must be greater than 0", k))
-											}
-											return
-										},
+										ValidateFunc: validation.IntAtLeast(1),
 									},
 
 									"type": &schema.Schema{

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -69,9 +69,9 @@ func resourceComputeInstance() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"size": &schema.Schema{
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.IntAtLeast(1),
 									},
 

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/container/v1"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceContainerNodePool() *schema.Resource {
@@ -75,27 +76,13 @@ func resourceContainerNodePool() *schema.Resource {
 						"min_node_count": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(int)
-
-								if value < 1 {
-									errors = append(errors, fmt.Errorf("%q must be >=1", k))
-								}
-								return
-							},
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 
 						"max_node_count": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(int)
-
-								if value < 1 {
-									errors = append(errors, fmt.Errorf("%q must be >=1", k))
-								}
-								return
-							},
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},
 				},

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"google.golang.org/api/container/v1"
 	"github.com/hashicorp/terraform/helper/validation"
+	"google.golang.org/api/container/v1"
 )
 
 func resourceContainerNodePool() *schema.Resource {
@@ -74,14 +74,14 @@ func resourceContainerNodePool() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"min_node_count": &schema.Schema{
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 
 						"max_node_count": &schema.Schema{
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},


### PR DESCRIPTION
#302 lets us use the new `ValidateFunc`s in `helper/validation`; let's use those so that we are consistent across the provider, and don't need to maintain that validation code ourselves.