### PR TITLE
Stop shadowing err in version switches by using = over :=

### DIFF
--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -189,7 +189,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 	switch computeApiVersion {
 	case v1:
 		firewallV1 := &compute.Firewall{}
-		err := Convert(firewall, firewallV1)
+		err = Convert(firewall, firewallV1)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func resourceComputeFirewallCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	case v0beta:
 		firewallV0Beta := &computeBeta.Firewall{}
-		err := Convert(firewall, firewallV0Beta)
+		err = Convert(firewall, firewallV0Beta)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 	switch computeApiVersion {
 	case v1:
 		firewallV1 := &compute.Firewall{}
-		err := Convert(firewall, firewallV1)
+		err = Convert(firewall, firewallV1)
 		if err != nil {
 			return err
 		}
@@ -333,7 +333,7 @@ func resourceComputeFirewallUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	case v0beta:
 		firewallV0Beta := &computeBeta.Firewall{}
-		err := Convert(firewall, firewallV0Beta)
+		err = Convert(firewall, firewallV0Beta)
 		if err != nil {
 			return err
 		}

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -224,7 +224,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	switch computeApiVersion {
 	case v1:
 		managerV1 := &compute.InstanceGroupManager{}
-		err := Convert(manager, managerV1)
+		err = Convert(manager, managerV1)
 		if err != nil {
 			return err
 		}
@@ -234,7 +234,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 			project, d.Get("zone").(string), managerV1).Do()
 	case v0beta:
 		managerV0beta := &computeBeta.InstanceGroupManager{}
-		err := Convert(manager, managerV0beta)
+		err = Convert(manager, managerV0beta)
 		if err != nil {
 			return err
 		}
@@ -416,7 +416,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		switch computeApiVersion {
 		case v1:
 			setTargetPoolsV1 := &compute.InstanceGroupManagersSetTargetPoolsRequest{}
-			err := Convert(setTargetPools, setTargetPoolsV1)
+			err = Convert(setTargetPools, setTargetPoolsV1)
 			if err != nil {
 				return err
 			}
@@ -425,7 +425,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				project, d.Get("zone").(string), d.Id(), setTargetPoolsV1).Do()
 		case v0beta:
 			setTargetPoolsV0beta := &computeBeta.InstanceGroupManagersSetTargetPoolsRequest{}
-			err := Convert(setTargetPools, setTargetPoolsV0beta)
+			err = Convert(setTargetPools, setTargetPoolsV0beta)
 			if err != nil {
 				return err
 			}
@@ -458,7 +458,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		switch computeApiVersion {
 		case v1:
 			setInstanceTemplateV1 := &compute.InstanceGroupManagersSetInstanceTemplateRequest{}
-			err := Convert(setInstanceTemplate, setInstanceTemplateV1)
+			err = Convert(setInstanceTemplate, setInstanceTemplateV1)
 			if err != nil {
 				return err
 			}
@@ -467,7 +467,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				project, d.Get("zone").(string), d.Id(), setInstanceTemplateV1).Do()
 		case v0beta:
 			setInstanceTemplateV0beta := &computeBeta.InstanceGroupManagersSetInstanceTemplateRequest{}
-			err := Convert(setInstanceTemplate, setInstanceTemplateV0beta)
+			err = Convert(setInstanceTemplate, setInstanceTemplateV0beta)
 			if err != nil {
 				return err
 			}
@@ -527,7 +527,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			switch computeApiVersion {
 			case v1:
 				recreateInstancesV1 := &compute.InstanceGroupManagersRecreateInstancesRequest{}
-				err := Convert(recreateInstances, recreateInstancesV1)
+				err = Convert(recreateInstances, recreateInstancesV1)
 				if err != nil {
 					return err
 				}
@@ -539,7 +539,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				}
 			case v0beta:
 				recreateInstancesV0beta := &computeBeta.InstanceGroupManagersRecreateInstancesRequest{}
-				err := Convert(recreateInstances, recreateInstancesV0beta)
+				err = Convert(recreateInstances, recreateInstancesV0beta)
 				if err != nil {
 					return err
 				}
@@ -576,7 +576,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		switch computeApiVersion {
 		case v1:
 			setNamedPortsV1 := &compute.InstanceGroupsSetNamedPortsRequest{}
-			err := Convert(setNamedPorts, setNamedPortsV1)
+			err = Convert(setNamedPorts, setNamedPortsV1)
 			if err != nil {
 				return err
 			}
@@ -585,7 +585,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				project, d.Get("zone").(string), d.Id(), setNamedPortsV1).Do()
 		case v0beta:
 			setNamedPortsV0beta := &computeBeta.InstanceGroupsSetNamedPortsRequest{}
-			err := Convert(setNamedPorts, setNamedPortsV0beta)
+			err = Convert(setNamedPorts, setNamedPortsV0beta)
 			if err != nil {
 				return err
 			}

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -141,7 +141,7 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 	switch computeApiVersion {
 	case v1:
 		subnetworkV1 := &compute.Subnetwork{}
-		err := Convert(subnetwork, subnetworkV1)
+		err = Convert(subnetwork, subnetworkV1)
 		if err != nil {
 			return err
 		}
@@ -249,7 +249,7 @@ func resourceComputeSubnetworkUpdate(d *schema.ResourceData, meta interface{}) e
 		switch computeApiVersion {
 		case v1:
 			subnetworksSetPrivateIpGoogleAccessRequestV1 := &compute.SubnetworksSetPrivateIpGoogleAccessRequest{}
-			err := Convert(subnetworksSetPrivateIpGoogleAccessRequest, subnetworksSetPrivateIpGoogleAccessRequestV1)
+			err = Convert(subnetworksSetPrivateIpGoogleAccessRequest, subnetworksSetPrivateIpGoogleAccessRequestV1)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We shadow `err` in some versioned resources' switch statements by using `:=` instead of `=`; we then check the first `err`, but then later assign a new value to it and don't check that.

Let's use `=` over `:=`, that way we'll properly return `err`.

Fixes #317 