### PR TITLE
Changed zone name to be read correctly in google_compute_disk's detach logic

### DIFF
--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -301,9 +301,10 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 			}
 			for _, disk := range i.Disks {
 				if disk.Source == self {
+					zoneParts := strings.Split(i.Zone, "/")
 					detachCalls = append(detachCalls, detachArgs{
 						project:    project,
-						zone:       i.Zone,
+						zone:       zoneParts[len(zoneParts)-1],
 						instance:   i.Name,
 						deviceName: disk.DeviceName,
 					})


### PR DESCRIPTION
We don't support attaching/detaching disks post-create yet in instances, so the instance the disk was previously attached to will no longer be able to be `Read` as a result of this; we may not want to merge for that reason.

Right now, if we end up in the `Delete` for an attached disk, we error out because the `zone` is being set to a zone url and not a zone name in the detach request. 

Fixes #112 
