### PR TITLE
Remove default value for removed value automatic_restart

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -137,7 +137,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 			"automatic_restart": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 				ForceNew: true,
 				Removed:  "Use 'scheduling.automatic_restart' instead.",
 			},


### PR DESCRIPTION
Import tests for compute_instance_template fail without this change as
they expect a value of true for automatic_restart. As this value was
removed, we're no longer setting it (and therefore it looks like it has
a value of false, which is different from the default).