### PR TITLE
Change required fields to computed in compute instance group datasource

### DIFF
--- a/google/data_source_google_compute_instance_group.go
+++ b/google/data_source_google_compute_instance_group.go
@@ -44,12 +44,12 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Computed: true,
 						},
 
 						"port": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
To address my comments on PR #267 (the author didn't grant contributor push access to its branch). 

cc/ @danawillow @rileykarson 

make testacc TESTARGS="-run TestAccDataSourceGoogleComputeInstanceGroup_" TEST="./google"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run TestAccDataSourceGoogleComputeInstanceGroup_ -timeout 120m
=== RUN   TestAccDataSourceGoogleComputeInstanceGroup_basic
--- PASS: TestAccDataSourceGoogleComputeInstanceGroup_basic (104.47s)
=== RUN   TestAccDataSourceGoogleComputeInstanceGroup_withNamedPort
--- PASS: TestAccDataSourceGoogleComputeInstanceGroup_withNamedPort (92.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	197.301s