### PR TITLE
Rename spanner instance import tests to match format of resource tests

### DIFF
--- a/google/import_spanner_instance_test.go
+++ b/google/import_spanner_instance_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleSpannerInstance_importInstance(t *testing.T) {
+func TestAccSpannerInstance_importInstance(t *testing.T) {
 	resourceName := "google_spanner_instance.basic"
 	instanceName := fmt.Sprintf("span-itest-%s", acctest.RandString(10))
 
@@ -31,7 +31,7 @@ func TestAccGoogleSpannerInstance_importInstance(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSpannerInstance_importProjectInstance(t *testing.T) {
+func TestAccSpannerInstance_importProjectInstance(t *testing.T) {
 	resourceName := "google_spanner_instance.basic"
 	instanceName := fmt.Sprintf("span-itest-%s", acctest.RandString(10))
 	var projectId = multiEnvSearch([]string{"GOOGLE_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"})


### PR DESCRIPTION
Renamed `TestAccGoogleSpannerInstance_import*` to TestAccSpannerInstance_import*` to match the format of our other tests like the resource test for the spanner instance `TestAccSpannerInstance_basic`.

This way, it is consistent and we can run all the spanner instance test with one command.