### PR TITLE
 Add support for min_cpu_platform in google_compute_instance.

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -19,6 +19,10 @@ var InstanceVersionedFeatures = []Feature{
 		Version: v0beta,
 		Item:    "guest_accelerator",
 	},
+	{
+		Version: v0beta,
+		Item:    "min_cpu_platform",
+	},
 }
 
 func stringScopeHashcode(v interface{}) int {
@@ -465,6 +469,12 @@ func resourceComputeInstance() *schema.Resource {
 				},
 			},
 
+			"min_cpu_platform": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -858,6 +868,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		Labels:            expandLabels(d),
 		ServiceAccounts:   serviceAccounts,
 		GuestAccelerators: expandGuestAccelerators(zone.Name, d.Get("guest_accelerator").([]interface{})),
+		MinCpuPlatform:    d.Get("min_cpu_platform").(string),
 		Scheduling:        scheduling,
 	}
 
@@ -1122,6 +1133,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("scratch_disk", scratchDisks)
 	d.Set("scheduling", flattenBetaScheduling(instance.Scheduling))
 	d.Set("guest_accelerator", flattenGuestAccelerators(instance.Zone, instance.GuestAccelerators))
+	d.Set("min_cpu_platform", instance.MinCpuPlatform)
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
 	d.SetId(instance.Name)
 

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -469,6 +469,11 @@ func resourceComputeInstance() *schema.Resource {
 				},
 			},
 
+			"cpu_platform": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"min_cpu_platform": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1133,6 +1138,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("scratch_disk", scratchDisks)
 	d.Set("scheduling", flattenBetaScheduling(instance.Scheduling))
 	d.Set("guest_accelerator", flattenGuestAccelerators(instance.Zone, instance.GuestAccelerators))
+	d.Set("cpu_platform", instance.CpuPlatform)
 	d.Set("min_cpu_platform", instance.MinCpuPlatform)
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
 	d.SetId(instance.Name)

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -717,6 +717,27 @@ func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 
 }
 
+func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
+	var instance computeBeta.Instance
+	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_minCpuPlatform(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasMinCpuPlatform(&instance, "Intel Haswell"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1093,6 +1114,16 @@ func testAccCheckComputeInstanceHasGuestAccelerator(instance *computeBeta.Instan
 
 		if instance.GuestAccelerators[0].AcceleratorCount != acceleratorCount {
 			return fmt.Errorf("Wrong accelerator acceleratorCount: expected %d, got %d", acceleratorCount, instance.GuestAccelerators[0].AcceleratorCount)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceHasMinCpuPlatform(instance *computeBeta.Instance, minCpuPlatform string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instance.MinCpuPlatform != minCpuPlatform {
+			return fmt.Errorf("Wrong minimum CPU platform: expected %d, got %d", minCpuPlatform, instance.MinCpuPlatform)
 		}
 
 		return nil
@@ -1948,5 +1979,26 @@ resource "google_compute_instance" "foobar" {
     count = 1
     type = "nvidia-tesla-k80"
   }
+}`, instance)
+}
+
+func testAccComputeInstance_minCpuPlatform(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foobar" {
+  name = "%s"
+  machine_type = "n1-standard-1"
+  zone = "us-east1-d"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = "Intel Haswell"
 }`, instance)
 }

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1123,7 +1123,7 @@ func testAccCheckComputeInstanceHasGuestAccelerator(instance *computeBeta.Instan
 func testAccCheckComputeInstanceHasMinCpuPlatform(instance *computeBeta.Instance, minCpuPlatform string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance.MinCpuPlatform != minCpuPlatform {
-			return fmt.Errorf("Wrong minimum CPU platform: expected %d, got %d", minCpuPlatform, instance.MinCpuPlatform)
+			return fmt.Errorf("Wrong minimum CPU platform: expected %s, got %s", minCpuPlatform, instance.MinCpuPlatform)
 		}
 
 		return nil

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -286,6 +286,8 @@ exported:
 
 * `label_fingerprint` - The unique fingerprint of the labels.
 
+* `cpu_platform` - The CPU platform used by this instance.
+
 * `network_interface.0.address` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.assigned_nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -264,6 +264,9 @@ The `scheduling` block supports:
 
 * `guest_accelerator` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) List of the type and count of accelerator cards attached to the instance. Structure documented below.
 
+* `min_cpu_platform` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
+`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+
 The `guest_accelerator` block supports:
 
 * `type` (Required) - The accelerator type resource to expose to this instance. E.g. `nvidia-tesla-k80`.


### PR DESCRIPTION
Fixes #106 