### PR TITLE
adding priority setting to firewall

### DIFF
--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -19,6 +19,7 @@ var FirewallVersionedFeatures = []Feature{
 	Feature{Version: v0beta, Item: "deny"},
 	Feature{Version: v0beta, Item: "direction"},
 	Feature{Version: v0beta, Item: "destination_ranges"},
+	Feature{Version: v0beta, Item: "priority"},
 }
 
 func resourceComputeFirewall() *schema.Resource {
@@ -95,6 +96,11 @@ func resourceComputeFirewall() *schema.Resource {
 
 			"description": {
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"priority": {
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
@@ -478,6 +484,7 @@ func resourceFirewall(d *schema.ResourceData, meta interface{}, computeApiVersio
 		Name:              d.Get("name").(string),
 		Description:       d.Get("description").(string),
 		Direction:         d.Get("direction").(string),
+		Priority:          int64(d.Get("priority").(int)),
 		Network:           network.SelfLink,
 		Allowed:           allowed,
 		Denied:            denied,

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
     rule. Each deny block supports fields documented below. Can be specified
     instead of allow.
 
+* `priority` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Sets the priority of the firewall rule.
+
 * `direction` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Direction of traffic to which this firewall applies;
     One of `INGRESS` or `EGRESS`. Defaults to `INGRESS`.
 


### PR DESCRIPTION
Hi there,

At Etsy we had a use case in our network engineering department to use the `priority` setting for our firewall rules but we found that we were unable to do so using the latest version of the terraform provider. I've extended the schema and beta attributes, and tested successfully using the plan below. 

```
resource "google_compute_firewall" "etsy" {
  name    = "etsy"
  network = "${var.network}"

  target_tags = ["etsy"]
  priority = 1005

  allow {
    protocol = "tcp"
    ports    = ["22"]
  }

  source_ranges = ["1.2.3.4/24"]
}
```

In this commit we've added the support for `priority` and the associated documentation. I looked at the acceptance tests but didn't see a clear place that I could test `priority` in a useful way. 

If you would like some acceptance tests with this patch, could you please provide some direction or suggestions as to how we could include them with this PR?

Best regards,


