### PR TITLE
Added support for updating a cloud storage object using source field

### DIFF
--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -41,6 +42,49 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectBasic(bucketName),
 				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
+			},
+		},
+	})
+}
+
+func TestAccGoogleStorageObject_recreate(t *testing.T) {
+	bucketName := testBucketName()
+
+	writeFile := func(name string, data []byte) string {
+		h := md5.New()
+		h.Write(data)
+		data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+		ioutil.WriteFile(name, data, 0644)
+		return data_md5
+	}
+	data_md5 := writeFile(tf.Name(), []byte("data data data"))
+	updated_data_md5 := writeFile(tf.Name()+".update", []byte("datum"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if err != nil {
+				panic(err)
+			}
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleStorageBucketsObjectBasic(bucketName),
+				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
+			},
+			resource.TestStep{
+				PreConfig: func() {
+					updateName := tf.Name() + ".update"
+					err := os.Rename(updateName, tf.Name())
+					if err != nil {
+						t.Errorf("Failed to rename %s to %s", updateName, tf.Name())
+					}
+				},
+				Config: testGoogleStorageBucketsObjectBasic(bucketName),
+				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, updated_data_md5),
 			},
 		},
 	})

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -48,6 +48,8 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_recreate(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 
 	writeFile := func(name string, data []byte) string {


### PR DESCRIPTION
This PR intends to add support for updating a cloud storage object if the content of the source fields changes.
Currently if the content of the source changes, the object storage does not detect that the state changes.
To do so we use a `StateFunc` which will encode the md5 for the source file. If the file changes, the md5 will also changes which will invalidate the state and trigger an update. 