### PR TITLE
Add support for alias_ip_range in google_compute_instance network interface

### DIFF
--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -78,8 +78,10 @@ type Feature struct {
 	// The feature is considered to be in-use if the field referenced by "Item" is set in the state.
 	// The path can reference:
 	// - a beta field at the top-level (e.g. "min_cpu_platform").
-	// - a beta field nested under a field of "TypeList" (e.g. "network_interface.*.alias_ip_range" is considered to be
+	// - a beta field nested inside a list (e.g. "network_interface.*.alias_ip_range" is considered to be
 	// 		in-use if the "alias_ip_range" field is set in the state for any of the network interfaces).
+	//
+	// Note: beta field nested inside a SET are NOT supported at the moment.
 	Item string
 }
 

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -73,9 +73,13 @@ func getComputeApiVersionUpdate(d TerraformResourceData, resourceVersion Compute
 // A field of a resource and the version of the Compute API required to use it.
 type Feature struct {
 	Version ComputeApiVersion
-	// Path to the beta field. Supports:
-	// - beta field: "min_cpu_platform"
-	// - nested beta field: "network_interface.*.alias_ip_range"
+	// Path to the beta field.
+	//
+	// The feature is considered to be in-use if the field referenced by "Item" is set in the state.
+	// The path can reference:
+	// - a beta field at the top-level (e.g. "min_cpu_platform").
+	// - a beta field nested under a field of "TypeList" (e.g. "network_interface.*.alias_ip_range" is considered to be
+	// 		in-use if the "alias_ip_range" field is set in the state for any of the network interfaces).
 	Item string
 }
 

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -76,7 +76,7 @@ type Feature struct {
 	// Path to the beta field. Supports:
 	// - beta field: "min_cpu_platform"
 	// - nested beta field: "network_interface.*.alias_ip_range"
-	Item    string
+	Item string
 }
 
 // Returns true when a feature has been modified.

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -73,6 +73,9 @@ func getComputeApiVersionUpdate(d TerraformResourceData, resourceVersion Compute
 // A field of a resource and the version of the Compute API required to use it.
 type Feature struct {
 	Version ComputeApiVersion
+	// Path to the beta field. Supports:
+	// - beta field: "min_cpu_platform"
+	// - nested beta field: "network_interface.*.alias_ip_range"
 	Item    string
 }
 

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -294,7 +294,7 @@ func resourceComputeInstance() *schema.Resource {
 							Optional:         true,
 							Computed:         true,
 							ForceNew:         true,
-							DiffSuppressFunc: linkDiffSuppress,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
 						},
 
 						"subnetwork": &schema.Schema{
@@ -302,7 +302,7 @@ func resourceComputeInstance() *schema.Resource {
 							Optional:         true,
 							Computed:         true,
 							ForceNew:         true,
-							DiffSuppressFunc: linkDiffSuppress,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
 						},
 
 						"subnetwork_project": &schema.Schema{
@@ -1058,7 +1058,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 				"name":               iface.Name,
 				"address":            iface.NetworkIP,
 				"network":            iface.Network,
-				"subnetwork":         ConvertSelfLinkToV1(iface.Subnetwork),
+				"subnetwork":         iface.Subnetwork,
 				"subnetwork_project": getProjectFromSubnetworkLink(iface.Subnetwork),
 				"access_config":      accessConfigs,
 				"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -735,7 +735,46 @@ func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
 			},
 		},
 	})
+}
 
+func TestAccComputeInstance_primaryAliasIpRange(t *testing.T) {
+	var instance computeBeta.Instance
+	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_primaryAliasIpRange(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasAliasIpRange(&instance, "", "/24"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
+	var instance computeBeta.Instance
+	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeInstance_secondaryAliasIpRange(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasAliasIpRange(&instance, "inst-test-secondary", "172.16.0.0/24"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFunc {
@@ -1127,6 +1166,20 @@ func testAccCheckComputeInstanceHasMinCpuPlatform(instance *computeBeta.Instance
 		}
 
 		return nil
+	}
+}
+
+func testAccCheckComputeInstanceHasAliasIpRange(instance *computeBeta.Instance, subnetworkRangeName, iPCidrRange string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, networkInterface := range instance.NetworkInterfaces {
+			for _, aliasIpRange := range networkInterface.AliasIpRanges {
+				if aliasIpRange.SubnetworkRangeName == subnetworkRangeName && (aliasIpRange.IpCidrRange == iPCidrRange || ipCidrRangeDiffSuppress("ip_cidr_range", aliasIpRange.IpCidrRange, iPCidrRange, nil)) {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("Alias ip range with name %s and cidr %s not present", subnetworkRangeName, iPCidrRange)
 	}
 }
 
@@ -2001,4 +2054,64 @@ resource "google_compute_instance" "foobar" {
 
   min_cpu_platform = "Intel Haswell"
 }`, instance)
+}
+
+func testAccComputeInstance_primaryAliasIpRange(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foobar" {
+  name = "%s"
+  machine_type = "n1-standard-1"
+  zone = "us-east1-d"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    alias_ip_range {
+      ip_cidr_range = "/24"
+    }
+  }
+}`, instance)
+}
+
+func testAccComputeInstance_secondaryAliasIpRange(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "inst-test-network" {
+	name = "inst-test-network-%s"
+}
+resource "google_compute_subnetwork" "inst-test-subnetwork" {
+	name          = "inst-test-subnetwork-%s"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-east1"
+	network       = "${google_compute_network.inst-test-network.self_link}"
+	secondary_ip_range {
+		range_name = "inst-test-secondary"
+		ip_cidr_range = "172.16.0.0/20"
+	}
+}
+resource "google_compute_instance" "foobar" {
+  name = "%s"
+  machine_type = "n1-standard-1"
+  zone = "us-east1-d"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.inst-test-subnetwork.self_link}"
+
+    alias_ip_range {
+      subnetwork_range_name = "${google_compute_subnetwork.inst-test-subnetwork.secondary_ip_range.0.range_name}"
+      ip_cidr_range = "172.16.0.0/24"
+    }
+  }
+}`, acctest.RandString(10), acctest.RandString(10), instance)
 }

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -46,7 +46,7 @@ func resourceComputeSubnetwork() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: compareGlobalSelfLinkOrResourceName,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"description": &schema.Schema{

--- a/google/self_link_helpers.go
+++ b/google/self_link_helpers.go
@@ -28,15 +28,21 @@ func compareSelfLinkRelativePaths(k, old, new string, d *schema.ResourceData) bo
 	return false
 }
 
-// Use this method when the field accepts either a name or a self_link referencing a global resource.
-func compareGlobalSelfLinkOrResourceName(k, old, new string, d *schema.ResourceData) bool {
-	oldParts := strings.Split(old, "/")
+// Use this method when the field accepts either a name or a self_link referencing a resource.
+// The value we store (i.e. `old` in this method), must be a self_link.
+func compareSelfLinkOrResourceName(k, old, new string, d *schema.ResourceData) bool {
+	oldParts := strings.Split(old, "/") // always a self_link
 	newParts := strings.Split(new, "/")
 
-	if oldParts[len(oldParts)-1] == newParts[len(newParts)-1] {
-		return true
+	if len(newParts) == 1 {
+		// The `new` string is a name
+		if oldParts[len(oldParts)-1] == newParts[0] {
+			return true
+		}
 	}
-	return false
+
+	// The `new` string is a self_link
+	return compareSelfLinkRelativePaths(k, old, new, d)
 }
 
 // Hash the relative path of a self link.

--- a/google/utils.go
+++ b/google/utils.go
@@ -229,6 +229,30 @@ func linkDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+func ipCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The range may be a:
+	// A) single IP address (e.g. 10.2.3.4)
+	// B) CIDR format string (e.g. 10.1.2.0/24)
+	// C) netmask (e.g. /24)
+	//
+	// For A) and B), no diff to suppress, they have to match completely.
+	// For C), The API picks a network IP address and this creates a diff of the form:
+	// network_interface.0.alias_ip_range.0.ip_cidr_range: "10.128.1.0/24" => "/24"
+	// We should only compare the mask portion for this case.
+	if len(new) > 0 && new[0] == '/' {
+		oldNetmaskStartPos := strings.LastIndex(old, "/")
+
+		if oldNetmaskStartPos != -1 {
+			oldNetmask := old[strings.LastIndex(old, "/"):]
+			if oldNetmask == new {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // expandLabels pulls the value of "labels" out of a schema.ResourceData as a map[string]string.
 func expandLabels(d *schema.ResourceData) map[string]string {
 	return expandStringMap(d, "labels")

--- a/google/utils_test.go
+++ b/google/utils_test.go
@@ -1,0 +1,47 @@
+package google
+
+import "testing"
+
+func TestIpCidrRangeDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New          string
+		ExpectDiffSupress bool
+	}{
+		"single ip address": {
+			Old:               "10.2.3.4",
+			New:               "10.2.3.5",
+			ExpectDiffSupress: false,
+		},
+		"cidr format string": {
+			Old:               "10.1.2.0/24",
+			New:               "10.1.3.0/24",
+			ExpectDiffSupress: false,
+		},
+		"netmask same mask": {
+			Old:               "10.1.2.0/24",
+			New:               "/24",
+			ExpectDiffSupress: true,
+		},
+		"netmask different mask": {
+			Old:               "10.1.2.0/24",
+			New:               "/32",
+			ExpectDiffSupress: false,
+		},
+		"add netmask": {
+			Old:               "",
+			New:               "/24",
+			ExpectDiffSupress: false,
+		},
+		"remove netmask": {
+			Old:               "/24",
+			New:               "",
+			ExpectDiffSupress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if ipCidrRangeDiffSuppress("ip_cidr_range", tc.Old, tc.New, nil) != tc.ExpectDiffSupress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSupress)
+		}
+	}
+}

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -229,10 +229,25 @@ The `network_interface` block supports:
     on that network). This block can be repeated multiple times. Structure
     documented below.
 
+* `alias_ip_range` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) An
+    array of alias IP ranges for this network interface. Can only be specified for network
+    interfaces on subnet-mode networks. Structure documented below.
+
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
     network ip. If not given, one will be generated.
+
+The `alias_ip_range` block supports:
+
+* `ip_cidr_range` - The IP CIDR range represented by this alias IP range. This IP CIDR range
+    must belong to the specified subnetwork and cannot contain IP addresses reserved by
+    system or used by other network interfaces. This range may be a single IP address
+    (e.g. 10.2.3.4), a netmask (e.g. /24) or a CIDR format string (e.g. 10.1.2.0/24).
+
+* `subnetwork_range_name` - (Optional) The subnetwork secondary range name specifying
+    the secondary range from which to allocate the IP CIDR range for this alias IP
+    range. If left unspecified, the primary range of the subnetwork will be used.
 
 The `service_account` block supports:
 


### PR DESCRIPTION
Fixes #288, #311 

1. The alias ip range can use addresses from the primary ip range or the secondary range defined in the subnetwork.
1. Updated api_versions.go to handle the case where the beta field is nested. For this case, `alias_ip_range` is nested under `network_interface`. Created a new notation for this.