### PR TITLE
Import for compute_address now requires region/name. Changed the ID format.

### DIFF
--- a/google/resource_compute_address_migrate.go
+++ b/google/resource_compute_address_migrate.go
@@ -41,7 +41,7 @@ func migrateComputeAddressV0toV1(is *terraform.InstanceState, meta interface{}) 
 		Project: project,
 		Region:  region,
 		Name:    is.Attributes["name"],
-	}.terraformId()
+	}.canonicalId()
 
 	log.Printf("[DEBUG] ID after migration: %s", is.ID)
 	return is, nil

--- a/google/resource_compute_address_migrate.go
+++ b/google/resource_compute_address_migrate.go
@@ -1,0 +1,42 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+)
+
+func resourceComputeAddressMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Container Node Pool State v0; migrating to v1")
+		return migrateComputeAddressV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateComputeAddressV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+	log.Printf("[DEBUG] ID before migration: %s", is.ID)
+
+	config := meta.(*Config)
+
+	region, err := getRegionFromInstanceState(is, config)
+	if err != nil {
+		return is, err
+	}
+
+	is.ID = computeAddressId{
+		Region: region,
+		Name:   is.Attributes["name"],
+	}.terraformId()
+
+	log.Printf("[DEBUG] ID after migration: %s", is.ID)
+	return is, nil
+}

--- a/google/resource_compute_address_migrate.go
+++ b/google/resource_compute_address_migrate.go
@@ -27,14 +27,20 @@ func migrateComputeAddressV0toV1(is *terraform.InstanceState, meta interface{}) 
 
 	config := meta.(*Config)
 
+	project, err := getProjectFromInstanceState(is, config)
+	if err != nil {
+		return is, err
+	}
+
 	region, err := getRegionFromInstanceState(is, config)
 	if err != nil {
 		return is, err
 	}
 
 	is.ID = computeAddressId{
-		Region: region,
-		Name:   is.Attributes["name"],
+		Project: project,
+		Region:  region,
+		Name:    is.Attributes["name"],
 	}.terraformId()
 
 	log.Printf("[DEBUG] ID after migration: %s", is.ID)

--- a/google/resource_compute_address_migrate_test.go
+++ b/google/resource_compute_address_migrate_test.go
@@ -17,7 +17,7 @@ func TestComputeAddressMigrateState(t *testing.T) {
 			Attributes: map[string]string{
 				"name": "address-1",
 			},
-			ExpectedId: "gcp-project/us-central1/address-1",
+			ExpectedId: "projects/gcp-project/regions/us-central1/addresses/address-1",
 			Meta:       &Config{Region: "us-central1", Project: "gcp-project"},
 		},
 	}

--- a/google/resource_compute_address_migrate_test.go
+++ b/google/resource_compute_address_migrate_test.go
@@ -17,8 +17,8 @@ func TestComputeAddressMigrateState(t *testing.T) {
 			Attributes: map[string]string{
 				"name": "address-1",
 			},
-			ExpectedId: "us-central1/address-1",
-			Meta:       &Config{Region: "us-central1"},
+			ExpectedId: "gcp-project/us-central1/address-1",
+			Meta:       &Config{Region: "us-central1", Project: "gcp-project"},
 		},
 	}
 

--- a/google/resource_compute_address_migrate_test.go
+++ b/google/resource_compute_address_migrate_test.go
@@ -1,0 +1,65 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestComputeAddressMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		ExpectedId   string
+		Meta         interface{}
+	}{
+		"update id from name to region/name": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"name": "address-1",
+			},
+			ExpectedId: "us-central1/address-1",
+			Meta:       &Config{Region: "us-central1"},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.Attributes["name"],
+			Attributes: tc.Attributes,
+		}
+
+		is, err := resourceComputeAddressMigrateState(tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.ID != tc.ExpectedId {
+			t.Fatalf("Id should be set to `%s` but is `%s`", tc.ExpectedId, is.ID)
+		}
+	}
+}
+
+func TestComputeAddressMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta *Config
+
+	// should handle nil
+	is, err := resourceComputeAddressMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceComputeAddressMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -40,8 +40,14 @@ func TestComputeAddressIdParsing(t *testing.T) {
 			ExpectedCanonicalId: "projects/default-project/regions/us-central1/addresses/test-address",
 			Config:              &Config{Project: "default-project"},
 		},
+		"id is address": {
+			ImportId:            "test-address",
+			ExpectedError:       false,
+			ExpectedCanonicalId: "projects/default-project/regions/us-east1/addresses/test-address",
+			Config:              &Config{Project: "default-project", Region: "us-east1"},
+		},
 		"id has invalid format": {
-			ImportId:      "invalid",
+			ImportId:      "i/n/v/a/l/i/d",
 			ExpectedError: true,
 		},
 	}

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -37,8 +37,10 @@ func testAccCheckComputeAddressDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := config.clientCompute.Addresses.Get(
-			config.Project, config.Region, rs.Primary.ID).Do()
+		addressId, err := parseComputeAddressId(rs.Primary.ID)
+
+		_, err = config.clientCompute.Addresses.Get(
+			config.Project, addressId.Region, addressId.Name).Do()
 		if err == nil {
 			return fmt.Errorf("Address still exists")
 		}
@@ -60,13 +62,15 @@ func testAccCheckComputeAddressExists(n string, addr *compute.Address) resource.
 
 		config := testAccProvider.Meta().(*Config)
 
+		addressId, err := parseComputeAddressId(rs.Primary.ID)
+
 		found, err := config.clientCompute.Addresses.Get(
-			config.Project, config.Region, rs.Primary.ID).Do()
+			config.Project, addressId.Region, addressId.Name).Do()
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.ID {
+		if found.Name != addressId.Name {
 			return fmt.Errorf("Addr not found")
 		}
 

--- a/google/utils.go
+++ b/google/utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -36,6 +37,20 @@ func getRegion(d *schema.ResourceData, config *Config) (string, error) {
 		return "", fmt.Errorf("%q: required field is not set", "region")
 	}
 	return res.(string), nil
+}
+
+func getRegionFromInstanceState(is *terraform.InstanceState, config *Config) (string, error) {
+	res, ok := is.Attributes["region"]
+
+	if ok && res != "" {
+		return res, nil
+	}
+
+	if config.Region != "" {
+		return config.Region, nil
+	}
+
+	return "", fmt.Errorf("region: required field is not set")
 }
 
 // getProject reads the "project" field from the given resource data and falls

--- a/google/utils.go
+++ b/google/utils.go
@@ -34,7 +34,7 @@ func getRegion(d *schema.ResourceData, config *Config) (string, error) {
 		if config.Region != "" {
 			return config.Region, nil
 		}
-		return "", fmt.Errorf("%q: required field is not set", "region")
+		return "", fmt.Errorf("region: required field is not set")
 	}
 	return res.(string), nil
 }
@@ -62,9 +62,23 @@ func getProject(d *schema.ResourceData, config *Config) (string, error) {
 		if config.Project != "" {
 			return config.Project, nil
 		}
-		return "", fmt.Errorf("%q: required field is not set", "project")
+		return "", fmt.Errorf("project: required field is not set")
 	}
 	return res.(string), nil
+}
+
+func getProjectFromInstanceState(is *terraform.InstanceState, config *Config) (string, error) {
+	res, ok := is.Attributes["project"]
+
+	if ok && res != "" {
+		return res, nil
+	}
+
+	if config.Project != "" {
+		return config.Project, nil
+	}
+
+	return "", fmt.Errorf("project: required field is not set")
 }
 
 func getZonalResourceFromRegion(getResource func(string) (interface{}, error), region string, compute *compute.Service, project string) (interface{}, error) {

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -46,8 +46,8 @@ exported:
 
 ## Import
 
-Addresses can be imported using the `name`, e.g.
+Addresses can be imported using the `region` and `name`, e.g.
 
 ```
-$ terraform import google_compute_address.default test-address
+$ terraform import google_compute_address.default us-central1/test-address
 ```

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -51,3 +51,17 @@ Addresses can be imported using the `project`, `region` and `name`, e.g.
 ```
 $ terraform import google_compute_address.default gcp-project/us-central1/test-address
 ```
+
+If `project` is omitted, the default project set for the provider will be used:
+
+```
+$ terraform import google_compute_address.default us-central1/test-address
+```
+
+Alternatively, addresses can be imported using a full or partial `self_link`.
+
+```
+$ terraform import google_compute_address.default https://www.googleapis.com/compute/v1/projects/gcp-project/regions/us-central1/addresses/test-address
+
+$ terraform import google_compute_address.default projects/gcp-project/regions/us-central1/addresses/test-address
+```

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -52,7 +52,7 @@ Addresses can be imported using the `project`, `region` and `name`, e.g.
 $ terraform import google_compute_address.default gcp-project/us-central1/test-address
 ```
 
-If `project` is omitted, the default project set for the provider are used:
+If `project` is omitted, the default project set for the provider is used:
 
 ```
 $ terraform import google_compute_address.default us-central1/test-address

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -46,8 +46,8 @@ exported:
 
 ## Import
 
-Addresses can be imported using the `region` and `name`, e.g.
+Addresses can be imported using the `project`, `region` and `name`, e.g.
 
 ```
-$ terraform import google_compute_address.default us-central1/test-address
+$ terraform import google_compute_address.default gcp-project/us-central1/test-address
 ```

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -52,10 +52,16 @@ Addresses can be imported using the `project`, `region` and `name`, e.g.
 $ terraform import google_compute_address.default gcp-project/us-central1/test-address
 ```
 
-If `project` is omitted, the default project set for the provider will be used:
+If `project` is omitted, the default project set for the provider are used:
 
 ```
 $ terraform import google_compute_address.default us-central1/test-address
+```
+
+If `project` and `region` are omitted, the default project and region set for the provider are used.
+
+```
+$ terraform import google_compute_address.default test-address
 ```
 
 Alternatively, addresses can be imported using a full or partial `self_link`.


### PR DESCRIPTION
Fixes #374

Also performed the migration to the new ID format for backward compatibility.

```sh
make testacc TESTARGS="-run TestAccComputeAddress_basic" TEST="./google"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run TestAccComputeAddress_basic -timeout 120m
=== RUN   TestAccComputeAddress_basic
--- PASS: TestAccComputeAddress_basic (23.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	23.831s

make testacc TESTARGS="-run TestAccComputeAddress_importBasic" TEST="./google"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run TestAccComputeAddress_importBasic -timeout 120m
=== RUN   TestAccComputeAddress_importBasic
--- PASS: TestAccComputeAddress_importBasic (23.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	23.217s
```

@paddycarver We use this PR to discuss also including the project in the import string and the the relative part of the self link (anything right of the version) as the resource id.