### PR TITLE
Fix docs. Node Pool autoscaling attribute names

### DIFF
--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -107,8 +107,8 @@ resource "google_container_cluster" "primary" {
 
 The `autoscaling` block supports:
 
-* `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
-    <= `maxNodeCount`.
+    * `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
+    <= `max_node_count`.
 
 * `max_node_count` - (Required) Maximum number of nodes in the NodePool. Must be >= min_node_count.
 

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -107,10 +107,10 @@ resource "google_container_cluster" "primary" {
 
 The `autoscaling` block supports:
 
-* `minNodeCount` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
+* `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
     <= `maxNodeCount`.
 
-* `maxNodeCount` - (Required) Maximum number of nodes in the NodePool. Must be >= minNodeCount.
+* `max_node_count` - (Required) Maximum number of nodes in the NodePool. Must be >= min_node_count.
 
 ## Import
 


### PR DESCRIPTION
Documentation fix

Correct attribute names for google_container_node_pool:
* `minNodeCount` -> `min_node_count` as expected by resource config
* `maxNodeCount` -> `max_node_count` as expected by resource config