### PR TITLE
Add support for setting labels to `google_project`

### DIFF
--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -3,9 +3,12 @@ package google
 import (
 	"fmt"
 	"os"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -70,6 +73,23 @@ func TestAccGoogleProject_createBilling(t *testing.T) {
 				Config: testAccGoogleProject_createBilling(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasBillingAccount("google_project.acceptance", pid, billingId),
+				),
+			},
+		},
+	})
+}
+
+// Test that a Project resource can be created with labels
+func TestAccGoogleProject_createLabels(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGoogleProject_createLabels(pid, pname, org, "test", "that"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectHasLabels("google_project.acceptance", pid, map[string]string{"test": "that"}),
 				),
 			},
 		},
@@ -154,6 +174,48 @@ func TestAccGoogleProject_merge(t *testing.T) {
 	})
 }
 
+// Test that a Project resource can be updated with labels
+func TestAccGoogleProject_updateLabels(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// create project without labels
+			{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+			// update project with labels
+			{
+				Config: testAccGoogleProject_updateLabels(pid, pname, org, map[string]string{"label": "label-value"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					testAccCheckGoogleProjectHasLabels("google_project.acceptance", pid, map[string]string{"label": "label-value"}),
+				),
+			},
+			// update project with other labels
+			{
+				Config: testAccGoogleProject_updateLabels(pid, pname, org, map[string]string{"empty-label": ""}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					testAccCheckGoogleProjectHasLabels("google_project.acceptance", pid, map[string]string{"empty-label": ""}),
+				),
+			},
+			// update project delete labels
+			{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					testAccCheckGoogleProjectHasNoLabels("google_project.acceptance", pid),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
@@ -212,6 +274,77 @@ func testAccCheckGoogleProjectHasMoreBindingsThan(pid string, count int) resourc
 	}
 }
 
+func testAccCheckGoogleProjectHasLabels(r, pid string, expected map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("Not found: %s", r)
+		}
+
+		// State should have the same number of labels
+		if rs.Primary.Attributes["labels.%"] != strconv.Itoa(len(expected)) {
+			return fmt.Errorf("Expected %d labels, got %s", len(expected), rs.Primary.Attributes["labels.%"])
+		}
+
+		// Actual value in API should match state and expected
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientResourceManager.Projects.Get(pid).Do()
+		if err != nil {
+			return err
+		}
+
+		actual := found.Labels
+		if !reflect.DeepEqual(actual, expected) {
+			// Determine only the different attributes
+			for k, v := range expected {
+				if av, ok := actual[k]; ok && v == av {
+					delete(expected, k)
+					delete(actual, k)
+				}
+			}
+
+			spewConf := spew.NewDefaultConfig()
+			spewConf.SortKeys = true
+			return fmt.Errorf(
+				"Labels not equivalent. Difference is shown below. Top is actual, bottom is expected."+
+					"\n\n%s\n\n%s",
+				spewConf.Sdump(actual), spewConf.Sdump(expected),
+			)
+		}
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectHasNoLabels(r, pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("Not found: %s", r)
+		}
+
+		// State should have zero labels
+		if rs.Primary.Attributes["labels.%"] != "0" {
+			return fmt.Errorf("Expected 0 labels, got %s", rs.Primary.Attributes["labels.%"])
+		}
+
+		// Actual value in API should match state and expected
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientResourceManager.Projects.Get(pid).Do()
+		if err != nil {
+			return err
+		}
+
+		spewConf := spew.NewDefaultConfig()
+		spewConf.SortKeys = true
+		if found.Labels != nil {
+			return fmt.Errorf("Labels should be empty. Actual \n%s", spewConf.Sdump(found.Labels))
+		}
+		return nil
+	}
+}
+
 func testAccGoogleProject_toMerge(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -242,6 +375,35 @@ resource "google_project" "acceptance" {
     name = "%s"
     org_id = "%s"
 }`, pid, name, org)
+}
+
+func testAccGoogleProject_createLabels(pid, name, org, key, value string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+	labels {
+		"%s" = "%s"
+	}
+}`, pid, name, org, key, value)
+}
+
+func testAccGoogleProject_updateLabels(pid, name, org string, labels map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+	labels {`, pid, name, org)
+
+	l := ""
+	for key, value := range labels {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }
 
 func skipIfEnvNotSet(t *testing.T, envs ...string) {

--- a/website/docs/r/google_project.html.markdown
+++ b/website/docs/r/google_project.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
     This argument is no longer supported, and will be removed in a future version
     of Terraform. It should be replaced with a `google_project_iam_policy` resource.
 
+* `labels` - (Optional) A set of key/value label pairs to assign to the project.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
This PR adds support for labels in the `google_project` resource.

e.g.
```
resource "google_project" "testing" {
  project_id      = "gcp-1234"
  name            = gcp-1234"
  org_id          = "XXXX"
  billing_account = "XXX"

  labels {
    environment = "production"
    app_env     = "staging"
  }
}
``` 

Acceptance Tests

```
make testacc TEST=./google TESTARGS='-run=TestAccGoogleProject_createLabels' GOOGLE_USE_DEFAULT_CREDENTIALS=true
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccGoogleProject_createLabels -timeout 120m
=== RUN   TestAccGoogleProject_createLabels
--- PASS: TestAccGoogleProject_createLabels (20.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 20.566s
make testacc TEST=./google TESTARGS='-run=TestAccGoogleProject_updateLabels' GOOGLE_USE_DEFAULT_CREDENTIALS=true
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccGoogleProject_updateLabels -timeout 120m
=== RUN   TestAccGoogleProject_updateLabels
--- PASS: TestAccGoogleProject_updateLabels (33.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 33.732s
```