### PR TITLE
Expose additional properties during cluster creation

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -59,7 +59,7 @@ func resourceContainerCluster() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Default: true,
+							Default:  true,
 						},
 						"password": {
 							Type:      schema.TypeString,

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -541,11 +541,11 @@ func testAccCheckContainerCluster(n string) resource.TestCheckFunc {
 			// attributes won't contain the mapped values unless they were provided in the template the tests will
 			// fail. We limit checking these fields unless they are part of the template itself
 			if np.Management != nil {
-				if _, ok := attributes[prefix + "management.0.auto_upgrade"]; ok {
+				if _, ok := attributes[prefix+"management.0.auto_upgrade"]; ok {
 					clusterTests = append(clusterTests, clusterTestField{prefix + "management.0.auto_upgrade", strconv.FormatBool(np.Management.AutoUpgrade)})
 				}
 
-				if _, ok := attributes[prefix + "management.0.auto_repair"]; ok {
+				if _, ok := attributes[prefix+"management.0.auto_repair"]; ok {
 					clusterTests = append(clusterTests, clusterTestField{prefix + "management.0.auto_repair", strconv.FormatBool(np.Management.AutoRepair)})
 				}
 			}

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -187,7 +187,7 @@ addons_config {
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
 
-* `auto_scaling` - (Optional) Configures the auto scaling parameters for the cluster
+* `autoscaling` - (Optional) Configures the auto scaling parameters for the cluster
 
 * `management` - (Optional) Defines the set of node management services turned on for the node pool
 

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -117,6 +117,9 @@ which the cluster's instances are launched
 * `username` - (Required) The username to use for HTTP basic authentication when accessing
     the Kubernetes master endpoint
 
+* `issue_client_certificate` - (Optional) Enables or disables the creation of the client
+    certificates on the cluster
+
 **Node Config** supports the following arguments:
 
 * `machine_type` - (Optional) The name of a Google Compute Engine machine type.
@@ -183,6 +186,26 @@ addons_config {
 
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
+
+* `auto_scaling` - (Optional) Configures the auto scaling parameters for the cluster
+
+* `management` - (Optional) Defines the set of node management services turned on for the node pool
+
+**Auto Scaling** supports the following arguments:
+
+* `enabled` - (Optional) Enabled or disables auto-scaling for the node pool
+
+* `min_node_count` - (Optional) The minimum number of nodes that the node pool should keep active
+
+* `max_node_count` - (Optional) The maximum number of nodes that the node pool can auto-scale to
+
+**Management** supports the following arguments:
+
+* `auto_repair` - (Optional) Enables or disables auto-repair for the node pool. If enabled, the nodes in the pool will be
+monitored and it they fail a health check too many times, an automatic repair action will be triggerd.
+
+* `auto_upgrade` - (Optional) Specifies whether auto-node upgrade is enabled for this node pool. If enabled,
+node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Allow for sending IssueClientCertificate as part of the cluster creation request
Allow for sending the Management object as part of the cluster creation request
Allow for sending the AutoScale object as part of the cluster creation request