### PR TITLE
Add google_client_config data source

### DIFF
--- a/google/data_source_google_client_config.go
+++ b/google/data_source_google_client_config.go
@@ -1,0 +1,34 @@
+package google
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleClientConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceClientConfigRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceClientConfigRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("project", config.Project)
+	d.Set("region", config.Region)
+
+	return nil
+}

--- a/google/data_source_google_client_config_test.go
+++ b/google/data_source_google_client_config_test.go
@@ -1,0 +1,29 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
+	resourceName := "data.google_client_config.current"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleClientConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckGoogleClientConfig_basic = `
+data "google_client_config" "current" { }
+`

--- a/google/provider.go
+++ b/google/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"google_dns_managed_zone":          dataSourceDnsManagedZone(),
+			"google_client_config":             dataSourceGoogleClientConfig(),
 			"google_compute_network":           dataSourceGoogleComputeNetwork(),
 			"google_compute_subnetwork":        dataSourceGoogleComputeSubnetwork(),
 			"google_compute_zones":             dataSourceGoogleComputeZones(),

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -26,8 +26,8 @@ There are no arguments available for this data source.
 
 ## Attributes Reference
 
+In addition to the arguments listed above, the following attributes are exported:
+
 * `project` - The ID of the project to apply any resources to.
 
 * `region` - The region to operate under.
-
-* `credentials` - Contents of the JSON file used to describe your account credentials.

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "google"
+page_title: "Google: google_client_config"
+sidebar_current: "docs-google-datasource-client-config"
+description: |-
+  Get information about the configuration of the Google Cloud provider.
+---
+
+# google\_client\_config
+
+Use this data source to access the configuration of the Google Cloud provider.
+
+## Example Usage
+
+```tf
+data "google_client_config" "current" {}
+
+output "project" {
+  value = "${data.google_client_config.current.project}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+* `project` - The ID of the project to apply any resources to.
+
+* `region` - The region to operate under.
+
+* `credentials` - Contents of the JSON file used to describe your account credentials.

--- a/website/google.erb
+++ b/website/google.erb
@@ -13,6 +13,9 @@
     <li<%= sidebar_current("docs-google-datasource") %>>
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav nav-visible">
+      <li<%= sidebar_current("docs-google-datasource-client-config") %>>
+        <a href="/docs/providers/google/d/datasource_client_config.html">google_compute_network</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
@@ -298,7 +301,7 @@
       <li<%= sidebar_current("docs-google-spanner-instance") %>>
       <a href="/docs/providers/google/r/spanner_instance.html">google_spanner_instance</a>
       </li>
-      
+
       <li<%= sidebar_current("docs-google-spanner-database") %>>
       <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
       </li>


### PR DESCRIPTION
Add a new data source, `google_client_config`, which is the GCP equivalent of the [`azurerm_client_config`](https://www.terraform.io/docs/providers/azurerm/d/client_config.html) data source. It can be used to get information about the configuration of the Google Cloud provider.
I decided not to include the [`credentials`](https://www.terraform.io/docs/providers/google/index.html#credentials) attribute as this value would be stored in the state file and can be sensitive.
Acceptance tests:
```
make testacc TEST=./google/ TESTARGS='-run=TestAccDataSourceGoogleClientConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google/ -v -run=TestAccDataSourceGoogleClientConfig -timeout 120m
=== RUN   TestAccDataSourceGoogleClientConfig_basic
--- PASS: TestAccDataSourceGoogleClientConfig_basic (0.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	0.031s
```