### PR TITLE
Add DSF for address' region field.

### DIFF
--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"google.golang.org/api/compute/v1"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
 )
 
 var (
@@ -46,10 +47,11 @@ func resourceComputeAddress() *schema.Resource {
 			},
 
 			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: linkDiffSuppress,
 			},
 
 			"self_link": &schema.Schema{

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -93,6 +93,25 @@ func TestAccComputeAddress_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeAddress_region(t *testing.T) {
+	var addr compute.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeAddressDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeAddress_region(acctest.RandomWithPrefix("test")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeAddressExists(
+						"google_compute_address.foobar", &addr),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeAddressDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -148,3 +167,11 @@ var testAccComputeAddress_basic = fmt.Sprintf(`
 resource "google_compute_address" "foobar" {
 	name = "address-test-%s"
 }`, acctest.RandString(10))
+
+func testAccComputeAddress_region(name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_address" "foobar" {
+	name = "%s"
+	region = "us-central1"
+}`, name)
+}


### PR DESCRIPTION
Region used to require the full self_link of a region to be in the
config. Now it accepts the name or the self_link.

Note that this will have weird consequences if referenced from a
field that doesn't support both name and self_link as well, but that
honestly is a bug in the other field, and should be fixed there, in my
opinion.

The other option is a StateFunc that translates everything to a
self_link, at least making things consistent in state, but I wasn't sure
it was worth the effort. IF we like, I can take that route instead.