### PR TITLE
Cross-reference multi-zone and single-zone documentation

### DIFF
--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -11,7 +11,9 @@ description: |-
 The Google Compute Engine Instance Group Manager API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance
 template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
-and [API](https://cloud.google.com/compute/docs/instance-groups/manager/v1beta2/instanceGroupManagers)
+and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers)
+
+~> **Note:** Use [google_compute_region_instance_group_manager](/docs/providers/google/r/google_compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
 
 ## Example Usage
 

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -13,6 +13,8 @@ of homogeneous Compute Engine virtual machine instances from a common instance
 template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups)
 and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroupManagers)
 
+~> **Note:** Use [google_compute_instance_group_manager](/docs/providers/google/r/google_compute_instance_group_manager.html) to create a single-zone instance group manager.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Also fix the API link for `google_compute_instance_group_manager` documentation.

cc/ @selmanj 