### PR TITLE
Update compute_global_forwading_rule docs to reference global IP address

### DIFF
--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `ip_address` - (Optional) The static IP. (if not set, an ephemeral IP is
     used). This should be the literal IP address to be used, not the `self_link`
-    to a `google_compute_address` resource. (If using a `google_compute_address`
+    to a `google_compute_global_address` resource. (If using a `google_compute_global_address`
     resource, use the `address` property instead of the `self_link` property.)
 
 * `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH"


### PR DESCRIPTION
Global forwarding rules need to use global IP addresses (google_compute_global_address),
not regional IP addresses (google_compute_address). Here's my related issue for improving the error message if you use the wrong kind: https://issuetracker.google.com/issues/65534174.