### PR TITLE
Fix BigQuery Dataset doc

### DIFF
--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
     expirationTime when creating a table, that value takes precedence
     over the default expiration time indicated by this property.
 
-  * `labels` - (Optional) A mapping of labels to assign to the resource.
+* `labels` - (Optional) A mapping of labels to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The `labels` argument should not be nested under `default_table_expiration_ms`