### PR TITLE
Instance group manager cleanup

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -105,9 +105,8 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"target_pools": &schema.Schema{
-				Type:             schema.TypeSet,
-				Optional:         true,
-				DiffSuppressFunc: compareSelfLinkRelativePaths,
+				Type:     schema.TypeSet,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -98,9 +98,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"update_strategy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "RESTART",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "RESTART",
+				ValidateFunc: validation.StringInSlice([]string{"RESTART", "NONE"}, false),
 			},
 
 			"target_pools": &schema.Schema{
@@ -178,45 +179,18 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	targetSize := int64(0)
-	if v, ok := d.GetOk("target_size"); ok {
-		targetSize = int64(v.(int))
-	}
-
 	// Build the parameter
 	manager := &computeBeta.InstanceGroupManager{
-		Name:             d.Get("name").(string),
-		BaseInstanceName: d.Get("base_instance_name").(string),
-		InstanceTemplate: d.Get("instance_template").(string),
-		TargetSize:       targetSize,
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		BaseInstanceName:    d.Get("base_instance_name").(string),
+		InstanceTemplate:    d.Get("instance_template").(string),
+		TargetSize:          int64(d.Get("target_size").(int)),
+		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
+		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
+		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		// Force send TargetSize to allow a value of 0.
 		ForceSendFields: []string{"TargetSize"},
-	}
-
-	// Set optional fields
-	if v, ok := d.GetOk("description"); ok {
-		manager.Description = v.(string)
-	}
-
-	if v, ok := d.GetOk("named_port"); ok {
-		manager.NamedPorts = getNamedPortsBeta(v.([]interface{}))
-	}
-
-	if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
-		var s []string
-		for _, v := range attr.List() {
-			s = append(s, v.(string))
-		}
-		manager.TargetPools = s
-	}
-
-	updateStrategy := d.Get("update_strategy").(string)
-	if !(updateStrategy == "NONE" || updateStrategy == "RESTART") {
-		return fmt.Errorf("Update strategy must be \"NONE\" or \"RESTART\"")
-	}
-
-	if v, ok := d.GetOk("auto_healing_policies"); ok {
-		manager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] InstanceGroupManager insert request: %#v", manager)
@@ -363,11 +337,10 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		manager = v0betaManager
 	}
 
-	zoneUrl := strings.Split(manager.Zone, "/")
 	d.Set("base_instance_name", manager.BaseInstanceName)
 	d.Set("instance_template", manager.InstanceTemplate)
 	d.Set("name", manager.Name)
-	d.Set("zone", zoneUrl[len(zoneUrl)-1])
+	d.Set("zone", GetResourceNameFromSelfLink(manager.Zone))
 	d.Set("description", manager.Description)
 	d.Set("project", project)
 	d.Set("target_size", manager.TargetSize)
@@ -399,12 +372,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 	// If target_pools changes then update
 	if d.HasChange("target_pools") {
-		var targetPools []string
-		if attr := d.Get("target_pools").(*schema.Set); attr.Len() > 0 {
-			for _, v := range attr.List() {
-				targetPools = append(targetPools, v.(string))
-			}
-		}
+		targetPools := convertStringSet(d.Get("target_pools").(*schema.Set))
 
 		// Build the parameter
 		setTargetPools := &computeBeta.InstanceGroupManagersSetTargetPoolsRequest{

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"sort"
 )
 
 func TestAccInstanceGroupManager_basic(t *testing.T) {
@@ -70,7 +71,8 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 	var manager compute.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	target1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	target2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	template2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -80,7 +82,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccInstanceGroupManager_update(template1, target, igm),
+				Config: testAccInstanceGroupManager_update(template1, target1, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-update", &manager),
@@ -91,13 +93,13 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccInstanceGroupManager_update2(template1, target, template2, igm),
+				Config: testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-update", &manager),
 					testAccCheckInstanceGroupManagerUpdated(
 						"google_compute_instance_group_manager.igm-update", 3,
-						"google_compute_target_pool.igm-update", template2),
+						[]string{target1, target2}, template2),
 					testAccCheckInstanceGroupManagerNamedPorts(
 						"google_compute_instance_group_manager.igm-update",
 						map[string]int64{"customhttp": 8080, "customhttps": 8443},
@@ -313,7 +315,7 @@ func testAccCheckInstanceGroupManagerBetaExists(n string, manager *computeBeta.I
 	}
 }
 
-func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPool string, template string) resource.TestCheckFunc {
+func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPools []string, template string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -336,6 +338,18 @@ func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPool st
 		// check the target_size.
 		if manager.TargetSize != size {
 			return fmt.Errorf("instance count incorrect")
+		}
+
+		tpNames := make([]string, 0, len(manager.TargetPools))
+		for _, targetPool := range manager.TargetPools {
+			targetPoolParts := strings.Split(targetPool, "/")
+			tpNames = append(tpNames, targetPoolParts[len(targetPoolParts)-1])
+		}
+
+		sort.Strings(tpNames)
+		sort.Strings(targetPools)
+		if !reflect.DeepEqual(tpNames, targetPools) {
+			return fmt.Errorf("target pools incorrect. Expected %s, got %s", targetPools, tpNames)
 		}
 
 		// check that the instance template updated
@@ -617,7 +631,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 }
 
 // Change IGM's instance template and target size
-func testAccInstanceGroupManager_update2(template1, target, template2, igm string) string {
+func testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_instance_template" "igm-update" {
 		name = "%s"
@@ -645,6 +659,12 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 	}
 
 	resource "google_compute_target_pool" "igm-update" {
+		description = "Resource created for Terraform acceptance testing"
+		name = "%s"
+		session_affinity = "CLIENT_IP_PROTO"
+	}
+
+	resource "google_compute_target_pool" "igm-update2" {
 		description = "Resource created for Terraform acceptance testing"
 		name = "%s"
 		session_affinity = "CLIENT_IP_PROTO"
@@ -679,7 +699,10 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		description = "Terraform test instance group manager"
 		name = "%s"
 		instance_template = "${google_compute_instance_template.igm-update2.self_link}"
-		target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
+		target_pools = [
+			"${google_compute_target_pool.igm-update.self_link}",
+			"${google_compute_target_pool.igm-update2.self_link}",
+		]
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
 		target_size = 3
@@ -691,7 +714,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 			name = "customhttps"
 			port = 8443
 		}
-	}`, template1, target, template2, igm)
+	}`, template1, target1, target2, template2, igm)
 }
 
 func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -86,6 +86,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-update", &manager),
+					testAccCheckInstanceGroupManagerUpdated("google_compute_instance_group_manager.igm-update", 2, []string{target1}, template1),
 					testAccCheckInstanceGroupManagerNamedPorts(
 						"google_compute_instance_group_manager.igm-update",
 						map[string]int64{"customhttp": 8080},


### PR DESCRIPTION
* Use ValidateFunc for update_strategy to move the validation at `plan` time.
* Rely on d.Get default values to avoid extraneous GetOk if checks
* Use common `convertStringSet` method whenever possible.
* Improve acceptance test assertion on target pools (before we were not doing any assertion at all on target pools)
* Improve acceptance test to test the multiple target pools update scenario.
* Remove the DiffSupressFunc from the TypeSet. All target pools are name so the function is useless and is causing issues when updating. 