### PR TITLE
Add DiffSuppressFunc to GKE cluster networks

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -176,10 +176,11 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"network": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "default",
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "default",
+				ForceNew:         true,
+				DiffSuppressFunc: linkDiffSuppress,
 			},
 			"subnetwork": {
 				Type:     schema.TypeString,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -176,11 +176,11 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"network": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          "default",
-				ForceNew:         true,
-				DiffSuppressFunc: linkDiffSuppress,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "default",
+				ForceNew:  true,
+				StateFunc: StoreResourceName,
 			},
 			"subnetwork": {
 				Type:     schema.TypeString,

--- a/google/self_link_helpers.go
+++ b/google/self_link_helpers.go
@@ -69,3 +69,7 @@ func GetResourceNameFromSelfLink(link string) string {
 	parts := strings.Split(link, "/")
 	return parts[len(parts)-1]
 }
+
+func StoreResourceName(resourceLink interface{}) string {
+	return GetResourceNameFromSelfLink(resourceLink.(string))
+}

--- a/google/utils.go
+++ b/google/utils.go
@@ -251,8 +251,9 @@ func isConflictError(err error) bool {
 }
 
 func linkDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	parts := strings.Split(old, "/")
-	if parts[len(parts)-1] == new {
+	oldParts := strings.Split(old, "/")
+	newParts := strings.Split(new, "/")
+	if oldParts[len(oldParts)-1] == newParts[len(newParts)-1] {
 		return true
 	}
 	return false

--- a/google/utils.go
+++ b/google/utils.go
@@ -251,9 +251,8 @@ func isConflictError(err error) bool {
 }
 
 func linkDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	oldParts := strings.Split(old, "/")
-	newParts := strings.Split(new, "/")
-	if oldParts[len(oldParts)-1] == newParts[len(newParts)-1] {
+	parts := strings.Split(old, "/")
+	if parts[len(parts)-1] == new {
 		return true
 	}
 	return false


### PR DESCRIPTION
`TestAccContainerCluster_network` was failing with a perma-diff after #391 because GKE returns the network as a name only, but we allow users to set it to the URL. Add a DiffSuppressFunc to fix the test:
```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_network'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_network -timeout 120m
=== RUN   TestAccContainerCluster_network
--- PASS: TestAccContainerCluster_network (348.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	348.976s
```