### PR TITLE
Save region name-only instead of the self-link in compute_address

### DIFF
--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -113,7 +113,7 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("address", addr.Address)
 	d.Set("self_link", addr.SelfLink)
 	d.Set("name", addr.Name)
-	d.Set("region", addr.Region)
+	d.Set("region", GetResourceNameFromSelfLink(addr.Region))
 
 	return nil
 }


### PR DESCRIPTION
Fixes #418

My change in #378 broke the TestAccComputeRouterInterface_basic.

Before

```sh
=== RUN   TestAccComputeRouterInterface_basic
--- FAIL: TestAccComputeRouterInterface_basic (213.52s)
    testing.go:434: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: google_compute_address.foobar
          address:   "35.202.203.23" => "<computed>"
          name:      "router-interface-test-mbf86si3bk" => "router-interface-test-mbf86si3bk"
          region:    "https://www.googleapis.com/compute/v1/projects/*******/regions/us-central1" => "us-central1" (forces new resource)
          self_link: "https://www.googleapis.com/compute/v1/projects/*******/regions/us-central1/addresses/router-interface-test-mbf86si3bk" => "<computed>"
[other stuff]
```

After this PR.

```sh
TF_ACC=1 go test ./google -v -run TestAccComputeRouterInterface_basic -timeout 120m
=== RUN   TestAccComputeRouterInterface_basic
--- PASS: TestAccComputeRouterInterface_basic (203.91s)
PASS
```