### PR TITLE
Save name-only instead of link path in pubsub_topic

### DIFF
--- a/google/resource_pubsub_topic.go
+++ b/google/resource_pubsub_topic.go
@@ -66,7 +66,7 @@ func resourcePubsubTopicRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d, fmt.Sprintf("Pubsub Topic %q", name))
 	}
 
-	d.Set("name", res.Name)
+	d.Set("name", GetResourceNameFromSelfLink(res.Name))
 
 	return nil
 }


### PR DESCRIPTION
Fixes #423. 

Before:
```sh
------- Stdout: -------
=== RUN   TestAccPubsubSubscriptionCreate
--- FAIL: TestAccPubsubSubscriptionCreate (5.55s)
    testing.go:434: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: google_pubsub_subscription.foobar_sub
          ack_deadline_seconds: "20" => "20"
          name:                 "pssub-test-pmz09wu8bo" => "pssub-test-pmz09wu8bo"
          path:                 "projects/*******/subscriptions/pssub-test-pmz09wu8bo" => "<computed>"
          topic:                "pssub-test-6rnbrodpv7" => "projects/*******/topics/pssub-test-6rnbrodpv7" (forces new resource)
        
        STATE:
        
        google_pubsub_subscription.foobar_sub:
          ID = projects/*******/subscriptions/pssub-test-pmz09wu8bo
          ack_deadline_seconds = 20
          name = pssub-test-pmz09wu8bo
          path = projects/*******/subscriptions/pssub-test-pmz09wu8bo
          topic = pssub-test-6rnbrodpv7
        
          Dependencies:
            google_pubsub_topic.foobar_sub
        google_pubsub_topic.foobar_sub:
          ID = projects/*******/topics/pssub-test-6rnbrodpv7
          name = projects/*******/topics/pssub-test-6rnbrodpv7
FAIL
```

After this PR:
```
TF_ACC=1 go test ./google -v -run TestAccPubsub -timeout 120m
=== RUN   TestAccPubsubTopic_import
--- PASS: TestAccPubsubTopic_import (2.87s)
=== RUN   TestAccPubsubSubscriptionCreate
--- PASS: TestAccPubsubSubscriptionCreate (4.89s)
=== RUN   TestAccPubsubTopicCreate
--- PASS: TestAccPubsubTopicCreate (2.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	10.044s
```