### PR TITLE
computeBetaOperationWaitTime doesn't use the timeoutMin properly

### DIFF
--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -100,5 +100,5 @@ func computeBetaOperationWaitTime(config *Config, op *computeBeta.Operation, pro
 		return err
 	}
 
-	return computeOperationWaitTime(config, opV1, project, activity, 4)
+	return computeOperationWaitTime(config, opV1, project, activity, timeoutMin)
 }


### PR DESCRIPTION
The `timeoutMin` parameters of `computeBetaOperationWaitTime` in the method was never used and instead always used a 4min timeout.