### PR TITLE
Expose instance_id as a computed field on compute_instance

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -250,6 +250,11 @@ func resourceComputeInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -1175,6 +1180,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("cpu_platform", instance.CpuPlatform)
 	d.Set("min_cpu_platform", instance.MinCpuPlatform)
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
+	d.Set("instance_id", fmt.Sprintf("%d", instance.Id))
 	d.SetId(instance.Name)
 
 	return nil

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -52,6 +52,7 @@ func TestAccComputeInstance_basic1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasInstanceId(&instance, "google_compute_instance.foobar"),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceLabel(&instance, "my_key", "my_value"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
@@ -969,6 +970,25 @@ func testAccCheckComputeInstanceDisk(instance *compute.Instance, source string, 
 		}
 
 		return fmt.Errorf("Disk not found: %s", source)
+	}
+}
+
+func testAccCheckComputeInstanceHasInstanceId(instance *compute.Instance, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		remote := fmt.Sprintf("%d", instance.Id)
+		local := rs.Primary.Attributes["instance_id"]
+
+		if remote != local {
+			return fmt.Errorf("Instance id stored does not match: remote has %#v but local has %#v", remote,
+				local)
+		}
+
+		return nil
 	}
 }
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -293,6 +293,8 @@ The `guest_accelerator` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `instance_id` - The server-assigned unique identifier of this instance.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.


### PR DESCRIPTION
Surprisingly, the Id of the compute instance is not currently exposed. Here I added it as `instance_id` to avoid colliding with terraform's internal id.