### PR TITLE
Fix error message not getting expanded properly.

### DIFF
--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -259,7 +259,7 @@ func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pi
 		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error applying IAM policy for project %q. Policy is %#v, error is {{err}}", pid, policy), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error applying IAM policy for project %q. Policy is %#v, error is {{err}}", pid, policy), err)
 	}
 	return nil
 }


### PR DESCRIPTION
Before this change, I get an error like:
```
Error applying plan:

1 error(s) occurred:

* google_project_iam_binding.log-writer: 1 error(s) occurred:

* google_project_iam_binding.log-writer: Error applying IAM policy to project: Error applying IAM policy for project "terraform-devel". Policy is &cloudresourcemanager.Policy{[...], error is {{err}}
```

This change properly expands out {{err}} to contain the actual error message.