### PR TITLE
Renaming cluster import test to match other acceptance tests naming scheme

### DIFF
--- a/google/import_container_cluster_test.go
+++ b/google/import_container_cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleContainerCluster_import(t *testing.T) {
+func TestAccContainerCluster_import(t *testing.T) {
 	resourceName := "google_container_cluster.primary"
 	name := fmt.Sprintf("tf-cluster-test-%s", acctest.RandString(10))
 	conf := testAccContainerCluster_basic(name)


### PR DESCRIPTION
Update the name of the import acceptance test to match the naming scheme of the other acceptances for gke cluster:

TestAccGoogleContainerCluster_import -> TestAccContainerCluster_import

TestAccContainerCluster_basic

This way, when we run tests for `TestAccContainerCluster_`, the import tests are running too.

cc/ @danawillow 