### PR TITLE
Assign IAM policy to folder.

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -107,6 +107,7 @@ func Provider() terraform.ResourceProvider {
 			"google_dns_managed_zone":                      resourceDnsManagedZone(),
 			"google_dns_record_set":                        resourceDnsRecordSet(),
 			"google_folder":                                resourceGoogleFolder(),
+			"google_folder_iam_policy":                     resourceGoogleFolderIamPolicy(),
 			"google_logging_project_sink":                  resourceLoggingProjectSink(),
 			"google_sourcerepo_repository":                 resourceSourceRepoRepository(),
 			"google_spanner_instance":                      resourceSpannerInstance(),

--- a/google/resource_google_folder_iam_policy.go
+++ b/google/resource_google_folder_iam_policy.go
@@ -57,7 +57,7 @@ func resourceGoogleFolderIamPolicyRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Set("etag", policy.Etag)
-	d.Set("policy_data", encodeV2IamPolicy(policy))
+	d.Set("policy_data", marshalV2IamPolicy(policy))
 
 	return nil
 }
@@ -92,7 +92,7 @@ func resourceGoogleFolderIamPolicyDelete(d *schema.ResourceData, meta interface{
 
 func setFolderIamPolicy(d *schema.ResourceData, config *Config) error {
 	folder := d.Get("folder").(string)
-	policy, err := decodeV2IamPolicy(d.Get("policy_data").(string))
+	policy, err := unmarshalV2IamPolicy(d.Get("policy_data").(string))
 	if err != nil {
 		return fmt.Errorf("'policy_data' is not valid for %s: %s", folder, err)
 	}
@@ -105,14 +105,14 @@ func setFolderIamPolicy(d *schema.ResourceData, config *Config) error {
 	return err
 }
 
-func encodeV2IamPolicy(policy *resourceManagerV2Beta1.Policy) string {
+func marshalV2IamPolicy(policy *resourceManagerV2Beta1.Policy) string {
 	pdBytes, _ := json.Marshal(&resourceManagerV2Beta1.Policy{
 		Bindings: policy.Bindings,
 	})
 	return string(pdBytes)
 }
 
-func decodeV2IamPolicy(policyData string) (*resourceManagerV2Beta1.Policy, error) {
+func unmarshalV2IamPolicy(policyData string) (*resourceManagerV2Beta1.Policy, error) {
 	policy := &resourceManagerV2Beta1.Policy{}
 	if err := json.Unmarshal([]byte(policyData), policy); err != nil {
 		return nil, fmt.Errorf("Could not unmarshal policy data %s:\n%s", policyData, err)
@@ -121,7 +121,7 @@ func decodeV2IamPolicy(policyData string) (*resourceManagerV2Beta1.Policy, error
 }
 
 func validateV2IamPolicy(i interface{}, k string) (s []string, es []error) {
-	_, err := decodeV2IamPolicy(i.(string))
+	_, err := unmarshalV2IamPolicy(i.(string))
 	if err != nil {
 		es = append(es, err)
 	}

--- a/google/resource_google_folder_iam_policy.go
+++ b/google/resource_google_folder_iam_policy.go
@@ -1,0 +1,129 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"encoding/json"
+	"fmt"
+	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
+)
+
+func resourceGoogleFolderIamPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleFolderIamPolicyCreate,
+		Read:   resourceGoogleFolderIamPolicyRead,
+		Update: resourceGoogleFolderIamPolicyUpdate,
+		Delete: resourceGoogleFolderIamPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"folder": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy_data": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: jsonPolicyDiffSuppress,
+				ValidateFunc:     validateV2IamPolicy,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleFolderIamPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	if err := setFolderIamPolicy(d, config); err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("folder").(string))
+
+	return resourceGoogleFolderIamPolicyRead(d, meta)
+}
+
+func resourceGoogleFolderIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	folder := d.Get("folder").(string)
+
+	policy, err := config.clientResourceManagerV2Beta1.Folders.GetIamPolicy(folder, &resourceManagerV2Beta1.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Iam policy for %s", folder))
+	}
+
+	d.Set("etag", policy.Etag)
+	d.Set("policy_data", encodeV2IamPolicy(policy))
+
+	return nil
+}
+
+func resourceGoogleFolderIamPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	if d.HasChange("policy_data") {
+		if err := setFolderIamPolicy(d, config); err != nil {
+			return err
+		}
+	}
+
+	return resourceGoogleFolderIamPolicyRead(d, meta)
+}
+
+func resourceGoogleFolderIamPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	folder := d.Get("folder").(string)
+
+	_, err := config.clientResourceManagerV2Beta1.Folders.SetIamPolicy(folder, &resourceManagerV2Beta1.SetIamPolicyRequest{
+		Policy:     &resourceManagerV2Beta1.Policy{},
+		UpdateMask: "bindings",
+	}).Do()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setFolderIamPolicy(d *schema.ResourceData, config *Config) error {
+	folder := d.Get("folder").(string)
+	policy, err := decodeV2IamPolicy(d.Get("policy_data").(string))
+	if err != nil {
+		return fmt.Errorf("'policy_data' is not valid for %s: %s", folder, err)
+	}
+
+	_, err = config.clientResourceManagerV2Beta1.Folders.SetIamPolicy(folder, &resourceManagerV2Beta1.SetIamPolicyRequest{
+		Policy:     policy,
+		UpdateMask: "bindings",
+	}).Do()
+
+	return err
+}
+
+func encodeV2IamPolicy(policy *resourceManagerV2Beta1.Policy) string {
+	pdBytes, _ := json.Marshal(&resourceManagerV2Beta1.Policy{
+		Bindings: policy.Bindings,
+	})
+	return string(pdBytes)
+}
+
+func decodeV2IamPolicy(policyData string) (*resourceManagerV2Beta1.Policy, error) {
+	policy := &resourceManagerV2Beta1.Policy{}
+	if err := json.Unmarshal([]byte(policyData), policy); err != nil {
+		return nil, fmt.Errorf("Could not unmarshal policy data %s:\n%s", policyData, err)
+	}
+	return policy, nil
+}
+
+func validateV2IamPolicy(i interface{}, k string) (s []string, es []error) {
+	_, err := decodeV2IamPolicy(i.(string))
+	if err != nil {
+		es = append(es, err)
+	}
+	return
+}

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -134,6 +134,10 @@ func testAccCheckGoogleFolderIamPolicy(n string, policy *resourceManagerV2Beta1.
 			return fmt.Errorf("Incorrect iam policy bindings. Expected '%s', got '%s'", policy.Bindings, p.Bindings)
 		}
 
+		if _, ok = rs.Primary.Attributes["etag"]; !ok {
+			return fmt.Errorf("Etag should be set.")
+		}
+
 		return nil
 	}
 }

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -1,0 +1,168 @@
+package google
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
+	skipIfEnvNotSet(t, "GOOGLE_ORG")
+
+	folderDisplayName := "tf-test-" + acctest.RandString(10)
+	org := os.Getenv("GOOGLE_ORG")
+	parent := "organizations/" + org
+
+	policy := &resourceManagerV2Beta1.Policy{
+		Bindings: []*resourceManagerV2Beta1.Binding{
+			{
+				Role: "roles/viewer",
+				Members: []string{
+					"user:admin@hashicorptest.com",
+				},
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleFolderIamPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy),
+				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy),
+			},
+		},
+	})
+}
+
+func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
+	skipIfEnvNotSet(t, "GOOGLE_ORG")
+
+	folderDisplayName := "tf-test-" + acctest.RandString(10)
+	org := os.Getenv("GOOGLE_ORG")
+	parent := "organizations/" + org
+
+	policy1 := &resourceManagerV2Beta1.Policy{
+		Bindings: []*resourceManagerV2Beta1.Binding{
+			{
+				Role: "roles/viewer",
+				Members: []string{
+					"user:admin@hashicorptest.com",
+				},
+			},
+		},
+	}
+	policy2 := &resourceManagerV2Beta1.Policy{
+		Bindings: []*resourceManagerV2Beta1.Binding{
+			{
+				Role: "roles/viewer",
+				Members: []string{
+					"user:admin@hashicorptest.com",
+				},
+			},
+			{
+				Role: "roles/editor",
+				Members: []string{
+					"user:admin@hashicorptest.com",
+				},
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleFolderIamPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy1),
+				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy1),
+			},
+			resource.TestStep{
+				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy2),
+				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy2),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleFolderIamPolicyDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_folder_iam_policy" {
+			continue
+		}
+
+		folder := rs.Primary.Attributes["folder"]
+		policy, err := config.clientResourceManagerV2Beta1.Folders.GetIamPolicy(folder, &resourceManagerV2Beta1.GetIamPolicyRequest{}).Do()
+
+		if err != nil && len(policy.Bindings) > 0 {
+			return fmt.Errorf("Folder '%s' policy hasn't been deleted.", folder)
+		}
+	}
+	return nil
+}
+
+func testAccCheckGoogleFolderIamPolicy(n string, policy *resourceManagerV2Beta1.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		p, err := config.clientResourceManagerV2Beta1.Folders.GetIamPolicy(rs.Primary.ID, &resourceManagerV2Beta1.GetIamPolicyRequest{}).Do()
+		if err != nil {
+			return err
+		}
+
+		if !reflect.DeepEqual(p.Bindings, policy.Bindings) {
+			return fmt.Errorf("Incorrect iam policy bindings. Expected '%s', got '%s'", policy.Bindings, p.Bindings)
+		}
+
+		return nil
+	}
+}
+
+func testAccGoogleFolderIamPolicy_basic(folder, parent string, policy *resourceManagerV2Beta1.Policy) string {
+	var bindingBuffer bytes.Buffer
+
+	for _, binding := range policy.Bindings {
+		bindingBuffer.WriteString("binding {\n")
+		bindingBuffer.WriteString(fmt.Sprintf("role = \"%s\"\n", binding.Role))
+		bindingBuffer.WriteString(fmt.Sprintf("members = [\n"))
+		for _, member := range binding.Members {
+			bindingBuffer.WriteString(fmt.Sprintf("\"%s\",\n", member))
+		}
+		bindingBuffer.WriteString("]}\n")
+	}
+	return fmt.Sprintf(`
+resource "google_folder" "permissiontest" {
+  display_name = "%s"
+  parent = "%s"
+}
+
+data "google_iam_policy" "test" {
+  %s
+}
+
+resource "google_folder_iam_policy" "test" {
+  folder = "${google_folder.permissiontest.name}"
+  policy_data = "${data.google_iam_policy.test.policy_data}"
+}
+`, folder, parent, bindingBuffer.String())
+}

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -138,6 +138,10 @@ func testAccCheckGoogleFolderIamPolicy(n string, policy *resourceManagerV2Beta1.
 			return fmt.Errorf("Etag should be set.")
 		}
 
+		if rs.Primary.Attributes["etag"] != p.Etag {
+			return fmt.Errorf("Incorrect etag value. Expected '%s', got '%s'", p.Etag, rs.Primary.Attributes["etag"])
+		}
+
 		return nil
 	}
 }

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -63,13 +63,13 @@ func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
 	policy2 := &resourceManagerV2Beta1.Policy{
 		Bindings: []*resourceManagerV2Beta1.Binding{
 			{
-				Role: "roles/viewer",
+				Role: "roles/editor",
 				Members: []string{
 					"user:admin@hashicorptest.com",
 				},
 			},
 			{
-				Role: "roles/editor",
+				Role: "roles/viewer",
 				Members: []string{
 					"user:admin@hashicorptest.com",
 				},

--- a/website/docs/r/google_folder.html.markdown
+++ b/website/docs/r/google_folder.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_folder"
-sidebar_current: "docs-google-folder"
+sidebar_current: "docs-google-folder-x"
 description: |-
  Allows management of a Google Cloud Platform folder.
 ---

--- a/website/docs/r/google_folder_iam_policy.html.markdown
+++ b/website/docs/r/google_folder_iam_policy.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "google"
+page_title: "Google: google_folder_iam_policy"
+sidebar_current: "docs-google-folders-iam-policy"
+description: |-
+ Allows management of the IAM policy for a Google Cloud Platform folders.
+---
+
+# google\_folder\_iam\_policy
+
+Allows creation and management of the IAM policy for an existing Google Cloud
+Platform folder.
+
+## Example Usage
+
+```hcl
+resource "google_folder_iam_policy" "folder_admin_policy" {
+  folder     = "${google_folder.department1.name}"
+  policy_data = "${data.google_iam_policy.admin.policy_data}"
+}
+
+resource "google_folder" "department1" {
+  display_name = "Department 1"
+  parent     = "organizations/1234567"
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/editor"
+
+    members = [
+      "user:jane@example.com",
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `folder` - (Required) The resource name of the folder the policy is attached to. Its format is folders/{folder_id}.
+
+* `policy_data` - (Required) The `google_iam_policy` data source that represents
+    the IAM policy that will be applied to the folder. This policy overrides any existing
+    policy applied to the folder.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `etag` - (Computed) The etag of the folder's IAM policy. `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. 

--- a/website/google.erb
+++ b/website/google.erb
@@ -68,8 +68,11 @@
     <li<%= sidebar_current("docs-google-(project|service)") %>>
     <a href="#">Google Cloud Platform Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-folder") %>>
+      <li<%= sidebar_current("docs-google-folder-x") %>>
         <a href="/docs/providers/google/r/google_folder.html">google_folder</a>
+      </li>
+      <li<%= sidebar_current("docs-google-folder-iam-policy") %>>
+        <a href="/docs/providers/google/r/google_folder_iam_policy.html">google_folder_iam_policy</a>
       </li>
       <li<%= sidebar_current("docs-google-project-x") %>>
         <a href="/docs/providers/google/r/google_project.html">google_project</a>


### PR DESCRIPTION
Fixes #413 

This overrides any existing permissions on the folder. If users have a valid use cases for managing some roles in terraform and some other outside of terraform, we can create a new resource `google_folder_iam_policy_binding` to support it. For now, I believe this will cover most use cases from our users. 