### PR TITLE
Pubsub subscription read state from API and import support

### DIFF
--- a/google/import_pubsub_subscription_test.go
+++ b/google/import_pubsub_subscription_test.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPubsubSubscription_import(t *testing.T) {
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
+	subscription := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPubsubTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccPubsubSubscription_basic(topic, subscription),
+			},
+			resource.TestStep{
+				ResourceName:      "google_pubsub_subscription.foobar_sub",
+				ImportStateId:     subscription,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -139,7 +139,7 @@ func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("topic", subscription.Topic)
 	d.Set("ack_deadline_seconds", subscription.AckDeadlineSeconds)
 	d.Set("path", subscription.Name)
-	d.Set("push_config", flattenPushConfigs(subscription.PushConfig))
+	d.Set("push_config", flattenPushConfig(subscription.PushConfig))
 
 	return nil
 }
@@ -172,7 +172,7 @@ func resourcePubsubSubscriptionStateImporter(d *schema.ResourceData, meta interf
 	return []*schema.ResourceData{d}, nil
 }
 
-func flattenPushConfigs(pushConfig *pubsub.PushConfig) []map[string]interface{} {
+func flattenPushConfig(pushConfig *pubsub.PushConfig) []map[string]interface{} {
 	configs := make([]map[string]interface{}, 0, 1)
 
 	if pushConfig == nil || len(pushConfig.PushEndpoint) == 0 {

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -13,6 +13,10 @@ func resourcePubsubSubscription() *schema.Resource {
 		Read:   resourcePubsubSubscriptionRead,
 		Delete: resourcePubsubSubscriptionDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourcePubsubSubscriptionStateImporter,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -21,14 +25,16 @@ func resourcePubsubSubscription() *schema.Resource {
 			},
 
 			"topic": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"ack_deadline_seconds": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -47,6 +53,7 @@ func resourcePubsubSubscription() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attributes": &schema.Schema{
@@ -58,7 +65,7 @@ func resourcePubsubSubscription() *schema.Resource {
 
 						"push_endpoint": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ForceNew: true,
 						},
 					},
@@ -98,10 +105,6 @@ func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("push_config"); ok {
 		push_configs := v.([]interface{})
 
-		if len(push_configs) > 1 {
-			return fmt.Errorf("At most one PushConfig is allowed per subscription!")
-		}
-
 		push_config := push_configs[0].(map[string]interface{})
 		attributes := push_config["attributes"].(map[string]interface{})
 		attributesClean := cleanAdditionalArgs(attributes)
@@ -127,11 +130,16 @@ func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 
 	name := d.Id()
-	call := config.clientPubsub.Projects.Subscriptions.Get(name)
-	_, err := call.Do()
+	subscription, err := config.clientPubsub.Projects.Subscriptions.Get(name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Pubsub Subscription %q", name))
 	}
+
+	d.Set("name", GetResourceNameFromSelfLink(subscription.Name))
+	d.Set("topic", subscription.Topic)
+	d.Set("ack_deadline_seconds", subscription.AckDeadlineSeconds)
+	d.Set("path", subscription.Name)
+	d.Set("push_config", flattenPushConfigs(subscription.PushConfig))
 
 	return nil
 }
@@ -147,4 +155,34 @@ func resourcePubsubSubscriptionDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func resourcePubsubSubscriptionStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	id := fmt.Sprintf("projects/%s/subscriptions/%s", project, d.Id())
+
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func flattenPushConfigs(pushConfig *pubsub.PushConfig) []map[string]interface{} {
+	configs := make([]map[string]interface{}, 0, 1)
+
+	if pushConfig == nil || len(pushConfig.PushEndpoint) == 0 {
+		return configs
+	}
+
+	configs = append(configs, map[string]interface{}{
+		"push_endpoint": pushConfig.PushEndpoint,
+		"attributes":    pushConfig.Attributes,
+	})
+
+	return configs
 }

--- a/google/resource_pubsub_subscription_test.go
+++ b/google/resource_pubsub_subscription_test.go
@@ -41,6 +41,7 @@ func TestAccPubsubSubscription_basic(t *testing.T) {
 //
 // An easy way to test this would be to create an App Engine Hello World app. With AppEngine, SSL certificate, DNS and domain registry is handled for us.
 // App Engine is not yet supported by Terraform but once it is, it will provide an easy path to testing push configs.
+// Another option would be to use Cloud Functions once Terraform support is added.
 func testAccCheckPubsubSubscriptionDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "google_pubsub_subscription" {

--- a/google/resource_pubsub_subscription_test.go
+++ b/google/resource_pubsub_subscription_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccPubsubSubscriptionCreate(t *testing.T) {
+func TestAccPubsubSubscription_basic(t *testing.T) {
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
+	subscription := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +19,7 @@ func TestAccPubsubSubscriptionCreate(t *testing.T) {
 		CheckDestroy: testAccCheckPubsubSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubSubscription,
+				Config: testAccPubsubSubscription_basic(topic, subscription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPubsubSubscriptionExists(
 						"google_pubsub_subscription.foobar_sub"),
@@ -28,6 +30,17 @@ func TestAccPubsubSubscriptionCreate(t *testing.T) {
 	})
 }
 
+// TODO: Add acceptance test for push delivery.
+//
+// Testing push endpoints is tricky for the following reason:
+// - You need a publicly accessible HTTPS server to handle POST requests in order to receive push messages.
+// - The server must present a valid SSL certificate signed by a certificate authority
+// - The server must be routable by DNS.
+// - You also need to validate that you own the domain (or have equivalent access to the endpoint).
+// - Finally, you must register the endpoint domain with the GCP project.
+//
+// An easy way to test this would be to create an App Engine Hello World app. With AppEngine, SSL certificate, DNS and domain registry is handled for us.
+// App Engine is not yet supported by Terraform but once it is, it will provide an easy path to testing push configs.
 func testAccCheckPubsubSubscriptionDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "google_pubsub_subscription" {
@@ -64,13 +77,15 @@ func testAccPubsubSubscriptionExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccPubsubSubscription = fmt.Sprintf(`
+func testAccPubsubSubscription_basic(topic, subscription string) string {
+	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foobar_sub" {
-	name = "pssub-test-%s"
+	name = "%s"
 }
 
 resource "google_pubsub_subscription" "foobar_sub" {
-	name                 = "pssub-test-%s"
+	name                 = "%s"
 	topic                = "${google_pubsub_topic.foobar_sub.name}"
 	ack_deadline_seconds = 20
-}`, acctest.RandString(10), acctest.RandString(10))
+}`, topic, subscription)
+}

--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 The optional `push_config` block supports:
 
-* `push_endpoint` - (Optional) The URL of the endpoint to which messages should
+* `push_endpoint` - (Required) The URL of the endpoint to which messages should
     be pushed. Changing this forces a new resource to be created.
 
 * `attributes` - (Optional) Key-value pairs of API supported attributes used

--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Creates a subscription in Google's pubsub queueing system. For more information see
 [the official documentation](https://cloud.google.com/pubsub/docs) and
-[API](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions).
+[API](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions).
 
 
 ## Example Usage
@@ -69,3 +69,12 @@ The optional `push_config` block supports:
 ## Attributes Reference
 
 * `path` - Path of the subscription in the format `projects/{project}/subscriptions/{sub}`
+
+## Import
+
+Pubsub subscription can be imported using the `name`, e.g.
+
+```
+$ terraform import google_pubsub_subscription.default default-subscription
+```
+


### PR DESCRIPTION
Fixes #386, #393 

* Fixed the Read method which was doing nothing.
* Added import support
* `topic` field support either the `path` or the `name`.
* `push_configs` cannot have more than one item. Express this in the schema definition to bring this validation at `terraform plan` time.
* `push_configs.push_endpoint` is required. Update the schema accordingly.
* Renamed acceptance test to follow our naming convention
* Tested manually `push_configs` (see below why this is not automated).

Next steps: I filled an issue (#455) to add update support for `push_configs` and `ack_deadline`.