### PR TITLE
Use the v1 instead of beta API for IPv6.

### DIFF
--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -12,7 +12,7 @@ import (
 )
 
 var GlobalAddressBaseApiVersion = v1
-var GlobalAddressVersionedFeatures = []Feature{Feature{Version: v0beta, Item: "ip_version"}}
+var GlobalAddressVersionedFeatures = []Feature{}
 
 func resourceComputeGlobalAddress() *schema.Resource {
 	return &schema.Resource{

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -26,8 +25,8 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
 
-					// implicitly IPV4 - if we don't send an ip_version, we don't get one back even when using Beta apis
-					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", ""),
+					// implicitly IPV4 - if we don't send an ip_version, we don't get one back.
+					testAccCheckComputeGlobalAddressIpVersion("google_compute_global_address.foobar", ""),
 				),
 			},
 		},
@@ -35,7 +34,7 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 }
 
 func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
-	var addr computeBeta.Address
+	var addr compute.Address
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,9 +44,9 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeGlobalAddress_ipv6,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeBetaGlobalAddressExists(
+					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
-					testAccCheckComputeBetaGlobalAddressIpVersion("google_compute_global_address.foobar", "IPV6"),
+					testAccCheckComputeGlobalAddressIpVersion("google_compute_global_address.foobar", "IPV6"),
 				),
 			},
 		},
@@ -101,7 +100,7 @@ func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) res
 	}
 }
 
-func testAccCheckComputeBetaGlobalAddressExists(n string, addr *computeBeta.Address) resource.TestCheckFunc {
+func testAccCheckComputeGlobalAddressIpVersion(n, version string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -114,35 +113,7 @@ func testAccCheckComputeBetaGlobalAddressExists(n string, addr *computeBeta.Addr
 
 		config := testAccProvider.Meta().(*Config)
 
-		found, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != rs.Primary.ID {
-			return fmt.Errorf("Addr not found")
-		}
-
-		*addr = *found
-
-		return nil
-	}
-}
-
-func testAccCheckComputeBetaGlobalAddressIpVersion(n, version string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		addr, err := config.clientComputeBeta.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
+		addr, err := config.clientCompute.GlobalAddresses.Get(config.Project, rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -13,7 +13,6 @@ import (
 
 var GlobalForwardingRuleBaseApiVersion = v1
 var GlobalForwardingRuleVersionedFeatures = []Feature{
-	{Version: v0beta, Item: "ip_version"},
 	{Version: v0beta, Item: "labels"},
 }
 

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -33,10 +33,7 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
 is not provided, the provider project is used.
 
-- - -
-
-* `ip_version` - (Optional, [Beta](/docs/providers/google/index.html#beta-features))
-The IP Version that will be used by this address. One of `"IPV4"` or `"IPV6"`.
+* `ip_version` - (Optional) The IP Version that will be used by this address. One of `"IPV4"` or `"IPV6"`.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -96,10 +96,10 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-- - -
-
-* `ip_version` - (Optional, [Beta](/docs/providers/google/index.html#beta-features))
+* `ip_version` - (Optional)
 The IP Version that will be used by this resource's address. One of `"IPV4"` or `"IPV6"`.
+
+- - -
 
 * `labels` - (Optional, [Beta](/docs/providers/google/index.html#beta-features))
 A set of key/value label pairs to assign to the resource.


### PR DESCRIPTION
Fixes #445 

IPv6 support is now in GA.

I left the codepath handling the `resource_compute_global_address.go` even if there is no beta feature anymore. My thinking is that it will make adding support for future beta feature easier.