### PR TITLE
Update dataset_id value for google_bigquery_table resource in docs

### DIFF
--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -29,7 +29,7 @@ resource "google_bigquery_dataset" "default" {
 }
 
 resource "google_bigquery_table" "default" {
-  dataset_id = "${google_bigquery_dataset.default.id}"
+  dataset_id = "${google_bigquery_dataset.default.dataset_id}"
   table_id   = "bar"
 
   time_partitioning {


### PR DESCRIPTION
Whenever I tried to use `${google_bigquery_dataset.default.id` as the `dataset_id` value, it used the fully-qualified ID (`project-id:dataset_name`) and then fail to create the table. Terraform would then provide a mysterious error message:

```
* google_bigquery_table.table_name: googleapi: Error 400: Invalid dataset ID "project-id:table_name". Dataset IDs must be alphanumeric (plus underscores, dashes, and colons) and must be at most 1024 characters long., invalid
```

which doesn't make sense, because the ID matches the description. ¯\_(ツ)_/¯

Using `"${google_bigquery_dataset.default.dataset_id}"` instead works, though! 🎉 