### PR TITLE
Fix a few instances where we read the project from the provider config and not using the helper function

### DIFF
--- a/google/disk_type.go
+++ b/google/disk_type.go
@@ -5,8 +5,8 @@ import (
 )
 
 // readDiskType finds the disk type with the given name.
-func readDiskType(c *Config, zone *compute.Zone, name string) (*compute.DiskType, error) {
-	diskType, err := c.clientCompute.DiskTypes.Get(c.Project, zone.Name, name).Do()
+func readDiskType(c *Config, zone *compute.Zone, project, name string) (*compute.DiskType, error) {
+	diskType, err := c.clientCompute.DiskTypes.Get(project, zone.Name, name).Do()
 	if err == nil && diskType != nil && diskType.SelfLink != "" {
 		return diskType, nil
 	} else {

--- a/google/image.go
+++ b/google/image.go
@@ -67,7 +67,7 @@ func sanityTestRegexMatches(expected int, got []string, regexType, name string) 
 //    If not, check if it could be a GCP-provided image, and if it exists. If it does, return it as projects/{project}/global/images/{image}.
 //    If not, check if it's a family in the current project. If it is, return it as global/images/family/{family}.
 //    If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}
-func resolveImage(c *Config, name string) (string, error) {
+func resolveImage(c *Config, project, name string) (string, error) {
 	// built-in projects to look for images/families containing the string
 	// on the left in
 	imageMap := map[string]string{
@@ -119,7 +119,7 @@ func resolveImage(c *Config, name string) (string, error) {
 		if err := sanityTestRegexMatches(1, res, "family family", name); err != nil {
 			return "", err
 		}
-		if ok, err := resolveImageFamilyExists(c, c.Project, res[1]); err != nil {
+		if ok, err := resolveImageFamilyExists(c, project, res[1]); err != nil {
 			return "", err
 		} else if ok {
 			return fmt.Sprintf("global/images/family/%s", res[1]), nil
@@ -157,7 +157,7 @@ func resolveImage(c *Config, name string) (string, error) {
 		if err := sanityTestRegexMatches(1, res, "image", name); err != nil {
 			return "", err
 		}
-		if ok, err := resolveImageImageExists(c, c.Project, res[1]); err != nil {
+		if ok, err := resolveImageImageExists(c, project, res[1]); err != nil {
 			return "", err
 		} else if ok {
 			return fmt.Sprintf("global/images/%s", res[1]), nil

--- a/google/image_test.go
+++ b/google/image_test.go
@@ -79,7 +79,7 @@ func testAccCheckComputeImageResolution(n string) resource.TestCheckFunc {
 		}
 
 		for input, expectation := range images {
-			result, err := resolveImage(config, input)
+			result, err := resolveImage(config, project, input)
 			if err != nil {
 				return fmt.Errorf("Error resolving input %s to image: %+v\n", input, err)
 			}

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -139,7 +139,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	// If we were given a source image, load that.
 	if v, ok := d.GetOk("image"); ok {
 		log.Printf("[DEBUG] Resolving image name: %s", v.(string))
-		imageUrl, err := resolveImage(config, v.(string))
+		imageUrl, err := resolveImage(config, project, v.(string))
 		if err != nil {
 			return fmt.Errorf(
 				"Error resolving image name '%s': %s",
@@ -152,7 +152,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("type"); ok {
 		log.Printf("[DEBUG] Loading disk type: %s", v.(string))
-		diskType, err := readDiskType(config, zone, v.(string))
+		diskType, err := readDiskType(config, zone, project, v.(string))
 		if err != nil {
 			return fmt.Errorf(
 				"Error loading disk type '%s': %s",

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -621,7 +621,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	var hasScratchDisk bool
 	if _, hasScratchDisk := d.GetOk("scratch_disk"); hasScratchDisk {
-		scratchDisks, err := expandScratchDisks(d, config, zone)
+		scratchDisks, err := expandScratchDisks(d, config, zone, project)
 		if err != nil {
 			return err
 		}
@@ -685,7 +685,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		if v, ok := d.GetOk(prefix + ".image"); ok && !hasSource {
 			imageName := v.(string)
 
-			imageUrl, err := resolveImage(config, imageName)
+			imageUrl, err := resolveImage(config, project, imageName)
 			if err != nil {
 				return fmt.Errorf(
 					"Error resolving image name '%s': %s",
@@ -699,7 +699,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 		if v, ok := d.GetOk(prefix + ".type"); ok && !hasSource {
 			diskTypeName := v.(string)
-			diskType, err := readDiskType(config, zone, diskTypeName)
+			diskType, err := readDiskType(config, zone, project, diskTypeName)
 			if err != nil {
 				return fmt.Errorf(
 					"Error loading disk type '%s': %s",
@@ -1527,7 +1527,7 @@ func expandBootDisk(d *schema.ResourceData, config *Config, zone *compute.Zone, 
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.type"); ok {
 			diskTypeName := v.(string)
-			diskType, err := readDiskType(config, zone, diskTypeName)
+			diskType, err := readDiskType(config, zone, project, diskTypeName)
 			if err != nil {
 				return nil, fmt.Errorf("Error loading disk type '%s': %s", diskTypeName, err)
 			}
@@ -1536,7 +1536,7 @@ func expandBootDisk(d *schema.ResourceData, config *Config, zone *compute.Zone, 
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.image"); ok {
 			imageName := v.(string)
-			imageUrl, err := resolveImage(config, imageName)
+			imageUrl, err := resolveImage(config, project, imageName)
 			if err != nil {
 				return nil, fmt.Errorf("Error resolving image name '%s': %s", imageName, err)
 			}
@@ -1571,8 +1571,8 @@ func flattenBootDisk(d *schema.ResourceData, disk *computeBeta.AttachedDisk) []m
 	return []map[string]interface{}{result}
 }
 
-func expandScratchDisks(d *schema.ResourceData, config *Config, zone *compute.Zone) ([]*computeBeta.AttachedDisk, error) {
-	diskType, err := readDiskType(config, zone, "local-ssd")
+func expandScratchDisks(d *schema.ResourceData, config *Config, zone *compute.Zone, project string) ([]*computeBeta.AttachedDisk, error) {
+	diskType, err := readDiskType(config, zone, project, "local-ssd")
 	if err != nil {
 		return nil, fmt.Errorf("Error loading disk type 'local-ssd': %s", err)
 	}

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -331,6 +331,11 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 func buildDisks(d *schema.ResourceData, meta interface{}) ([]*compute.AttachedDisk, error) {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
 	disksCount := d.Get("disk.#").(int)
 
 	disks := make([]*compute.AttachedDisk, 0, disksCount)
@@ -371,7 +376,7 @@ func buildDisks(d *schema.ResourceData, meta interface{}) ([]*compute.AttachedDi
 
 			if v, ok := d.GetOk(prefix + ".source_image"); ok {
 				imageName := v.(string)
-				imageUrl, err := resolveImage(config, imageName)
+				imageUrl, err := resolveImage(config, project, imageName)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"Error resolving image name '%s': %s",

--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -88,7 +88,7 @@ func resourceSqlDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 			instance_name, err)
 	}
 
-	err = sqladminOperationWait(config, op, "Insert Database")
+	err = sqladminOperationWait(config, op, project, "Insert Database")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for insertion of %s "+
@@ -162,7 +162,7 @@ func resourceSqlDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
 			instance_name, err)
 	}
 
-	err = sqladminOperationWait(config, op, "Update Database")
+	err = sqladminOperationWait(config, op, project, "Update Database")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for update of %s "+
@@ -194,7 +194,7 @@ func resourceSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
 			instance_name, err)
 	}
 
-	err = sqladminOperationWait(config, op, "Delete Database")
+	err = sqladminOperationWait(config, op, project, "Delete Database")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for deletion of %s "+

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -611,7 +611,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	d.SetId(instance.Name)
 
-	err = sqladminOperationWait(config, op, "Create Instance")
+	err = sqladminOperationWait(config, op, project, "Create Instance")
 	if err != nil {
 		d.SetId("")
 		return err
@@ -635,7 +635,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 				if err != nil {
 					return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
 				}
-				err = sqladminOperationWait(config, op, "Delete default root User")
+				err = sqladminOperationWait(config, op, project, "Delete default root User")
 				if err != nil {
 					return err
 				}
@@ -939,7 +939,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to update instance %s: %s", instance.Name, err)
 	}
 
-	err = sqladminOperationWait(config, op, "Create Instance")
+	err = sqladminOperationWait(config, op, project, "Create Instance")
 	if err != nil {
 		return err
 	}
@@ -961,7 +961,7 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to delete instance %s: %s", d.Get("name").(string), err)
 	}
 
-	err = sqladminOperationWait(config, op, "Delete Instance")
+	err = sqladminOperationWait(config, op, project, "Delete Instance")
 	if err != nil {
 		return err
 	}

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -76,7 +76,7 @@ func testSweepDatabases(region string) error {
 				return fmt.Errorf("error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
 			}
 
-			err = sqladminOperationWait(config, op, "Stop Replica")
+			err = sqladminOperationWait(config, op, config.Project, "Stop Replica")
 			if err != nil {
 				if strings.Contains(err.Error(), "does not exist") {
 					log.Printf("Replication operation not found")
@@ -106,7 +106,7 @@ func testSweepDatabases(region string) error {
 				return fmt.Errorf("Error, failed to delete instance %s: %s", db, err)
 			}
 
-			err = sqladminOperationWait(config, op, "Delete Instance")
+			err = sqladminOperationWait(config, op, config.Project, "Delete Instance")
 			if err != nil {
 				if strings.Contains(err.Error(), "does not exist") {
 					log.Printf("SQL instance not found")
@@ -224,7 +224,7 @@ func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.
 						t.Errorf("Error while inserting root@%% user: %s", err)
 						return
 					}
-					err = sqladminOperationWait(config, op, "Waiting for user to insert")
+					err = sqladminOperationWait(config, op, config.Project, "Waiting for user to insert")
 					if err != nil {
 						t.Errorf("Error while waiting for user insert operation to complete: %s", err.Error())
 					}

--- a/google/resource_sql_user.go
+++ b/google/resource_sql_user.go
@@ -88,7 +88,7 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(fmt.Sprintf("%s/%s", instance, name))
 
-	err = sqladminOperationWait(config, op, "Insert User")
+	err = sqladminOperationWait(config, op, project, "Insert User")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for insertion of %s "+
@@ -175,7 +175,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				"user %s into user %s: %s", name, instance, err)
 		}
 
-		err = sqladminOperationWait(config, op, "Insert User")
+		err = sqladminOperationWait(config, op, project, "Insert User")
 
 		if err != nil {
 			return fmt.Errorf("Error, failure waiting for update of %s "+
@@ -210,7 +210,7 @@ func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 			instance, err)
 	}
 
-	err = sqladminOperationWait(config, op, "Delete User")
+	err = sqladminOperationWait(config, op, project, "Delete User")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for deletion of %s "+

--- a/google/sqladmin_operation.go
+++ b/google/sqladmin_operation.go
@@ -56,11 +56,11 @@ func (e SqlAdminOperationError) Error() string {
 	return buf.String()
 }
 
-func sqladminOperationWait(config *Config, op *sqladmin.Operation, activity string) error {
+func sqladminOperationWait(config *Config, op *sqladmin.Operation, project, activity string) error {
 	w := &SqlAdminOperationWaiter{
 		Service: config.clientSqlAdmin,
 		Op:      op,
-		Project: config.Project,
+		Project: project,
 	}
 
 	state := w.Conf()


### PR DESCRIPTION
This was causing errors for people who specify the project in the resource instead of the provider config. Fixes #167 and #436.