### PR TITLE
Firewall network field now supports self_link in addition of name

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -7,7 +7,7 @@ import (
 
 const networkLinkTemplate = "projects/%s/global/networks/%s"
 
-var networkLinkRegex = regexp.MustCompile(fmt.Sprintf(networkLinkTemplate, "(.+)", "(.+)"))
+var networkLinkRegex = regexp.MustCompile("projects/(.+)/global/networks/(.+)")
 
 type NetworkFieldValue struct {
 	Project string
@@ -35,6 +35,6 @@ func ParseNetworkFieldValue(network string, config *Config) *NetworkFieldValue {
 	}
 }
 
-func (f *NetworkFieldValue) RelativeLink() string {
+func (f NetworkFieldValue) RelativeLink() string {
 	return fmt.Sprintf(networkLinkTemplate, f.Project, f.Name)
 }

--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -1,0 +1,40 @@
+package google
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const networkLinkTemplate = "projects/%s/global/networks/%s"
+
+var networkLinkRegex = regexp.MustCompile(fmt.Sprintf(networkLinkTemplate, "(.+)", "(.+)"))
+
+type NetworkFieldValue struct {
+	Project string
+	Name    string
+}
+
+// Parses a `network` supporting 4 different formats:
+// - https://www.googleapis.com/compute/{version}/projects/myproject/global/networks/my-network
+// - projects/myproject/global/networks/my-network
+// - global/networks/my-network (default project is used)
+// - my-network (default project is used)
+func ParseNetworkFieldValue(network string, config *Config) *NetworkFieldValue {
+	if networkLinkRegex.MatchString(network) {
+		parts := networkLinkRegex.FindStringSubmatch(network)
+
+		return &NetworkFieldValue{
+			Project: parts[1],
+			Name:    parts[2],
+		}
+	}
+
+	return &NetworkFieldValue{
+		Project: config.Project,
+		Name:    GetResourceNameFromSelfLink(network),
+	}
+}
+
+func (f *NetworkFieldValue) RelativeLink() string {
+	return fmt.Sprintf(networkLinkTemplate, f.Project, f.Name)
+}

--- a/google/field_helpers_test.go
+++ b/google/field_helpers_test.go
@@ -1,0 +1,36 @@
+package google
+
+import "testing"
+
+func TestParseNetworkFieldValue(t *testing.T) {
+	cases := map[string]struct {
+		Network              string
+		ExpectedRelativeLink string
+		Config               *Config
+	}{
+		"network is a full self link": {
+			Network:              "https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network",
+			ExpectedRelativeLink: "projects/myproject/global/networks/my-network",
+		},
+		"network is a relative self link": {
+			Network:              "projects/myproject/global/networks/my-network",
+			ExpectedRelativeLink: "projects/myproject/global/networks/my-network",
+		},
+		"network is a partial relative self link": {
+			Network:              "global/networks/my-network",
+			ExpectedRelativeLink: "projects/default-project/global/networks/my-network",
+			Config:               &Config{Project: "default-project"},
+		},
+		"network is the name only": {
+			Network:              "my-network",
+			ExpectedRelativeLink: "projects/default-project/global/networks/my-network",
+			Config:               &Config{Project: "default-project"},
+		},
+	}
+
+	for tn, tc := range cases {
+		if fieldValue := ParseNetworkFieldValue(tc.Network, tc.Config); fieldValue.RelativeLink() != tc.ExpectedRelativeLink {
+			t.Fatalf("bad: %s, expected relative link to be '%s' but got '%s'", tn, tc.ExpectedRelativeLink, fieldValue.RelativeLink())
+		}
+	}
+}

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `network` - (Required) The name of the network to attach this firewall to.
+* `network` - (Required) The name or self_link of the network to attach this firewall to.
 
 * `allow` - (Required) Can be specified multiple times for each allow
     rule. Each allow block supports fields documented below.


### PR DESCRIPTION
Fixes #377. 

`network` field for other resources will be able to reuse `NetworkFieldValue`. #431 is listing the other resources with a network field that is not properly supported.
