### PR TITLE
Forwarding rule network field supports name in addition of self_link

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -14,11 +14,12 @@ type NetworkFieldValue struct {
 	Name    string
 }
 
-// Parses a `network` supporting 4 different formats:
+// Parses a `network` supporting 5 different formats:
 // - https://www.googleapis.com/compute/{version}/projects/myproject/global/networks/my-network
 // - projects/myproject/global/networks/my-network
 // - global/networks/my-network (default project is used)
 // - my-network (default project is used)
+// - "" (empty string). RelativeLink() returns empty. For most API, the behavior is to use the default network.
 func ParseNetworkFieldValue(network string, config *Config) *NetworkFieldValue {
 	if networkLinkRegex.MatchString(network) {
 		parts := networkLinkRegex.FindStringSubmatch(network)
@@ -36,5 +37,9 @@ func ParseNetworkFieldValue(network string, config *Config) *NetworkFieldValue {
 }
 
 func (f NetworkFieldValue) RelativeLink() string {
+	if len(f.Name) == 0 {
+		return ""
+	}
+
 	return fmt.Sprintf(networkLinkTemplate, f.Project, f.Name)
 }

--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -65,10 +65,11 @@ func resourceComputeForwardingRule() *schema.Resource {
 			},
 
 			"network": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"port_range": &schema.Schema{
@@ -147,7 +148,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 		Description:         d.Get("description").(string),
 		LoadBalancingScheme: d.Get("load_balancing_scheme").(string),
 		Name:                d.Get("name").(string),
-		Network:             d.Get("network").(string),
+		Network:             ParseNetworkFieldValue(d.Get("network").(string), config).RelativeLink(),
 		PortRange:           d.Get("port_range").(string),
 		Ports:               ports,
 		Subnetwork:          d.Get("subnetwork").(string),

--- a/google/resource_compute_forwarding_rule_test.go
+++ b/google/resource_compute_forwarding_rule_test.go
@@ -73,7 +73,9 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
-	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -81,10 +83,12 @@ func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
 		CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, ruleName),
+				Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeForwardingRuleExists(
 						"google_compute_forwarding_rule.foobar"),
+					testAccCheckComputeForwardingRuleExists(
+						"google_compute_forwarding_rule.foobar2"),
 				),
 			},
 		},
@@ -191,7 +195,7 @@ resource "google_compute_forwarding_rule" "foobar" {
 `, addrName, poolName, ruleName)
 }
 
-func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, ruleName string) string {
+func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2 string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar-bs" {
   name                  = "%s"
@@ -209,12 +213,25 @@ resource "google_compute_health_check" "zero" {
     port = "80"
   }
 }
+resource "google_compute_network" "foobar" {
+  name = "%s"
+  auto_create_subnetworks = true
+}
 resource "google_compute_forwarding_rule" "foobar" {
   description           = "Resource created for Terraform acceptance testing"
   name                  = "%s"
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
   ports                 = ["80"]
+  network				= "${google_compute_network.foobar.name}"
 }
-`, serviceName, checkName, ruleName)
+resource "google_compute_forwarding_rule" "foobar2" {
+  description           = "Resource created for Terraform acceptance testing"
+  name                  = "%s"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
+  ports                 = ["80"]
+  network				= "${google_compute_network.foobar.self_link}"
+}
+`, serviceName, checkName, networkName, ruleName1, ruleName2)
 }

--- a/google/resource_compute_forwarding_rule_test.go
+++ b/google/resource_compute_forwarding_rule_test.go
@@ -223,7 +223,7 @@ resource "google_compute_forwarding_rule" "foobar" {
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
   ports                 = ["80"]
-  network				= "${google_compute_network.foobar.name}"
+  network               = "${google_compute_network.foobar.name}"
 }
 resource "google_compute_forwarding_rule" "foobar2" {
   description           = "Resource created for Terraform acceptance testing"
@@ -231,7 +231,7 @@ resource "google_compute_forwarding_rule" "foobar2" {
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
   ports                 = ["80"]
-  network				= "${google_compute_network.foobar.self_link}"
+  network               = "${google_compute_network.foobar.self_link}"
 }
 `, serviceName, checkName, networkName, ruleName1, ruleName2)
 }

--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -47,9 +47,9 @@ The following arguments are supported:
 * `load_balancing_scheme` - (Optional) Type of load balancing to use. Can be
     set to "INTERNAL" or "EXTERNAL" (default "EXTERNAL").
 
-* `network` - (Optional) Network that the load balanced IP should belong to.
-    Only used for internal load balancing. If it is not provided, the default
-    network is used.
+* `network` - (Optional) Network name or self_link that the load balanced IP
+    should belong to. Only used for internal load balancing. If it is not
+    provided, the default network is used.
 
 * `port_range` - (Optional) A range e.g. "1024-2048" or a single port "1024"
     (defaults to all ports!). Only used for external load balancing.


### PR DESCRIPTION
Fixes one resource for #431.