### PR TITLE
Mark certificate as sensitive within `google_compute_ssl_certificate`

### DIFF
--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -17,9 +17,10 @@ func resourceComputeSslCertificate() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"certificate": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 
 			"name": &schema.Schema{


### PR DESCRIPTION
Fixes #448 