### PR TITLE
1.0.0 Deprecations, pt 2

### DIFF
--- a/examples/content-based-load-balancing/main.tf
+++ b/examples/content-based-load-balancing/main.tf
@@ -1,19 +1,21 @@
 # https://cloud.google.com/compute/docs/load-balancing/http/content-based-example
 
 provider "google" {
-  region = "${var.region}"
-  project = "${var.project_name}"
+  region      = "${var.region}"
+  project     = "${var.project_name}"
   credentials = "${file("${var.credentials_file_path}")}"
 }
 
 resource "google_compute_instance" "www" {
-  name = "tf-www-compute"
+  name         = "tf-www-compute"
   machine_type = "f1-micro"
-  zone = "${var.region_zone}"
-  tags = ["http-tag"]
+  zone         = "${var.region_zone}"
+  tags         = ["http-tag"]
 
-  disk {
-    image = "projects/debian-cloud/global/images/family/debian-8"
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-8"
+    }
   }
 
   network_interface {
@@ -32,13 +34,15 @@ resource "google_compute_instance" "www" {
 }
 
 resource "google_compute_instance" "www-video" {
-  name = "tf-www-video-compute"
+  name         = "tf-www-video-compute"
   machine_type = "f1-micro"
-  zone = "${var.region_zone}"
-  tags = ["http-tag"]
+  zone         = "${var.region_zone}"
+  tags         = ["http-tag"]
 
-  disk {
-    image = "projects/debian-cloud/global/images/family/debian-8"
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-8"
+    }
   }
 
   network_interface {
@@ -87,12 +91,11 @@ resource "google_compute_instance_group" "video-resources" {
 resource "google_compute_health_check" "health-check" {
   name = "tf-health-check"
 
-  http_health_check {
-  }
+  http_health_check {}
 }
 
 resource "google_compute_backend_service" "www-service" {
-  name = "tf-www-service"
+  name     = "tf-www-service"
   protocol = "HTTP"
 
   backend {
@@ -103,7 +106,7 @@ resource "google_compute_backend_service" "www-service" {
 }
 
 resource "google_compute_backend_service" "video-service" {
-  name = "tf-video-service"
+  name     = "tf-video-service"
   protocol = "HTTP"
 
   backend {
@@ -114,46 +117,46 @@ resource "google_compute_backend_service" "video-service" {
 }
 
 resource "google_compute_url_map" "web-map" {
-  name = "tf-web-map"
+  name            = "tf-web-map"
   default_service = "${google_compute_backend_service.www-service.self_link}"
 
   host_rule {
-    hosts = ["*"]
+    hosts        = ["*"]
     path_matcher = "tf-allpaths"
   }
 
   path_matcher {
-    name = "tf-allpaths"
+    name            = "tf-allpaths"
     default_service = "${google_compute_backend_service.www-service.self_link}"
 
     path_rule {
-      paths = ["/video", "/video/*",]
+      paths   = ["/video", "/video/*"]
       service = "${google_compute_backend_service.video-service.self_link}"
     }
   }
 }
 
 resource "google_compute_target_http_proxy" "http-lb-proxy" {
-  name = "tf-http-lb-proxy"
+  name    = "tf-http-lb-proxy"
   url_map = "${google_compute_url_map.web-map.self_link}"
 }
 
 resource "google_compute_global_forwarding_rule" "default" {
-  name = "tf-http-content-gfr"
-  target = "${google_compute_target_http_proxy.http-lb-proxy.self_link}"
+  name       = "tf-http-content-gfr"
+  target     = "${google_compute_target_http_proxy.http-lb-proxy.self_link}"
   ip_address = "${google_compute_global_address.external-address.address}"
   port_range = "80"
 }
 
 resource "google_compute_firewall" "default" {
-  name = "tf-www-firewall-allow-internal-only"
+  name    = "tf-www-firewall-allow-internal-only"
   network = "default"
 
   allow {
     protocol = "tcp"
-    ports = ["80"]
+    ports    = ["80"]
   }
 
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags = ["http-tag"]
+  target_tags   = ["http-tag"]
 }

--- a/examples/internal-load-balancing/main.tf
+++ b/examples/internal-load-balancing/main.tf
@@ -1,257 +1,272 @@
 provider "google" {
-	region      = "${var.region}"
-	project     = "${var.project_name}"
+  region  = "${var.region}"
+  project = "${var.project_name}"
 }
 
 resource "google_compute_network" "my-custom-network" {
-	name = "my-custom-network"
+  name = "my-custom-network"
 }
 
 resource "google_compute_subnetwork" "my-custom-subnet" {
-	name          = "my-custom-subnet"
-	ip_cidr_range = "10.128.0.0/20"
-	network       = "${google_compute_network.my-custom-network.self_link}"
-	region        = "${var.region}"
+  name          = "my-custom-subnet"
+  ip_cidr_range = "10.128.0.0/20"
+  network       = "${google_compute_network.my-custom-network.self_link}"
+  region        = "${var.region}"
 }
 
 resource "google_compute_firewall" "allow-all-internal" {
-	name    = "allow-all-10-128-0-0-20"
-	network = "${google_compute_network.my-custom-network.name}"
+  name    = "allow-all-10-128-0-0-20"
+  network = "${google_compute_network.my-custom-network.name}"
 
-	allow {
-		protocol = "tcp"
-	}
+  allow {
+    protocol = "tcp"
+  }
 
-	allow {
-		protocol = "udp"
-	}
+  allow {
+    protocol = "udp"
+  }
 
-	allow {
-		protocol = "icmp"
-	}
+  allow {
+    protocol = "icmp"
+  }
 
-	source_ranges = ["10.128.0.0/20"]
+  source_ranges = ["10.128.0.0/20"]
 }
 
 resource "google_compute_firewall" "allow-ssh-rdp-icmp" {
-	name    = "allow-tcp22-tcp3389-icmp"
-	network = "${google_compute_network.my-custom-network.name}"
+  name    = "allow-tcp22-tcp3389-icmp"
+  network = "${google_compute_network.my-custom-network.name}"
 
-	allow {
-		protocol = "tcp"
-		ports    = ["22", "3389",]
-	}
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
 
-	allow {
-		protocol = "icmp"
-	}
+  allow {
+    protocol = "icmp"
+  }
 }
 
 resource "google_compute_instance" "ilb-instance-1" {
-	name         = "ilb-instance-1"
-	machine_type = "n1-standard-1"
-	zone         = "${var.region_zone}"
+  name         = "ilb-instance-1"
+  machine_type = "n1-standard-1"
+  zone         = "${var.region_zone}"
 
-	tags = ["int-lb"]
+  tags = ["int-lb"]
 
-	disk {
-		image = "debian-cloud/debian-8"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
 
-	network_interface {
-		subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
-		access_config {
-			// Ephemeral IP
-		}
-	}
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
 
-	service_account {
-    	scopes = ["compute-rw"]
-  	}
+    access_config {
+      // Ephemeral IP
+    }
+  }
 
-	metadata_startup_script = "${file("startup.sh")}"
+  service_account {
+    scopes = ["compute-rw"]
+  }
+
+  metadata_startup_script = "${file("startup.sh")}"
 }
 
 resource "google_compute_instance" "ilb-instance-2" {
-	name         = "ilb-instance-2"
-	machine_type = "n1-standard-1"
-	zone         = "${var.region_zone}"
+  name         = "ilb-instance-2"
+  machine_type = "n1-standard-1"
+  zone         = "${var.region_zone}"
 
-	tags = ["int-lb"]
+  tags = ["int-lb"]
 
-	disk {
-		image = "debian-cloud/debian-8"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
 
-	network_interface {
-		subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
-		access_config {
-			// Ephemeral IP
-		}
-	}
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
 
-	service_account {
-    	scopes = ["compute-rw"]
-  	}
+    access_config {
+      // Ephemeral IP
+    }
+  }
 
-	metadata_startup_script = "${file("startup.sh")}"
+  service_account {
+    scopes = ["compute-rw"]
+  }
+
+  metadata_startup_script = "${file("startup.sh")}"
 }
 
 resource "google_compute_instance" "ilb-instance-3" {
-	name         = "ilb-instance-3"
-	machine_type = "n1-standard-1"
-	zone         = "${var.region_zone_2}"
+  name         = "ilb-instance-3"
+  machine_type = "n1-standard-1"
+  zone         = "${var.region_zone_2}"
 
-	tags = ["int-lb"]
+  tags = ["int-lb"]
 
-	disk {
-		image = "debian-cloud/debian-8"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
 
-	network_interface {
-		subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
-		access_config {
-			// Ephemeral IP
-		}
-	}
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
 
-	service_account {
-    	scopes = ["compute-rw"]
-  	}
+    access_config {
+      // Ephemeral IP
+    }
+  }
 
-	metadata_startup_script = "${file("startup.sh")}"
+  service_account {
+    scopes = ["compute-rw"]
+  }
+
+  metadata_startup_script = "${file("startup.sh")}"
 }
 
 resource "google_compute_instance" "ilb-instance-4" {
-	name         = "ilb-instance-4"
-	machine_type = "n1-standard-1"
-	zone         = "${var.region_zone_2}"
+  name         = "ilb-instance-4"
+  machine_type = "n1-standard-1"
+  zone         = "${var.region_zone_2}"
 
-	tags = ["int-lb"]
+  tags = ["int-lb"]
 
-	disk {
-		image = "debian-cloud/debian-8"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
 
-	network_interface {
-		subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
-		access_config {
-			// Ephemeral IP
-		}
-	}
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
 
-	service_account {
-    	scopes = ["compute-rw"]
-  	}
+    access_config {
+      // Ephemeral IP
+    }
+  }
 
-	metadata_startup_script = "${file("startup.sh")}"
+  service_account {
+    scopes = ["compute-rw"]
+  }
+
+  metadata_startup_script = "${file("startup.sh")}"
 }
 
 resource "google_compute_instance_group" "us-ig1" {
-	name        = "us-ig1"
+  name = "us-ig1"
 
-	instances = [
-		"${google_compute_instance.ilb-instance-1.self_link}",
-		"${google_compute_instance.ilb-instance-2.self_link}"
-	]
+  instances = [
+    "${google_compute_instance.ilb-instance-1.self_link}",
+    "${google_compute_instance.ilb-instance-2.self_link}",
+  ]
 
-	zone = "${var.region_zone}"
+  zone = "${var.region_zone}"
 }
 
 resource "google_compute_instance_group" "us-ig2" {
-	name        = "us-ig2"
+  name = "us-ig2"
 
-	instances = [
-		"${google_compute_instance.ilb-instance-3.self_link}",
-		"${google_compute_instance.ilb-instance-4.self_link}"
-	]
+  instances = [
+    "${google_compute_instance.ilb-instance-3.self_link}",
+    "${google_compute_instance.ilb-instance-4.self_link}",
+  ]
 
-	zone = "${var.region_zone_2}"
+  zone = "${var.region_zone_2}"
 }
 
 resource "google_compute_health_check" "my-tcp-health-check" {
-	name = "my-tcp-health-check"
+  name = "my-tcp-health-check"
 
-	tcp_health_check {
-		port = "80"
-	}
+  tcp_health_check {
+    port = "80"
+  }
 }
 
 resource "google_compute_region_backend_service" "my-int-lb" {
-	name                  = "my-int-lb"
-	health_checks         = ["${google_compute_health_check.my-tcp-health-check.self_link}"]
-	region                = "${var.region}"
+  name          = "my-int-lb"
+  health_checks = ["${google_compute_health_check.my-tcp-health-check.self_link}"]
+  region        = "${var.region}"
 
-	backend {
-		group = "${google_compute_instance_group.us-ig1.self_link}"
-	}
+  backend {
+    group = "${google_compute_instance_group.us-ig1.self_link}"
+  }
 
-	backend {
-		group = "${google_compute_instance_group.us-ig2.self_link}"
-	}
+  backend {
+    group = "${google_compute_instance_group.us-ig2.self_link}"
+  }
 }
 
 resource "google_compute_forwarding_rule" "my-int-lb-forwarding-rule" {
-	name                  = "my-int-lb-forwarding-rule"
-	load_balancing_scheme = "INTERNAL"
-	ports                 = ["80"]
-	network               = "${google_compute_network.my-custom-network.self_link}"
-	subnetwork            = "${google_compute_subnetwork.my-custom-subnet.self_link}"
-	backend_service       = "${google_compute_region_backend_service.my-int-lb.self_link}"
+  name                  = "my-int-lb-forwarding-rule"
+  load_balancing_scheme = "INTERNAL"
+  ports                 = ["80"]
+  network               = "${google_compute_network.my-custom-network.self_link}"
+  subnetwork            = "${google_compute_subnetwork.my-custom-subnet.self_link}"
+  backend_service       = "${google_compute_region_backend_service.my-int-lb.self_link}"
 }
 
 resource "google_compute_firewall" "allow-internal-lb" {
-	name    = "allow-internal-lb"
-	network = "${google_compute_network.my-custom-network.name}"
+  name    = "allow-internal-lb"
+  network = "${google_compute_network.my-custom-network.name}"
 
-	allow {
-		protocol = "tcp"
-		ports    = ["80", "443"]
-	}
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
 
-	source_ranges = ["10.128.0.0/20"]
-	target_tags = ["int-lb"]
+  source_ranges = ["10.128.0.0/20"]
+  target_tags   = ["int-lb"]
 }
 
 resource "google_compute_firewall" "allow-health-check" {
-	name    = "allow-health-check"
-	network = "${google_compute_network.my-custom-network.name}"
+  name    = "allow-health-check"
+  network = "${google_compute_network.my-custom-network.name}"
 
-	allow {
-		protocol = "tcp"
-	}
+  allow {
+    protocol = "tcp"
+  }
 
-	source_ranges = ["130.211.0.0/22","35.191.0.0/16"]
-	target_tags = ["int-lb"]
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["int-lb"]
 }
 
 resource "google_compute_instance" "standalone-instance-1" {
-	name         = "standalone-instance-1"
-	machine_type = "n1-standard-1"
-	zone         = "${var.region_zone}"
+  name         = "standalone-instance-1"
+  machine_type = "n1-standard-1"
+  zone         = "${var.region_zone}"
 
-	tags = ["standalone"]
+  tags = ["standalone"]
 
-	disk {
-		image = "debian-cloud/debian-8"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
 
-	network_interface {
-		subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
-		access_config {
-			// Ephemeral IP
-		}
-	}
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.my-custom-subnet.name}"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
 }
 
 resource "google_compute_firewall" "allow-ssh-to-standalone" {
-	name    = "allow-ssh-to-standalone"
-	network = "${google_compute_network.my-custom-network.name}"
+  name    = "allow-ssh-to-standalone"
+  network = "${google_compute_network.my-custom-network.name}"
 
-	allow {
-		protocol = "tcp"
-		ports    = ["22"]
-	}
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
 
-	target_tags = ["standalone"]
+  target_tags = ["standalone"]
 }

--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -35,8 +35,10 @@ resource "google_compute_instance" "www" {
   zone         = "${var.region_zone}"
   tags         = ["www-node"]
 
-  disk {
-    image = "ubuntu-os-cloud/ubuntu-1404-trusty-v20160602"
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-1404-trusty-v20160602"
+    }
   }
 
   network_interface {

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -149,7 +149,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -209,7 +209,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -422,7 +422,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  disk {
+  boot_disk {
     source_image = "debian-8-jessie-v20160803"
     auto_delete  = true
     boot         = true

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -355,11 +355,11 @@ resource "google_compute_instance" "bar" {
 	machine_type = "n1-standard-1"
 	zone = "us-central1-a"
 
-	disk {
+	boot_disk {
 		image = "debian-8-jessie-v20170523"
 	}
 
-	disk {
+	attached_disk {
 		disk = "${google_compute_disk.foo.name}"
 		auto_delete = false
 	}

--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
+	"strings"
+
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
-	"strings"
 )
 
 func TestAccComputeFirewall_basic(t *testing.T) {
@@ -306,7 +307,6 @@ func testAccComputeFirewall_basic(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -325,7 +325,6 @@ func testAccComputeFirewall_update(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -345,7 +344,6 @@ func testAccComputeFirewall_priority(network, firewall string, priority int) str
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -365,7 +363,6 @@ func testAccComputeFirewall_noSource(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -384,7 +381,6 @@ func testAccComputeFirewall_denied(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -404,7 +400,6 @@ func testAccComputeFirewall_egress(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
-		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -9,10 +9,11 @@ import (
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
+	"sort"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"sort"
 )
 
 func TestAccInstanceGroupManager_basic(t *testing.T) {
@@ -500,7 +501,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -554,7 +555,7 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -591,7 +592,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -640,7 +641,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -677,7 +678,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -725,7 +726,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		can_ip_forward = false
 		tags = ["%s"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -765,7 +766,7 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 		can_ip_forward = false
 		tags = ["terraform-testing"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -806,7 +807,7 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -852,7 +853,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	disk {
+	boot_disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -908,7 +909,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	disk {
+	boot_disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true

--- a/google/resource_compute_instance_group_test.go
+++ b/google/resource_compute_instance_group_test.go
@@ -269,8 +269,10 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 		can_ip_forward = false
 		zone = "us-central1-c"
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {
@@ -317,8 +319,10 @@ func testAccComputeInstanceGroup_update(instance string) string {
 		zone = "us-central1-c"
 		count = 2
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {
@@ -352,8 +356,10 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 		zone = "us-central1-c"
 		count = 1
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {
@@ -386,8 +392,10 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 		can_ip_forward = false
 		zone = "us-central1-c"
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {
@@ -401,8 +409,10 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 		can_ip_forward = false
 		zone = "us-central1-c"
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {
@@ -439,8 +449,10 @@ func testAccComputeInstanceGroup_network(instance string) string {
 		can_ip_forward = false
 		zone = "us-central1-c"
 
-		disk {
-			image = "debian-8-jessie-v20160803"
+		boot_disk {
+			initialize_params {
+				image = "debian-8-jessie-v20160803"
+			}
 		}
 
 		network_interface {

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -419,7 +419,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -450,7 +450,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -484,7 +484,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 	}
 
@@ -507,7 +507,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 	}
 
@@ -535,14 +535,14 @@ resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true
 	}
 
-	disk {
+	attached_disk {
 		source = "terraform-test-foobar"
 		auto_delete = false
 		boot = false
@@ -568,7 +568,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 		name = "instance-tpl-%s"
 		machine_type = "n1-standard-1"
 
-		disk {
+		boot_disk {
 			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			disk_size_gb = 10
@@ -603,7 +603,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	region = "us-central1"
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 10
@@ -640,7 +640,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(xpn_host string) string {
 		machine_type = "n1-standard-1"
 		region = "us-central1"
 
-		disk {
+		boot_disk {
 			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			disk_size_gb = 10
@@ -663,7 +663,7 @@ resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
-	disk {
+	boot_disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 10

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -325,7 +325,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  disk {
+  boot_disk {
     source_image = "debian-8-jessie-v20160803"
     auto_delete  = true
     boot         = true

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -9,10 +9,11 @@ import (
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
+	"sort"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"sort"
 )
 
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
@@ -431,7 +432,7 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -485,7 +486,7 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -522,7 +523,7 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -571,7 +572,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -608,7 +609,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -656,7 +657,7 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		can_ip_forward = false
 		tags = ["%s"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -696,7 +697,7 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		disk {
+		boot_disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -742,7 +743,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	disk {
+	boot_disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -98,21 +98,33 @@ func testAccCheckComputeRouteExists(n string, route *compute.Route) resource.Tes
 var testAccComputeRoute_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "route-test-%s"
-	ipv4_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "route-test-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "${google_compute_network.foobar.self_link}"
+  region        = "us-central1"
 }
 
 resource "google_compute_route" "foobar" {
 	name = "route-test-%s"
 	dest_range = "15.0.0.0/24"
 	network = "${google_compute_network.foobar.name}"
-	next_hop_ip = "10.0.1.5"
+	next_hop_ip = "10.154.0.1"
 	priority = 100
-}`, acctest.RandString(10), acctest.RandString(10))
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 
 var testAccComputeRoute_defaultInternetGateway = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "route-test-%s"
-	ipv4_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "route-test-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "${google_compute_network.foobar.self_link}"
+  region        = "us-central1"
 }
 
 resource "google_compute_route" "foobar" {
@@ -121,4 +133,4 @@ resource "google_compute_route" "foobar" {
 	network = "${google_compute_network.foobar.name}"
 	next_hop_gateway = "default-internet-gateway"
 	priority = 100
-}`, acctest.RandString(10), acctest.RandString(10))
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/google/resource_compute_router_interface_test.go
+++ b/google/resource_compute_router_interface_test.go
@@ -156,7 +156,7 @@ func testAccComputeRouterInterfaceBasic(testId string) string {
 			name = "router-interface-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-interface-test-%s"
+			name = "router-interface-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "us-central1"
@@ -225,7 +225,7 @@ func testAccComputeRouterInterfaceKeepRouter(testId string) string {
 			name = "router-interface-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-interface-test-%s"
+			name = "router-interface-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "us-central1"

--- a/google/resource_compute_router_peer_test.go
+++ b/google/resource_compute_router_peer_test.go
@@ -156,7 +156,7 @@ func testAccComputeRouterPeerBasic(testId string) string {
 			name = "router-peer-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-peer-test-%s"
+			name = "router-peer-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "us-central1"
@@ -234,7 +234,7 @@ func testAccComputeRouterPeerKeepRouter(testId string) string {
 			name = "router-peer-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-peer-test-%s"
+			name = "router-peer-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "us-central1"

--- a/google/resource_compute_router_test.go
+++ b/google/resource_compute_router_test.go
@@ -140,7 +140,7 @@ func testAccComputeRouterBasic(resourceRegion string) string {
 			name = "router-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-test-%s"
+			name = "router-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "%s"
@@ -163,7 +163,7 @@ func testAccComputeRouterNoRegion(providerRegion string) string {
 			name = "router-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-test-%s"
+			name = "router-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "%s"
@@ -185,7 +185,7 @@ func testAccComputeRouterNetworkLink() string {
 			name = "router-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-test-%s"
+			name = "router-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "europe-west1"

--- a/google/resource_compute_vpn_gateway_test.go
+++ b/google/resource_compute_vpn_gateway_test.go
@@ -85,8 +85,9 @@ func testAccCheckComputeVpnGatewayExists(n string) resource.TestCheckFunc {
 var testAccComputeVpnGateway_basic = fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "gateway-test-%s"
-	ipv4_range = "10.0.0.0/16"
+	auto_create_subnetworks = true
 }
+
 resource "google_compute_vpn_gateway" "foobar" {
 	name = "gateway-test-%s"
 	network = "${google_compute_network.foobar.self_link}"

--- a/google/resource_compute_vpn_tunnel_test.go
+++ b/google/resource_compute_vpn_tunnel_test.go
@@ -125,7 +125,7 @@ resource "google_compute_network" "foobar" {
 	name = "tunnel-test-%s"
 }
 resource "google_compute_subnetwork" "foobar" {
-	name = "tunnel-test-%s"
+	name = "tunnel-test-subnetwork-%s"
 	network = "${google_compute_network.foobar.self_link}"
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
@@ -181,7 +181,7 @@ func testAccComputeVpnTunnelRouter(router string) string {
 			name = "tunnel-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "tunnel-test-%s"
+			name = "tunnel-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "us-central1"

--- a/website/docs/r/compute_image.html.markdown
+++ b/website/docs/r/compute_image.html.markdown
@@ -29,8 +29,10 @@ resource "google_compute_instance" "vm" {
   machine_type = "n1-standard-1"
   zone         = "us-east1-c"
 
-  disk {
-    image = "${google_compute_image.bootable-image.self_link}"
+  boot_disk {
+    initialize_params {
+      image = "${google_compute_image.bootable-image.self_link}"
+    }
   }
 
   network_interface {

--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -30,8 +30,10 @@ resource "google_compute_instance" "frontend" {
   machine_type = "g1-small"
   zone         = "us-central1-b"
 
-  disk {
-    image = "debian-cloud/debian-8"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
   }
 
   network_interface {


### PR DESCRIPTION
Fix the CI tests we broke with the deprecations for 1.0.0, and update
the docs we missed. Also, update the examples.