### PR TITLE
Fix failing tests: instance templates still use `disk`

### DIFF
--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -149,7 +149,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -209,7 +209,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -422,7 +422,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  boot_disk {
+  disk {
     source_image = "debian-8-jessie-v20160803"
     auto_delete  = true
     boot         = true

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -360,7 +360,7 @@ resource "google_compute_instance" "bar" {
 	}
 
 	attached_disk {
-		disk = "${google_compute_disk.foo.name}"
+		source = "${google_compute_disk.foo.self_link}"
 		auto_delete = false
 	}
 

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -356,12 +356,13 @@ resource "google_compute_instance" "bar" {
 	zone = "us-central1-a"
 
 	boot_disk {
-		image = "debian-8-jessie-v20170523"
+		initialize_params {
+			image = "debian-8-jessie-v20170523"
+		}
 	}
 
 	attached_disk {
 		source = "${google_compute_disk.foo.self_link}"
-		auto_delete = false
 	}
 
 	network_interface {

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -501,7 +501,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -555,7 +555,7 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -592,7 +592,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -641,7 +641,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -678,7 +678,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -726,7 +726,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		can_ip_forward = false
 		tags = ["%s"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -766,7 +766,7 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 		can_ip_forward = false
 		tags = ["terraform-testing"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -807,7 +807,7 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -853,7 +853,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	boot_disk {
+	disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -909,7 +909,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	boot_disk {
+	disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -507,7 +507,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 	}
 
@@ -535,7 +535,7 @@ resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 100
@@ -568,7 +568,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 		name = "instance-tpl-%s"
 		machine_type = "n1-standard-1"
 
-		boot_disk {
+		disk {
 			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			disk_size_gb = 10
@@ -603,7 +603,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	region = "us-central1"
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 10
@@ -640,7 +640,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(xpn_host string) string {
 		machine_type = "n1-standard-1"
 		region = "us-central1"
 
-		boot_disk {
+		disk {
 			source_image = "debian-8-jessie-v20160803"
 			auto_delete = true
 			disk_size_gb = 10
@@ -663,7 +663,7 @@ resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		disk_size_gb = 10

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -419,7 +419,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -450,7 +450,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true
@@ -484,7 +484,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
-	boot_disk {
+	disk {
 		source_image = "debian-8-jessie-v20160803"
 	}
 
@@ -542,7 +542,7 @@ resource "google_compute_instance_template" "foobar" {
 		boot = true
 	}
 
-	attached_disk {
+	disk {
 		source = "terraform-test-foobar"
 		auto_delete = false
 		boot = false

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -325,7 +325,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  boot_disk {
+  disk {
     source_image = "debian-8-jessie-v20160803"
     auto_delete  = true
     boot         = true

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -432,7 +432,7 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -486,7 +486,7 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -523,7 +523,7 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -572,7 +572,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -609,7 +609,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -657,7 +657,7 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		can_ip_forward = false
 		tags = ["%s"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -697,7 +697,7 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
-		boot_disk {
+		disk {
 			source_image = "debian-cloud/debian-8-jessie-v20160803"
 			auto_delete = true
 			boot = true
@@ -743,7 +743,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
-	boot_disk {
+	disk {
 		source_image = "debian-cloud/debian-8-jessie-v20160803"
 		auto_delete = true
 		boot = true


### PR DESCRIPTION
Running the full compute suite now, will update back when it's done.