### PR TITLE
Add update support for pubsub subscription push config field

### DIFF
--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -11,6 +11,7 @@ func resourcePubsubSubscription() *schema.Resource {
 	return &schema.Resource{
 		Create: resourcePubsubSubscriptionCreate,
 		Read:   resourcePubsubSubscriptionRead,
+		Update: resourcePubsubSubscriptionUpdate,
 		Delete: resourcePubsubSubscriptionDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -52,35 +53,24 @@ func resourcePubsubSubscription() *schema.Resource {
 			"push_config": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attributes": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
-							ForceNew: true,
 							Elem:     schema.TypeString,
 						},
 
 						"push_endpoint": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 					},
 				},
 			},
 		},
 	}
-}
-
-func cleanAdditionalArgs(args map[string]interface{}) map[string]string {
-	cleaned_args := make(map[string]string)
-	for k, v := range args {
-		cleaned_args[k] = v.(string)
-	}
-	return cleaned_args
 }
 
 func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
@@ -101,17 +91,10 @@ func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) 
 		ackDeadlineSeconds = int64(v.(int))
 	}
 
-	var subscription *pubsub.Subscription
-	if v, ok := d.GetOk("push_config"); ok {
-		push_configs := v.([]interface{})
-
-		push_config := push_configs[0].(map[string]interface{})
-		attributes := push_config["attributes"].(map[string]interface{})
-		attributesClean := cleanAdditionalArgs(attributes)
-		pushConfig := &pubsub.PushConfig{Attributes: attributesClean, PushEndpoint: push_config["push_endpoint"].(string)}
-		subscription = &pubsub.Subscription{AckDeadlineSeconds: ackDeadlineSeconds, Topic: computed_topic_name, PushConfig: pushConfig}
-	} else {
-		subscription = &pubsub.Subscription{AckDeadlineSeconds: ackDeadlineSeconds, Topic: computed_topic_name}
+	subscription := &pubsub.Subscription{
+		AckDeadlineSeconds: ackDeadlineSeconds,
+		Topic:              computed_topic_name,
+		PushConfig:         expandPubsubSubscriptionPushConfig(d.Get("push_config").([]interface{})),
 	}
 
 	call := config.clientPubsub.Projects.Subscriptions.Create(name, subscription)
@@ -121,9 +104,8 @@ func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(res.Name)
-	d.Set("path", name)
 
-	return nil
+	return resourcePubsubSubscriptionRead(d, meta)
 }
 
 func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
@@ -139,7 +121,27 @@ func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("topic", subscription.Topic)
 	d.Set("ack_deadline_seconds", subscription.AckDeadlineSeconds)
 	d.Set("path", subscription.Name)
-	d.Set("push_config", flattenPushConfig(subscription.PushConfig))
+	d.Set("push_config", flattenPubsubSubscriptionPushConfig(subscription.PushConfig))
+
+	return nil
+}
+
+func resourcePubsubSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	d.Partial(true)
+
+	if d.HasChange("push_config") {
+		_, err := config.clientPubsub.Projects.Subscriptions.ModifyPushConfig(d.Id(), &pubsub.ModifyPushConfigRequest{
+			PushConfig: expandPubsubSubscriptionPushConfig(d.Get("push_config").([]interface{})),
+		}).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error updating subscription '%s': %s", d.Get("name"), err)
+		}
+	}
+
+	d.Partial(false)
 
 	return nil
 }
@@ -172,7 +174,7 @@ func resourcePubsubSubscriptionStateImporter(d *schema.ResourceData, meta interf
 	return []*schema.ResourceData{d}, nil
 }
 
-func flattenPushConfig(pushConfig *pubsub.PushConfig) []map[string]interface{} {
+func flattenPubsubSubscriptionPushConfig(pushConfig *pubsub.PushConfig) []map[string]interface{} {
 	configs := make([]map[string]interface{}, 0, 1)
 
 	if pushConfig == nil || len(pushConfig.PushEndpoint) == 0 {
@@ -185,4 +187,18 @@ func flattenPushConfig(pushConfig *pubsub.PushConfig) []map[string]interface{} {
 	})
 
 	return configs
+}
+
+func expandPubsubSubscriptionPushConfig(configured []interface{}) *pubsub.PushConfig {
+	if len(configured) != 1 {
+		// An empty `pushConfig` indicates that the Pub/Sub system should stop pushing messages
+		// from the given subscription and allow messages to be pulled and acknowledged.
+		return &pubsub.PushConfig{}
+	}
+
+	pushConfig := configured[0].(map[string]interface{})
+	return &pubsub.PushConfig{
+		PushEndpoint: pushConfig["push_endpoint"].(string),
+		Attributes:   convertStringMap(pushConfig["attributes"].(map[string]interface{})),
+	}
 }

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -190,7 +190,7 @@ func flattenPubsubSubscriptionPushConfig(pushConfig *pubsub.PushConfig) []map[st
 }
 
 func expandPubsubSubscriptionPushConfig(configured []interface{}) *pubsub.PushConfig {
-	if len(configured) != 1 {
+	if len(configured) == 0 {
 		// An empty `pushConfig` indicates that the Pub/Sub system should stop pushing messages
 		// from the given subscription and allow messages to be pulled and acknowledged.
 		return &pubsub.PushConfig{}

--- a/google/resource_spanner_instance.go
+++ b/google/resource_spanner_instance.go
@@ -335,11 +335,3 @@ func extractSpannerInstanceId(id string) (*spannerInstanceId, error) {
 		Instance: parts[1],
 	}, nil
 }
-
-func convertStringMap(v map[string]interface{}) map[string]string {
-	m := make(map[string]string)
-	for k, val := range v {
-		m[k] = val.(string)
-	}
-	return m
-}

--- a/google/utils.go
+++ b/google/utils.go
@@ -318,6 +318,14 @@ func convertStringSet(set *schema.Set) []string {
 	return s
 }
 
+func convertStringMap(v map[string]interface{}) map[string]string {
+	m := make(map[string]string)
+	for k, val := range v {
+		m[k] = val.(string)
+	}
+	return m
+}
+
 func convertArrToMap(ifaceArr []interface{}) map[string]struct{} {
 	sm := make(map[string]struct{})
 	for _, s := range ifaceArr {

--- a/google/utils.go
+++ b/google/utils.go
@@ -289,14 +289,21 @@ func expandLabels(d *schema.ResourceData) map[string]string {
 
 // expandStringMap pulls the value of key out of a schema.ResourceData as a map[string]string.
 func expandStringMap(d *schema.ResourceData, key string) map[string]string {
-	mp := map[string]string{}
-	if v, ok := d.GetOk(key); ok {
-		labelMap := v.(map[string]interface{})
-		for k, v := range labelMap {
-			mp[k] = v.(string)
-		}
+	v, ok := d.GetOk(key)
+
+	if !ok {
+		return map[string]string{}
 	}
-	return mp
+
+	return convertStringMap(v.(map[string]interface{}))
+}
+
+func convertStringMap(v map[string]interface{}) map[string]string {
+	m := make(map[string]string)
+	for k, val := range v {
+		m[k] = val.(string)
+	}
+	return m
 }
 
 func convertStringArr(ifaceArr []interface{}) []string {
@@ -316,14 +323,6 @@ func convertStringSet(set *schema.Set) []string {
 		s = append(s, v.(string))
 	}
 	return s
-}
-
-func convertStringMap(v map[string]interface{}) map[string]string {
-	m := make(map[string]string)
-	for k, val := range v {
-		m[k] = val.(string)
-	}
-	return m
 }
 
 func convertArrToMap(ifaceArr []interface{}) map[string]struct{} {


### PR DESCRIPTION
Fixes #455.

As discussed in #456, testing in not very practical for the `push_config` field. You can learn more also here: https://github.com/rosbo/terraform-provider-google/blob/f79044a57c7ed52d13144daa09899dc553e0ec2b/google/resource_pubsub_subscription_test.go#L33. I tested it manually.
