### PR TITLE
Fix: Updates sidebar text in docs for google_client_config resource

### DIFF
--- a/website/google.erb
+++ b/website/google.erb
@@ -14,7 +14,7 @@
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav nav-visible">
       <li<%= sidebar_current("docs-google-datasource-client-config") %>>
-        <a href="/docs/providers/google/d/datasource_client_config.html">google_compute_network</a>
+        <a href="/docs/providers/google/d/datasource_client_config.html">google_client_config</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>


### PR DESCRIPTION
I noticed that the sidebar in the docs had `google_compute_network` listed twice:

![image](https://user-images.githubusercontent.com/3793752/31148786-673f439a-a853-11e7-85e0-0a1c85b7405c.png)

It looks like the anchor tag was copy/pasted without changing the text content.