### PR TITLE
Fix BackendService group hash when instance groups use beta features

### DIFF
--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -19,6 +19,7 @@ func resourceComputeBackendService() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -42,8 +43,9 @@ func resourceComputeBackendService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 						"balancing_mode": &schema.Schema{
 							Type:     schema.TypeString,
@@ -374,7 +376,8 @@ func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	group, _ := getRelativePath(m["group"].(string))
+	buf.WriteString(fmt.Sprintf("%s-", group))
 
 	if v, ok := m["balancing_mode"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/google/resource_compute_backend_service_migrate.go
+++ b/google/resource_compute_backend_service_migrate.go
@@ -34,11 +34,7 @@ func migrateBackendServiceStateV0toV1(is *terraform.InstanceState) (*terraform.I
 
 	oldHashToValue := map[string]map[string]interface{}{}
 	for k, v := range is.Attributes {
-		if !strings.HasPrefix(k, "backend.") {
-			continue
-		}
-
-		if k == "backend.#" {
+		if !strings.HasPrefix(k, "backend.") || k == "backend.#" {
 			continue
 		}
 

--- a/google/resource_compute_backend_service_migrate.go
+++ b/google/resource_compute_backend_service_migrate.go
@@ -1,0 +1,94 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceComputeBackendServiceMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Compute Backend Service State v0; migrating to v1")
+		is, err := migrateBackendServiceStateV0toV1(is)
+		if err != nil {
+			return is, err
+		}
+		return is, nil
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateBackendServiceStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	oldHashToValue := map[string]map[string]interface{}{}
+	for k, v := range is.Attributes {
+		if !strings.HasPrefix(k, "backend.") {
+			continue
+		}
+
+		if k == "backend.#" {
+			continue
+		}
+
+		// Key is now of the form backend.%d.%s
+		kParts := strings.Split(k, ".")
+
+		// Sanity check: two parts should be there and <N> should be a number
+		badFormat := false
+		if len(kParts) != 3 {
+			badFormat = true
+		} else if _, err := strconv.Atoi(kParts[1]); err != nil {
+			badFormat = true
+		}
+
+		if badFormat {
+			return is, fmt.Errorf("migration error: found backend key in unexpected format: %s", k)
+		}
+
+		if oldHashToValue[kParts[1]] == nil {
+			oldHashToValue[kParts[1]] = map[string]interface{}{}
+		}
+		oldHashToValue[kParts[1]][kParts[2]] = v
+	}
+
+	oldHashToNewHash := map[string]int{}
+	for k, v := range oldHashToValue {
+		oldHashToNewHash[k] = resourceGoogleComputeBackendServiceBackendHash(v)
+	}
+
+	values := map[string]string{}
+	for k, v := range is.Attributes {
+		if !strings.HasPrefix(k, "backend.") {
+			continue
+		}
+
+		if k == "backend.#" {
+			continue
+		}
+
+		// Key is now of the form backend.%d.%s
+		kParts := strings.Split(k, ".")
+		newKey := fmt.Sprintf("%s.%d.%s", kParts[0], oldHashToNewHash[kParts[1]], kParts[2])
+		values[newKey] = v
+		delete(is.Attributes, k)
+	}
+
+	for k, v := range values {
+		is.Attributes[k] = v
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/google/resource_compute_backend_service_migrate_test.go
+++ b/google/resource_compute_backend_service_migrate_test.go
@@ -1,0 +1,95 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestComputeBackendServiceMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion       int
+		Attributes         map[string]string
+		ExpectedAttributes map[string]string
+		Meta               interface{}
+	}{
+		"v0 to v1": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"backend.#":                         "1",
+				"backend.242332812.group":           "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instanceGroups/igName",
+				"backend.242332812.balancing_mode":  "UTILIZATION",
+				"backend.242332812.max_utilization": "0.8",
+			},
+			ExpectedAttributes: map[string]string{
+				"backend.#":                          "1",
+				"backend.2573491210.group":           "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instanceGroups/igName",
+				"backend.2573491210.balancing_mode":  "UTILIZATION",
+				"backend.2573491210.max_utilization": "0.8",
+			},
+			Meta: &Config{},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "i-abc123",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceComputeBackendServiceMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.ExpectedAttributes {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+
+		for k, v := range is.Attributes {
+			if tc.ExpectedAttributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, tc.ExpectedAttributes[k], k, v, is.Attributes)
+			}
+		}
+	}
+}
+
+func TestComputeBackendServiceMigrateState_empty(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+	}{
+		"v0": {
+			StateVersion: 0,
+		},
+	}
+
+	for tn, tc := range cases {
+		var is *terraform.InstanceState
+		var meta *Config
+
+		// should handle nil
+		is, err := resourceComputeBackendServiceMigrateState(tc.StateVersion, is, meta)
+
+		if err != nil {
+			t.Fatalf("bad %s, err: %#v", tn, err)
+		}
+		if is != nil {
+			t.Fatalf("bad %s, expected nil instancestate, got: %#v", tn, is)
+		}
+
+		// should handle non-nil but empty
+		is = &terraform.InstanceState{}
+		is, err = resourceComputeBackendServiceMigrateState(tc.StateVersion, is, meta)
+
+		if err != nil {
+			t.Fatalf("bad %s, err: %#v", tn, err)
+		}
+	}
+}

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -412,6 +412,10 @@ resource "google_compute_instance_group_manager" "foobar" {
   base_instance_name = "foobar"
   zone               = "us-central1-f"
   target_size        = 1
+  auto_healing_policies {
+    health_check = "${google_compute_http_health_check.default.self_link}"
+    initial_delay_sec = "10"
+  }
 }
 
 resource "google_compute_instance_template" "foobar" {


### PR DESCRIPTION
Fixes #462.

The issue in #462 was that `backend.group` takes a self link of an instance group. Instance Group Managers have a beta field, `auto_healing_policies`. If that is set, then its self link will be the beta one since we have to read from the beta API in order to read that field. In that case, the example config ended up such that state had the v1 self link (because it reads from the v1 BackendServices API) but plan wanted to change it to a beta self link (because it reads from the beta InstanceGroupManagers API).

The link of the instance group is one of the factors that makes up the hash for the backend. In order to make sure changes in api version don't impact the backend hash, I've changed it to use the relative path instead of the full self link. Since this changes the value of the hash, I added a state migration.

While I was in the neighborhood, I also changed `group` to Required since it'll fail server-side if it's not set (and our documentation actually says it's Required) and added a self link DiffSuppress for it.

```
$ make testacc TEST=./google TESTARGS='-run=TestComputeBackendServiceMigrateState'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestComputeBackendServiceMigrateState -timeout 120m
=== RUN   TestComputeBackendServiceMigrateState
2017/10/03 16:46:42 [INFO] Found Compute Backend Service State v0; migrating to v1
2017/10/03 16:46:42 [DEBUG] Attributes before migration: map[string]string{"backend.242332812.balancing_mode":"UTILIZATION", "backend.242332812.max_utilization":"0.8", "backend.#":"1", "backend.242332812.group":"https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instanceGroups/igName"}
2017/10/03 16:46:42 [DEBUG] Attributes after migration: map[string]string{"backend.2573491210.balancing_mode":"UTILIZATION", "backend.2573491210.max_utilization":"0.8", "backend.2573491210.group":"https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instanceGroups/igName", "backend.#":"1"}
--- PASS: TestComputeBackendServiceMigrateState (0.00s)
=== RUN   TestComputeBackendServiceMigrateState_empty
2017/10/03 16:46:42 [DEBUG] Empty InstanceState; nothing to migrate.
2017/10/03 16:46:42 [DEBUG] Empty InstanceState; nothing to migrate.
--- PASS: TestComputeBackendServiceMigrateState_empty (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	0.159s
```

```
$ make testacc TEST=./google TESTARGS='-run=TestAccComputeBackendService_withBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeBackendService_withBackend -timeout 120m
=== RUN   TestAccComputeBackendService_withBackend
--- PASS: TestAccComputeBackendService_withBackend (93.22s)
=== RUN   TestAccComputeBackendService_withBackendAndUpdate
--- PASS: TestAccComputeBackendService_withBackendAndUpdate (105.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	198.636s
```