### PR TITLE
Improve VPN gateway and router to generate network link without calling network API

### DIFF
--- a/google/resource_compute_router_test.go
+++ b/google/resource_compute_router_test.go
@@ -164,7 +164,8 @@ func testAccComputeRouterNoRegion(providerRegion string) string {
 		}
 		resource "google_compute_subnetwork" "foobar" {
 			name = "router-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
+			network = "${google_compute_network.foobar.name}"
+			ip_cidr_range = "10.0.0.0/16"
 			ip_cidr_range = "10.0.0.0/16"
 			region = "%s"
 		}


### PR DESCRIPTION
Helps for #431 

Not calling the network API for generating the network `self_link` has 2 main advantages:
* Faster, avoid an extraneous network call
* Requires less permission: you may have the permission to create a router without the permission to actually read the network info.