### PR TITLE
Fix crash when creating node pools with `name_prefix` or no name

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -158,8 +158,8 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	zone := d.Get("zone").(string)
-	name := d.Get("name").(string)
 	cluster := d.Get("cluster").(string)
+	name := getNodePoolName(d.Id())
 
 	nodePool, err := config.clientContainer.Projects.Zones.Clusters.NodePools.Get(
 		project, zone, cluster, name).Do()
@@ -233,13 +233,13 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 	}
 
 	zone := d.Get("zone").(string)
-	name := d.Get("name").(string)
 	cluster := d.Get("cluster").(string)
+	name := getNodePoolName(d.Id())
 
 	_, err = config.clientContainer.Projects.Zones.Clusters.NodePools.Get(
 		project, zone, cluster, name).Do()
 	if err != nil {
-		if err = handleNotFoundError(err, d, fmt.Sprintf("Container NodePool %s", d.Get("name").(string))); err == nil {
+		if err = handleNotFoundError(err, d, fmt.Sprintf("Container NodePool %s", name)); err == nil {
 			return false, nil
 		}
 		// There was some other error in reading the resource
@@ -416,4 +416,9 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, clusterName, prefi
 	}
 
 	return nil
+}
+
+func getNodePoolName(id string) string {
+	// name can be specified with name, name_prefix, or neither, so read it from the id.
+	return strings.Split(id, "/")[2]
 }

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -32,6 +32,42 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_namePrefix(t *testing.T) {
+	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerNodePool_namePrefix(cluster, "tf-np-"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContainerNodePool_noName(t *testing.T) {
+	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerNodePool_noName(cluster),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerNodePoolMatches("google_container_node_pool.np"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -236,6 +272,37 @@ resource "google_container_node_pool" "np" {
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 }`, cluster, np)
+}
+
+func testAccContainerNodePool_namePrefix(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+}
+
+resource "google_container_node_pool" "np" {
+	name_prefix = "%s"
+	zone = "us-central1-a"
+	cluster = "${google_container_cluster.cluster.name}"
+	initial_node_count = 2
+}`, cluster, np)
+}
+
+func testAccContainerNodePool_noName(cluster string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+}
+
+resource "google_container_node_pool" "np" {
+	zone = "us-central1-a"
+	cluster = "${google_container_cluster.cluster.name}"
+	initial_node_count = 2
+}`, cluster)
 }
 
 func testAccContainerNodePool_autoscaling(cluster, np string) string {


### PR DESCRIPTION
Fixes #479.

```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_noName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerNodePool_noName -timeout 120m
=== RUN   TestAccContainerNodePool_noName
--- PASS: TestAccContainerNodePool_noName (573.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	574.179s
```
```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_namePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerNodePool_namePrefix -timeout 120m
=== RUN   TestAccContainerNodePool_namePrefix
--- PASS: TestAccContainerNodePool_namePrefix (614.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	615.102s
```
```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_withNodePoolNamePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_withNodePoolNamePrefix -timeout 120m
=== RUN   TestAccContainerCluster_withNodePoolNamePrefix
--- PASS: TestAccContainerCluster_withNodePoolNamePrefix (387.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	387.860s
```