### PR TITLE
Copy network_interface attributes back to state on resourceComputeInstanceRead(). (Fixes #519)

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -890,6 +890,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
 		})
 	}
+	d.Set("network_interface", networkInterfaces)
 
 	// Fall back on internal ip if there is no external ip.  This makes sense in the situation where
 	// terraform is being used on a cloud instance and can therefore access the instances it creates


### PR DESCRIPTION
Fixes #519.

Added an acceptance test for coverage.