### PR TITLE
add master_version to container cluster

### DIFF
--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -172,7 +172,7 @@ func TestAccContainerCluster_updateVersion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccContainerCluster_withVersion(clusterName),
+				Config: testAccContainerCluster_updateVersion(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_version"),
@@ -824,7 +824,7 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	node_version = "${data.google_container_engine_versions.central1a.latest_node_version}"
+	master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 	initial_node_count = 1
 
 	master_auth {
@@ -843,7 +843,27 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	node_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	initial_node_count = 1
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+}`, clusterName)
+}
+
+func testAccContainerCluster_updateVersion(clusterName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+	zone = "us-central1-a"
+}
+
+resource "google_container_cluster" "with_version" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
+	node_version = "${data.google_container_engine_versions.central1a.latest_node_version}"
 	initial_node_count = 1
 
 	master_auth {


### PR DESCRIPTION
Fixes #492 

```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_withVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_withVersion -timeout 120m
=== RUN   TestAccContainerCluster_withVersion
--- PASS: TestAccContainerCluster_withVersion (367.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	367.200s
```
```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_updateVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_updateVersion -timeout 120m
=== RUN   TestAccContainerCluster_updateVersion
--- PASS: TestAccContainerCluster_updateVersion (871.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	872.204s
```
```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_basic -timeout 120m
=== RUN   TestAccContainerCluster_basic
--- PASS: TestAccContainerCluster_basic (379.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	379.704s
```

I also tested that existing users won't have issues by creating a cluster without a specific version on an older build (creating it with a specific version is what this is fixing), then updated my build and ran `terraform plan`.