### PR TITLE
Use go1.9.1 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- 1.9
+- 1.9.1
 
 install:
 # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
Go 1.9.1 was just released to fix a security vulnerability in 1.9.0. Let's use it for our Travis tests.