### PR TITLE
fix default for connection_draining_timeout_sec

### DIFF
--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
     to a request before considering the request failed. Defaults to `30`.
 
 * `connection_draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections,
-but still work to finish started ones). Defaults to `0`.
+but still work to finish started ones). Defaults to `300`.
 
 The `backend` block supports:
 


### PR DESCRIPTION
The default value for the connection_draining_timeout_sec arg was changed in commit 5cd3e1ec99398698b5caabe4e39a9306253d4496 from 0 to 300. Fixing the doc to reflect this change.