### PR TITLE
Fix crash because missing error check before waiting on operation

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -770,7 +770,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	switch computeApiVersion {
 	case v1:
 		instanceV1 := &compute.Instance{}
-		err := Convert(instance, instanceV1)
+		err = Convert(instance, instanceV1)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #553 

The short assignment of `err` caused the err check below the switch case for v1/beta to be skipped when the v1 path was used causing the app to crash on the wait operation