### PR TITLE
Add t.Parallel to all acceptance tests

### DIFF
--- a/google/data_source_dns_managed_zone_test.go
+++ b/google/data_source_dns_managed_zone_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/data_source_google_client_config_test.go
+++ b/google/data_source_google_client_config_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "data.google_client_config.current"
 
 	resource.Test(t, resource.TestCase{

--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAccDataSourceGoogleComputeInstanceGroup_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -30,6 +32,8 @@ func TestAccDataSourceGoogleComputeInstanceGroup_basic(t *testing.T) {
 }
 
 func TestAccDataSourceGoogleComputeInstanceGroup_withNamedPort(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/google/data_source_google_compute_network_test.go
+++ b/google/data_source_google_compute_network_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccDataSourceGoogleNetwork(t *testing.T) {
+	t.Parallel()
+
 	networkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/google/data_source_google_compute_zones_test.go
+++ b/google/data_source_google_compute_zones_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccGoogleComputeZones_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/google/data_source_google_container_engine_versions_test.go
+++ b/google/data_source_google_container_engine_versions_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccGoogleContainerEngineVersions_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/google/data_source_storage_object_signed_url_test.go
+++ b/google/data_source_storage_object_signed_url_test.go
@@ -100,6 +100,8 @@ func TestUrlData_SignedUrl(t *testing.T) {
 }
 
 func TestAccStorageSignedUrl_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -115,6 +117,8 @@ func TestAccStorageSignedUrl_basic(t *testing.T) {
 }
 
 func TestAccStorageSignedUrl_accTest(t *testing.T) {
+	t.Parallel()
+
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	headers := map[string]string{

--- a/google/image_test.go
+++ b/google/image_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeImage_resolveImage(t *testing.T) {
+	t.Parallel()
+
 	var image compute.Image
 	rand := acctest.RandString(10)
 	name := fmt.Sprintf("test-image-%s", rand)

--- a/google/import_bigquery_dataset_test.go
+++ b/google/import_bigquery_dataset_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccBigQueryDataset_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_bigquery_dataset.test"
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 

--- a/google/import_bigquery_table_test.go
+++ b/google/import_bigquery_table_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccBigQueryTable_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_bigquery_table.test"
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))

--- a/google/import_compute_address_test.go
+++ b/google/import_compute_address_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeAddress_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_address.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_autoscaler_test.go
+++ b/google/import_compute_autoscaler_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeAutoscaler_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_autoscaler.foobar"
 
 	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))

--- a/google/import_compute_backend_service_test.go
+++ b/google/import_compute_backend_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeBackendService_importBasic(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/google/import_compute_disk_test.go
+++ b/google/import_compute_disk_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeDisk_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_disk.foobar"
 	diskName := fmt.Sprintf("disk-test-%s", acctest.RandString(10))
 

--- a/google/import_compute_firewall_test.go
+++ b/google/import_compute_firewall_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeFirewall_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_firewall.foobar"
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))

--- a/google/import_compute_forwarding_rule_test.go
+++ b/google/import_compute_forwarding_rule_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeForwardingRule_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_forwarding_rule.foobar"
 	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))

--- a/google/import_compute_global_address_test.go
+++ b/google/import_compute_global_address_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeGlobalAddress_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_global_address.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_health_check_test.go
+++ b/google/import_compute_health_check_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeHealthCheck_importBasicHttp(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_health_check.foobar"
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -31,6 +33,8 @@ func TestAccComputeHealthCheck_importBasicHttp(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_importBasicHttps(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_health_check.foobar"
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -53,6 +57,8 @@ func TestAccComputeHealthCheck_importBasicHttps(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_importBasicTcp(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_health_check.foobar"
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -74,6 +80,8 @@ func TestAccComputeHealthCheck_importBasicTcp(t *testing.T) {
 	})
 }
 func TestAccComputeHealthCheck_importBasicSsl(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_health_check.foobar"
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/google/import_compute_http_health_check_test.go
+++ b/google/import_compute_http_health_check_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeHttpHealthCheck_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_http_health_check.foobar"
 
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/import_compute_https_health_check_test.go
+++ b/google/import_compute_https_health_check_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeHttpsHealthCheck_importBasic(t *testing.T) {
+	t.Parallel()
+
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_image_test.go
+++ b/google/import_compute_image_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeImage_importFromRawDisk(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -27,6 +29,8 @@ func TestAccComputeImage_importFromRawDisk(t *testing.T) {
 }
 
 func TestAccComputeImage_importFromSourceDisk(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/import_compute_instance_group_manager_test.go
+++ b/google/import_compute_instance_group_manager_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccInstanceGroupManager_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName1 := "google_compute_instance_group_manager.igm-basic"
 	resourceName2 := "google_compute_instance_group_manager.igm-no-tp"
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -41,6 +43,8 @@ func TestAccInstanceGroupManager_importBasic(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_importUpdate(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_group_manager.igm-update"
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))

--- a/google/import_compute_instance_group_test.go
+++ b/google/import_compute_instance_group_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeInstanceGroup_import(t *testing.T) {
+	t.Parallel()
+
 	instanceName := fmt.Sprintf("instancegroup-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_instance_template_test.go
+++ b/google/import_compute_instance_template_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeInstanceTemplate_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_template.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -29,6 +31,8 @@ func TestAccComputeInstanceTemplate_importBasic(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_importIp(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_template.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -50,6 +54,8 @@ func TestAccComputeInstanceTemplate_importIp(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_importDisks(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_template.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -71,6 +77,8 @@ func TestAccComputeInstanceTemplate_importDisks(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_importSubnetAuto(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_template.foobar"
 	network := "network-" + acctest.RandString(10)
 
@@ -93,6 +101,8 @@ func TestAccComputeInstanceTemplate_importSubnetAuto(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_importSubnetCustom(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_instance_template.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_network_test.go
+++ b/google/import_compute_network_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeNetwork_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_network.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -27,6 +29,8 @@ func TestAccComputeNetwork_importBasic(t *testing.T) {
 }
 
 func TestAccComputeNetwork_importAuto_subnet(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_network.bar"
 
 	resource.Test(t, resource.TestCase{
@@ -46,6 +50,8 @@ func TestAccComputeNetwork_importAuto_subnet(t *testing.T) {
 }
 
 func TestAccComputeNetwork_importCustom_subnet(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_network.baz"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_project_metadata_item_test.go
+++ b/google/import_compute_project_metadata_item_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeProjectMetadataItem_importBasic(t *testing.T) {
+	t.Parallel()
+
 	key := "myKey" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_route_test.go
+++ b/google/import_compute_route_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeRoute_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_network.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -27,6 +29,8 @@ func TestAccComputeRoute_importBasic(t *testing.T) {
 }
 
 func TestAccComputeRoute_importDefaultInternetGateway(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_network.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_router_interface_test.go
+++ b/google/import_compute_router_interface_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeRouterInterface_import(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_router_interface.foobar"
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_router_peer_test.go
+++ b/google/import_compute_router_peer_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeRouterPeer_import(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_router_peer.foobar"
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_router_test.go
+++ b/google/import_compute_router_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeRouter_import(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_router.foobar"
 	resourceRegion := "europe-west1"
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_subnetwork_test.go
+++ b/google/import_compute_subnetwork_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeSubnetwork_importBasic(t *testing.T) {
+	t.Parallel()
+
 	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	subnetwork1Name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	subnetwork2Name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/import_compute_target_pool_test.go
+++ b/google/import_compute_target_pool_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccComputeTargetPool_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_compute_target_pool.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_compute_target_tcp_proxy_test.go
+++ b/google/import_compute_target_tcp_proxy_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccComputeTargetTcpProxy_import(t *testing.T) {
+	t.Parallel()
+
 	target := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	backend := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))

--- a/google/import_container_cluster_test.go
+++ b/google/import_container_cluster_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccContainerCluster_import(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_container_cluster.primary"
 	name := fmt.Sprintf("tf-cluster-test-%s", acctest.RandString(10))
 	conf := testAccContainerCluster_basic(name)

--- a/google/import_container_node_pool_test.go
+++ b/google/import_container_node_pool_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccGoogleContainerNodePool_import(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_container_node_pool.np"
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))

--- a/google/import_dns_managed_zone_test.go
+++ b/google/import_dns_managed_zone_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccDnsManagedZone_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_dns_managed_zone.foobar"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_google_folder_test.go
+++ b/google/import_google_folder_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccGoogleFolder_import(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)

--- a/google/import_google_organization_policy_test.go
+++ b/google/import_google_organization_policy_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccGoogleOrganizationPolicy_import(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 

--- a/google/import_google_project_test.go
+++ b/google/import_google_project_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccGoogleProject_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_project.acceptance"
 	projectId := "terraform-" + acctest.RandString(10)
 	conf := testAccGoogleProject_import(projectId, org, pname)

--- a/google/import_pubsub_subscription_test.go
+++ b/google/import_pubsub_subscription_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccPubsubSubscription_import(t *testing.T) {
+	t.Parallel()
+
 	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
 	subscription := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(10))
 

--- a/google/import_pubsub_topic_test.go
+++ b/google/import_pubsub_topic_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccPubsubTopic_import(t *testing.T) {
+	t.Parallel()
+
 	topicName := fmt.Sprintf("tf-test-topic-%d", acctest.RandInt())
 	conf := fmt.Sprintf(`
 		resource "google_pubsub_topic" "tf-test" {

--- a/google/import_spanner_database_test.go
+++ b/google/import_spanner_database_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSpannerDatabase_importInstanceDatabase(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_spanner_database.basic"
 	instanceName := fmt.Sprintf("span-iname-%s", acctest.RandString(10))
 	dbName := fmt.Sprintf("span-dbname-%s", acctest.RandString(10))
@@ -33,6 +35,8 @@ func TestAccSpannerDatabase_importInstanceDatabase(t *testing.T) {
 }
 
 func TestAccSpannerDatabase_importProjectInstanceDatabase(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_spanner_database.basic"
 	instanceName := fmt.Sprintf("span-iname-%s", acctest.RandString(10))
 	dbName := fmt.Sprintf("span-dbname-%s", acctest.RandString(10))

--- a/google/import_spanner_instance_test.go
+++ b/google/import_spanner_instance_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSpannerInstance_importInstance(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_spanner_instance.basic"
 	instanceName := fmt.Sprintf("span-itest-%s", acctest.RandString(10))
 
@@ -32,6 +34,8 @@ func TestAccSpannerInstance_importInstance(t *testing.T) {
 }
 
 func TestAccSpannerInstance_importProjectInstance(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_spanner_instance.basic"
 	instanceName := fmt.Sprintf("span-itest-%s", acctest.RandString(10))
 	projectId := getTestProjectFromEnv()

--- a/google/import_sql_database_instance_test.go
+++ b/google/import_sql_database_instance_test.go
@@ -10,6 +10,8 @@ import (
 
 // Test importing a first generation database
 func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_sql_database_instance.instance"
 	databaseID := acctest.RandInt()
 
@@ -34,6 +36,8 @@ func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
 
 // Test importing a second generation database
 func TestAccGoogleSqlDatabaseInstance_importBasic3(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_sql_database_instance.instance"
 	databaseID := acctest.RandInt()
 

--- a/google/import_sql_database_test.go
+++ b/google/import_sql_database_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccGoogleSqlDatabase_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_sql_database.database"
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_sql_user_test.go
+++ b/google/import_sql_user_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccGoogleSqlUser_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resourceName := "google_sql_user.user"
 	user := acctest.RandString(10)
 	instance := acctest.RandString(10)

--- a/google/import_storage_bucket_test.go
+++ b/google/import_storage_bucket_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccStorageBucket_import(t *testing.T) {
+	t.Parallel()
+
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccBigQueryDataset_basic(t *testing.T) {
+	t.Parallel()
+
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccBigQueryTable_Basic(t *testing.T) {
+	t.Parallel()
+
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
@@ -39,6 +41,8 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 }
 
 func TestAccBigQueryTable_View(t *testing.T) {
+	t.Parallel()
+
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
@@ -59,6 +63,8 @@ func TestAccBigQueryTable_View(t *testing.T) {
 }
 
 func TestAccBigQueryTable_ViewWithLegacySQL(t *testing.T) {
+	t.Parallel()
+
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccBigtableInstance_basic(t *testing.T) {
+	t.Parallel()
+
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +32,8 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 }
 
 func TestAccBigtableInstance_development(t *testing.T) {
+	t.Parallel()
+
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_bigtable_table_test.go
+++ b/google/resource_bigtable_table_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccBigtableTable_basic(t *testing.T) {
+	t.Parallel()
+
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	tableName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -31,6 +33,8 @@ func TestAccBigtableTable_basic(t *testing.T) {
 }
 
 func TestAccBigtableTable_splitKeys(t *testing.T) {
+	t.Parallel()
+
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	tableName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -75,6 +75,8 @@ func TestComputeAddressIdParsing(t *testing.T) {
 // Acceptance tests
 
 func TestAccComputeAddress_basic(t *testing.T) {
+	t.Parallel()
+
 	var addr compute.Address
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeAutoscaler_basic(t *testing.T) {
+	t.Parallel()
+
 	var ascaler compute.Autoscaler
 
 	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
@@ -35,6 +37,8 @@ func TestAccComputeAutoscaler_basic(t *testing.T) {
 }
 
 func TestAccComputeAutoscaler_update(t *testing.T) {
+	t.Parallel()
+
 	var ascaler compute.Autoscaler
 
 	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))

--- a/google/resource_compute_backend_bucket_test.go
+++ b/google/resource_compute_backend_bucket_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeBackendBucket_basic(t *testing.T) {
+	t.Parallel()
+
 	backendName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	storageName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendBucket
@@ -36,6 +38,8 @@ func TestAccComputeBackendBucket_basic(t *testing.T) {
 }
 
 func TestAccComputeBackendBucket_basicModified(t *testing.T) {
+	t.Parallel()
+
 	backendName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	storageName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	secondStorageName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -117,6 +121,8 @@ func testAccCheckComputeBackendBucketExists(n string, svc *compute.BackendBucket
 }
 
 func TestAccComputeBackendBucket_withCdnEnabled(t *testing.T) {
+	t.Parallel()
+
 	backendName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	storageName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendBucket

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeBackendService_basic(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	extraCheckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -41,6 +43,8 @@ func TestAccComputeBackendService_basic(t *testing.T) {
 }
 
 func TestAccComputeBackendService_withBackend(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -74,6 +78,8 @@ func TestAccComputeBackendService_withBackend(t *testing.T) {
 }
 
 func TestAccComputeBackendService_withBackendAndUpdate(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -115,6 +121,8 @@ func TestAccComputeBackendService_withBackendAndUpdate(t *testing.T) {
 }
 
 func TestAccComputeBackendService_updatePreservesOptionalParameters(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -149,6 +157,8 @@ func TestAccComputeBackendService_updatePreservesOptionalParameters(t *testing.T
 }
 
 func TestAccComputeBackendService_withConnectionDraining(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -174,6 +184,8 @@ func TestAccComputeBackendService_withConnectionDraining(t *testing.T) {
 }
 
 func TestAccComputeBackendService_withConnectionDrainingAndUpdate(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -206,6 +218,8 @@ func TestAccComputeBackendService_withConnectionDrainingAndUpdate(t *testing.T) 
 }
 
 func TestAccComputeBackendService_withHttpsHealthCheck(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -274,6 +288,8 @@ func testAccCheckComputeBackendServiceExists(n string, svc *compute.BackendServi
 }
 
 func TestAccComputeBackendService_withCDNEnabled(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -300,6 +316,8 @@ func TestAccComputeBackendService_withCDNEnabled(t *testing.T) {
 }
 
 func TestAccComputeBackendService_withSessionAffinity(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccComputeDisk_basic(t *testing.T) {
+	t.Parallel()
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var disk compute.Disk
 
@@ -35,6 +37,8 @@ func TestAccComputeDisk_basic(t *testing.T) {
 }
 
 func TestAccComputeDisk_update(t *testing.T) {
+	t.Parallel()
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var disk compute.Disk
 
@@ -68,6 +72,8 @@ func TestAccComputeDisk_update(t *testing.T) {
 }
 
 func TestAccComputeDisk_fromSnapshot(t *testing.T) {
+	t.Parallel()
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	firstDiskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -99,6 +105,8 @@ func TestAccComputeDisk_fromSnapshot(t *testing.T) {
 }
 
 func TestAccComputeDisk_encryption(t *testing.T) {
+	t.Parallel()
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var disk compute.Disk
 
@@ -121,6 +129,8 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 }
 
 func TestAccComputeDisk_deleteDetach(t *testing.T) {
+	t.Parallel()
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var disk compute.Disk

--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAccComputeFirewall_basic(t *testing.T) {
+	t.Parallel()
+
 	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
@@ -37,6 +39,8 @@ func TestAccComputeFirewall_basic(t *testing.T) {
 }
 
 func TestAccComputeFirewall_update(t *testing.T) {
+	t.Parallel()
+
 	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
@@ -69,6 +73,8 @@ func TestAccComputeFirewall_update(t *testing.T) {
 }
 
 func TestAccComputeFirewall_priority(t *testing.T) {
+	t.Parallel()
+
 	var firewall computeBeta.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
@@ -90,6 +96,8 @@ func TestAccComputeFirewall_priority(t *testing.T) {
 }
 
 func TestAccComputeFirewall_noSource(t *testing.T) {
+	t.Parallel()
+
 	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
@@ -112,6 +120,8 @@ func TestAccComputeFirewall_noSource(t *testing.T) {
 }
 
 func TestAccComputeFirewall_denied(t *testing.T) {
+	t.Parallel()
+
 	var firewall computeBeta.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
@@ -134,6 +144,8 @@ func TestAccComputeFirewall_denied(t *testing.T) {
 }
 
 func TestAccComputeFirewall_egress(t *testing.T) {
+	t.Parallel()
+
 	var firewall computeBeta.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))

--- a/google/resource_compute_forwarding_rule_test.go
+++ b/google/resource_compute_forwarding_rule_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeForwardingRule_basic(t *testing.T) {
+	t.Parallel()
+
 	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 
@@ -30,6 +32,8 @@ func TestAccComputeForwardingRule_basic(t *testing.T) {
 }
 
 func TestAccComputeForwardingRule_singlePort(t *testing.T) {
+	t.Parallel()
+
 	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 
@@ -50,6 +54,8 @@ func TestAccComputeForwardingRule_singlePort(t *testing.T) {
 }
 
 func TestAccComputeForwardingRule_ip(t *testing.T) {
+	t.Parallel()
+
 	addrName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
@@ -71,6 +77,8 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 }
 
 func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeGlobalAddress_basic(t *testing.T) {
+	t.Parallel()
+
 	var addr compute.Address
 
 	resource.Test(t, resource.TestCase{
@@ -34,6 +36,8 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 }
 
 func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
+	t.Parallel()
+
 	var addr compute.Address
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_global_forwarding_rule_test.go
+++ b/google/resource_compute_global_forwarding_rule_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeGlobalForwardingRule_basic(t *testing.T) {
+	t.Parallel()
+
 	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	proxy1 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	proxy2 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
@@ -39,6 +41,8 @@ func TestAccComputeGlobalForwardingRule_basic(t *testing.T) {
 }
 
 func TestAccComputeGlobalForwardingRule_update(t *testing.T) {
+	t.Parallel()
+
 	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	proxy1 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	proxy2 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
@@ -71,6 +75,8 @@ func TestAccComputeGlobalForwardingRule_update(t *testing.T) {
 }
 
 func TestAccComputeGlobalForwardingRule_ipv6(t *testing.T) {
+	t.Parallel()
+
 	var frule computeBeta.ForwardingRule
 
 	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
@@ -98,6 +104,8 @@ func TestAccComputeGlobalForwardingRule_ipv6(t *testing.T) {
 }
 
 func TestAccComputeGlobalForwardingRule_labels(t *testing.T) {
+	t.Parallel()
+
 	var frule computeBeta.ForwardingRule
 
 	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))

--- a/google/resource_compute_health_check_test.go
+++ b/google/resource_compute_health_check_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeHealthCheck_tcp(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HealthCheck
 
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -36,6 +38,8 @@ func TestAccComputeHealthCheck_tcp(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_tcp_update(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HealthCheck
 
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -70,6 +74,8 @@ func TestAccComputeHealthCheck_tcp_update(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_ssl(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HealthCheck
 
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -93,6 +99,8 @@ func TestAccComputeHealthCheck_ssl(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_http(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HealthCheck
 
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -116,6 +124,8 @@ func TestAccComputeHealthCheck_http(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_https(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HealthCheck
 
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -139,6 +149,8 @@ func TestAccComputeHealthCheck_https(t *testing.T) {
 }
 
 func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
+	t.Parallel()
+
 	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_http_health_check_test.go
+++ b/google/resource_compute_http_health_check_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeHttpHealthCheck_basic(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HttpHealthCheck
 
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -36,6 +38,8 @@ func TestAccComputeHttpHealthCheck_basic(t *testing.T) {
 }
 
 func TestAccComputeHttpHealthCheck_update(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HttpHealthCheck
 
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/resource_compute_https_health_check_test.go
+++ b/google/resource_compute_https_health_check_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeHttpsHealthCheck_basic(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HttpsHealthCheck
 
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -36,6 +38,8 @@ func TestAccComputeHttpsHealthCheck_basic(t *testing.T) {
 }
 
 func TestAccComputeHttpsHealthCheck_update(t *testing.T) {
+	t.Parallel()
+
 	var healthCheck compute.HttpsHealthCheck
 
 	hhckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeImage_basic(t *testing.T) {
+	t.Parallel()
+
 	var image compute.Image
 
 	resource.Test(t, resource.TestCase{
@@ -35,6 +37,8 @@ func TestAccComputeImage_basic(t *testing.T) {
 }
 
 func TestAccComputeImage_update(t *testing.T) {
+	t.Parallel()
+
 	var image compute.Image
 
 	name := "image-test-" + acctest.RandString(10)
@@ -70,6 +74,8 @@ func TestAccComputeImage_update(t *testing.T) {
 }
 
 func TestAccComputeImage_basedondisk(t *testing.T) {
+	t.Parallel()
+
 	var image compute.Image
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccInstanceGroupManager_basic(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -43,6 +45,8 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -69,6 +73,8 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_update(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -113,6 +119,8 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	tag1 := "tag1"
@@ -145,6 +153,8 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updateStrategy(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -167,6 +177,8 @@ func TestAccInstanceGroupManager_updateStrategy(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -191,6 +203,8 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
+	t.Parallel()
+
 	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -220,6 +234,8 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 // Once auto_healing_policies is no longer beta, we will need to use a new field or resource
 // with Beta fields.
 func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
+	t.Parallel()
+
 	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))

--- a/google/resource_compute_instance_group_test.go
+++ b/google/resource_compute_instance_group_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeInstanceGroup_basic(t *testing.T) {
+	t.Parallel()
+
 	var instanceGroup compute.InstanceGroup
 	var instanceName = fmt.Sprintf("instancegroup-test-%s", acctest.RandString(10))
 
@@ -34,6 +36,8 @@ func TestAccComputeInstanceGroup_basic(t *testing.T) {
 }
 
 func TestAccComputeInstanceGroup_update(t *testing.T) {
+	t.Parallel()
+
 	var instanceGroup compute.InstanceGroup
 	var instanceName = fmt.Sprintf("instancegroup-test-%s", acctest.RandString(10))
 
@@ -71,6 +75,8 @@ func TestAccComputeInstanceGroup_update(t *testing.T) {
 }
 
 func TestAccComputeInstanceGroup_outOfOrderInstances(t *testing.T) {
+	t.Parallel()
+
 	var instanceGroup compute.InstanceGroup
 	var instanceName = fmt.Sprintf("instancegroup-test-%s", acctest.RandString(10))
 
@@ -91,6 +97,8 @@ func TestAccComputeInstanceGroup_outOfOrderInstances(t *testing.T) {
 }
 
 func TestAccComputeInstanceGroup_network(t *testing.T) {
+	t.Parallel()
+
 	var instanceGroup compute.InstanceGroup
 	var instanceName = fmt.Sprintf("instancegroup-test-%s", acctest.RandString(10))
 

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -99,6 +99,8 @@ func TestComputeInstanceMigrateState_empty(t *testing.T) {
 }
 
 func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -161,6 +163,8 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 }
 
 func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -222,6 +226,8 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 }
 
 func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -300,6 +306,8 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 }
 
 func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -377,6 +385,8 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 }
 
 func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -443,6 +453,8 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 }
 
 func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -508,6 +520,8 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 }
 
 func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -578,6 +592,8 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 }
 
 func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -647,6 +663,8 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 }
 
 func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}
@@ -709,6 +727,8 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 }
 
 func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
+	t.Parallel()
+
 	if os.Getenv(resource.TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf("Network access not allowed; use %s=1 to enable", resource.TestEnvVar))
 	}

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccComputeInstanceTemplate_basic(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -36,6 +38,8 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_preemptible(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -57,6 +61,8 @@ func TestAccComputeInstanceTemplate_preemptible(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_IP(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -77,6 +83,8 @@ func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_networkIP(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 	networkIP := "10.128.0.2"
 
@@ -100,6 +108,8 @@ func TestAccComputeInstanceTemplate_networkIP(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_disks(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -121,6 +131,8 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 	network := "network-" + acctest.RandString(10)
 
@@ -142,6 +154,8 @@ func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -162,6 +176,8 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
 
@@ -183,6 +199,8 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_metadata_startup_script(t *testing.T) {
+	t.Parallel()
+
 	var instanceTemplate compute.InstanceTemplate
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAccComputeInstance_basic1(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -42,6 +44,8 @@ func TestAccComputeInstance_basic1(t *testing.T) {
 }
 
 func TestAccComputeInstance_basic2(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -65,6 +69,8 @@ func TestAccComputeInstance_basic2(t *testing.T) {
 }
 
 func TestAccComputeInstance_basic3(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -88,6 +94,8 @@ func TestAccComputeInstance_basic3(t *testing.T) {
 }
 
 func TestAccComputeInstance_basic4(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -111,6 +119,8 @@ func TestAccComputeInstance_basic4(t *testing.T) {
 }
 
 func TestAccComputeInstance_basic5(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -134,6 +144,8 @@ func TestAccComputeInstance_basic5(t *testing.T) {
 }
 
 func TestAccComputeInstance_IP(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var ipName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
@@ -156,6 +168,8 @@ func TestAccComputeInstance_IP(t *testing.T) {
 }
 
 func TestAccComputeInstance_diskEncryption(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	bootEncryptionKey := "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
@@ -193,6 +207,8 @@ func TestAccComputeInstance_diskEncryption(t *testing.T) {
 }
 
 func TestAccComputeInstance_attachedDisk(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-testd-%s", acctest.RandString(10))
@@ -215,6 +231,8 @@ func TestAccComputeInstance_attachedDisk(t *testing.T) {
 }
 
 func TestAccComputeInstance_bootDisk_source(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
@@ -237,6 +255,8 @@ func TestAccComputeInstance_bootDisk_source(t *testing.T) {
 }
 
 func TestAccComputeInstance_bootDisk_type(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskType = "pd-ssd"
@@ -259,6 +279,8 @@ func TestAccComputeInstance_bootDisk_type(t *testing.T) {
 }
 
 func TestAccComputeInstance_noDisk(t *testing.T) {
+	t.Parallel()
+
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -275,6 +297,8 @@ func TestAccComputeInstance_noDisk(t *testing.T) {
 }
 
 func TestAccComputeInstance_scratchDisk(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -296,6 +320,8 @@ func TestAccComputeInstance_scratchDisk(t *testing.T) {
 }
 
 func TestAccComputeInstance_forceNewAndChangeMetadata(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -325,6 +351,8 @@ func TestAccComputeInstance_forceNewAndChangeMetadata(t *testing.T) {
 }
 
 func TestAccComputeInstance_update(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -357,6 +385,8 @@ func TestAccComputeInstance_update(t *testing.T) {
 }
 
 func TestAccComputeInstance_service_account(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -383,6 +413,8 @@ func TestAccComputeInstance_service_account(t *testing.T) {
 }
 
 func TestAccComputeInstance_scheduling(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -403,6 +435,8 @@ func TestAccComputeInstance_scheduling(t *testing.T) {
 }
 
 func TestAccComputeInstance_subnet_auto(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -424,6 +458,8 @@ func TestAccComputeInstance_subnet_auto(t *testing.T) {
 }
 
 func TestAccComputeInstance_subnet_custom(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -445,6 +481,8 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstance_subnet_xpn(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
@@ -467,6 +505,8 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 }
 
 func TestAccComputeInstance_address_auto(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -488,6 +528,8 @@ func TestAccComputeInstance_address_auto(t *testing.T) {
 }
 
 func TestAccComputeInstance_address_custom(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var address = "10.0.200.200"
@@ -509,6 +551,8 @@ func TestAccComputeInstance_address_custom(t *testing.T) {
 }
 
 func TestAccComputeInstance_private_image_family(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var diskName = fmt.Sprintf("instance-testd-%s", acctest.RandString(10))
@@ -532,6 +576,8 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 }
 
 func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 
@@ -553,6 +599,8 @@ func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
 }
 
 func TestAccComputeInstance_multiNic(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 	networkName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
@@ -575,6 +623,8 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 }
 
 func TestAccComputeInstance_guestAccelerator(t *testing.T) {
+	t.Parallel()
+
 	var instance computeBeta.Instance
 	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 
@@ -596,6 +646,8 @@ func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 }
 
 func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
+	t.Parallel()
+
 	var instance computeBeta.Instance
 	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 
@@ -616,6 +668,8 @@ func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
 }
 
 func TestAccComputeInstance_primaryAliasIpRange(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 
@@ -636,6 +690,8 @@ func TestAccComputeInstance_primaryAliasIpRange(t *testing.T) {
 }
 
 func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
+	t.Parallel()
+
 	var instance compute.Instance
 	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 

--- a/google/resource_compute_network_peering_test.go
+++ b/google/resource_compute_network_peering_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeNetworkPeering_basic(t *testing.T) {
+	t.Parallel()
+
 	var peering compute.NetworkPeering
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_network_test.go
+++ b/google/resource_compute_network_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeNetwork_basic(t *testing.T) {
+	t.Parallel()
+
 	var network compute.Network
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +32,8 @@ func TestAccComputeNetwork_basic(t *testing.T) {
 }
 
 func TestAccComputeNetwork_auto_subnet(t *testing.T) {
+	t.Parallel()
+
 	var network compute.Network
 
 	resource.Test(t, resource.TestCase{
@@ -51,6 +55,8 @@ func TestAccComputeNetwork_auto_subnet(t *testing.T) {
 }
 
 func TestAccComputeNetwork_custom_subnet(t *testing.T) {
+	t.Parallel()
+
 	var network compute.Network
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_project_metadata_item_test.go
+++ b/google/resource_compute_project_metadata_item_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func TestAccComputeProjectMetadataItem_basic(t *testing.T) {
+	t.Parallel(
 	// Key must be unique to avoid concurrent tests interfering with each other
+	)
+
 	key := "myKey" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -29,7 +32,10 @@ func TestAccComputeProjectMetadataItem_basic(t *testing.T) {
 }
 
 func TestAccComputeProjectMetadataItem_basicMultiple(t *testing.T) {
+	t.Parallel(
 	// Generate a config of two config keys
+	)
+
 	config := testAccProjectMetadataItem_basic("myKey", "myValue") +
 		testAccProjectMetadataItem_basic("myOtherKey", "myOtherValue")
 	resource.Test(t, resource.TestCase{
@@ -49,7 +55,10 @@ func TestAccComputeProjectMetadataItem_basicMultiple(t *testing.T) {
 }
 
 func TestAccComputeProjectMetadataItem_basicWithEmptyVal(t *testing.T) {
+	t.Parallel(
 	// Key must be unique to avoid concurrent tests interfering with each other
+	)
+
 	key := "myKey" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -68,7 +77,10 @@ func TestAccComputeProjectMetadataItem_basicWithEmptyVal(t *testing.T) {
 }
 
 func TestAccComputeProjectMetadataItem_basicUpdate(t *testing.T) {
+	t.Parallel(
 	// Key must be unique to avoid concurrent tests interfering with each other
+	)
+
 	key := "myKey" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_project_metadata_test.go
+++ b/google/resource_compute_project_metadata_test.go
@@ -13,6 +13,8 @@ import (
 
 // Add two key value pairs
 func TestAccComputeProjectMetadata_basic(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -45,6 +47,8 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 
 // Add three key value pairs, then replace one and modify a second
 func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -90,6 +94,8 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 
 // Add two key value pairs, and replace both
 func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeRegionBackendService_basic(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	extraCheckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -41,6 +43,8 @@ func TestAccComputeRegionBackendService_basic(t *testing.T) {
 }
 
 func TestAccComputeRegionBackendService_withBackend(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -74,6 +78,8 @@ func TestAccComputeRegionBackendService_withBackend(t *testing.T) {
 }
 
 func TestAccComputeRegionBackendService_withBackendAndUpdate(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -115,6 +121,8 @@ func TestAccComputeRegionBackendService_withBackendAndUpdate(t *testing.T) {
 }
 
 func TestAccComputeRegionBackendService_withConnectionDraining(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -140,6 +148,8 @@ func TestAccComputeRegionBackendService_withConnectionDraining(t *testing.T) {
 }
 
 func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService
@@ -172,6 +182,8 @@ func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testi
 }
 
 func TestAccComputeRegionBackendService_withSessionAffinity(t *testing.T) {
+	t.Parallel()
+
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var svc compute.BackendService

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -43,6 +45,8 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -69,6 +73,8 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_update(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -112,6 +118,8 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	tag1 := "tag1"
@@ -144,6 +152,8 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
+	t.Parallel()
+
 	var manager compute.InstanceGroupManager
 
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -168,6 +178,8 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
+	t.Parallel()
+
 	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeRoute_basic(t *testing.T) {
+	t.Parallel()
+
 	var route compute.Route
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +32,8 @@ func TestAccComputeRoute_basic(t *testing.T) {
 }
 
 func TestAccComputeRoute_defaultInternetGateway(t *testing.T) {
+	t.Parallel()
+
 	var route compute.Route
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_router_interface_test.go
+++ b/google/resource_compute_router_interface_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeRouterInterface_basic(t *testing.T) {
+	t.Parallel()
+
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_compute_router_peer_test.go
+++ b/google/resource_compute_router_peer_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeRouterPeer_basic(t *testing.T) {
+	t.Parallel()
+
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_compute_router_test.go
+++ b/google/resource_compute_router_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeRouter_basic(t *testing.T) {
+	t.Parallel()
+
 	resourceRegion := "europe-west1"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,6 +32,8 @@ func TestAccComputeRouter_basic(t *testing.T) {
 }
 
 func TestAccComputeRouter_noRegion(t *testing.T) {
+	t.Parallel()
+
 	providerRegion := "us-central1"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,6 +54,8 @@ func TestAccComputeRouter_noRegion(t *testing.T) {
 }
 
 func TestAccComputeRouter_networkLink(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/resource_compute_snapshot_test.go
+++ b/google/resource_compute_snapshot_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeSnapshot_basic(t *testing.T) {
+	t.Parallel()
+
 	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var snapshot compute.Snapshot
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -33,6 +35,8 @@ func TestAccComputeSnapshot_basic(t *testing.T) {
 }
 
 func TestAccComputeSnapshot_encryption(t *testing.T) {
+	t.Parallel()
+
 	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	var snapshot compute.Snapshot

--- a/google/resource_compute_ssl_certificate_test.go
+++ b/google/resource_compute_ssl_certificate_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeSslCertificate_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -27,6 +29,8 @@ func TestAccComputeSslCertificate_basic(t *testing.T) {
 }
 
 func TestAccComputeSslCertificate_no_name(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -44,6 +48,8 @@ func TestAccComputeSslCertificate_no_name(t *testing.T) {
 }
 
 func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/resource_compute_subnetwork_test.go
+++ b/google/resource_compute_subnetwork_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccComputeSubnetwork_basic(t *testing.T) {
+	t.Parallel()
+
 	var subnetwork1 compute.Subnetwork
 	var subnetwork2 compute.Subnetwork
 
@@ -38,6 +40,8 @@ func TestAccComputeSubnetwork_basic(t *testing.T) {
 }
 
 func TestAccComputeSubnetwork_update(t *testing.T) {
+	t.Parallel()
+
 	var subnetwork compute.Subnetwork
 
 	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -71,6 +75,8 @@ func TestAccComputeSubnetwork_update(t *testing.T) {
 }
 
 func TestAccComputeSubnetwork_secondaryIpRanges(t *testing.T) {
+	t.Parallel()
+
 	var subnetwork compute.Subnetwork
 
 	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/resource_compute_target_http_proxy_test.go
+++ b/google/resource_compute_target_http_proxy_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeTargetHttpProxy_basic(t *testing.T) {
+	t.Parallel()
+
 	target := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
 	backend := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
@@ -33,6 +35,8 @@ func TestAccComputeTargetHttpProxy_basic(t *testing.T) {
 }
 
 func TestAccComputeTargetHttpProxy_update(t *testing.T) {
+	t.Parallel()
+
 	target := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
 	backend := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))

--- a/google/resource_compute_target_https_proxy_test.go
+++ b/google/resource_compute_target_https_proxy_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeTargetHttpsProxy_basic(t *testing.T) {
+	t.Parallel()
+
 	var proxy compute.TargetHttpsProxy
 	resourceSuffix := acctest.RandString(10)
 
@@ -34,6 +36,8 @@ func TestAccComputeTargetHttpsProxy_basic(t *testing.T) {
 }
 
 func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
+	t.Parallel()
+
 	var proxy compute.TargetHttpsProxy
 	resourceSuffix := acctest.RandString(10)
 
@@ -67,6 +71,8 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 }
 
 func TestAccComputeTargetHttpsProxy_invalidCertificate(t *testing.T) {
+	t.Parallel()
+
 	resourceSuffix := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccComputeTargetPool_basic(t *testing.T) {
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_compute_target_tcp_proxy_test.go
+++ b/google/resource_compute_target_tcp_proxy_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeTargetTcpProxy_basic(t *testing.T) {
+	t.Parallel()
+
 	target := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	backend := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
@@ -31,6 +33,8 @@ func TestAccComputeTargetTcpProxy_basic(t *testing.T) {
 }
 
 func TestAccComputeTargetTcpProxy_update(t *testing.T) {
+	t.Parallel()
+
 	target := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	backend := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("ttcp-test-%s", acctest.RandString(10))

--- a/google/resource_compute_url_map_test.go
+++ b/google/resource_compute_url_map_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccComputeUrlMap_basic(t *testing.T) {
+	t.Parallel()
+
 	bsName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	hcName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	umName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
@@ -30,6 +32,8 @@ func TestAccComputeUrlMap_basic(t *testing.T) {
 }
 
 func TestAccComputeUrlMap_update_path_matcher(t *testing.T) {
+	t.Parallel()
+
 	bsName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	hcName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	umName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
@@ -58,6 +62,8 @@ func TestAccComputeUrlMap_update_path_matcher(t *testing.T) {
 }
 
 func TestAccComputeUrlMap_advanced(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -83,6 +89,8 @@ func TestAccComputeUrlMap_advanced(t *testing.T) {
 }
 
 func TestAccComputeUrlMap_noPathRulesWithUpdate(t *testing.T) {
+	t.Parallel()
+
 	bsName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	hcName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))
 	umName := fmt.Sprintf("urlmap-test-%s", acctest.RandString(10))

--- a/google/resource_compute_vpn_gateway_test.go
+++ b/google/resource_compute_vpn_gateway_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeVpnGateway_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/resource_compute_vpn_tunnel_test.go
+++ b/google/resource_compute_vpn_tunnel_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccComputeVpnTunnel_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -33,6 +35,8 @@ func TestAccComputeVpnTunnel_basic(t *testing.T) {
 }
 
 func TestAccComputeVpnTunnel_router(t *testing.T) {
+	t.Parallel()
+
 	router := fmt.Sprintf("tunnel-test-router-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,6 +57,7 @@ func TestAccComputeVpnTunnel_router(t *testing.T) {
 }
 
 func TestAccComputeVpnTunnel_defaultTrafficSelectors(t *testing.T) {
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccContainerCluster_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -34,6 +36,8 @@ func TestAccContainerCluster_basic(t *testing.T) {
 }
 
 func TestAccContainerCluster_withTimeout(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -51,6 +55,8 @@ func TestAccContainerCluster_withTimeout(t *testing.T) {
 }
 
 func TestAccContainerCluster_withAddons(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -67,6 +73,8 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 	})
 }
 func TestAccContainerCluster_withMasterAuth(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -84,6 +92,8 @@ func TestAccContainerCluster_withMasterAuth(t *testing.T) {
 }
 
 func TestAccContainerCluster_withAdditionalZones(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -110,6 +120,8 @@ func TestAccContainerCluster_withAdditionalZones(t *testing.T) {
 }
 
 func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -138,6 +150,8 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 }
 
 func TestAccContainerCluster_withVersion(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -157,6 +171,8 @@ func TestAccContainerCluster_withVersion(t *testing.T) {
 }
 
 func TestAccContainerCluster_updateVersion(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -183,6 +199,8 @@ func TestAccContainerCluster_updateVersion(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodeConfig(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -200,6 +218,8 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodeConfigScopeAlias(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -217,6 +237,8 @@ func TestAccContainerCluster_withNodeConfigScopeAlias(t *testing.T) {
 }
 
 func TestAccContainerCluster_network(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -236,6 +258,8 @@ func TestAccContainerCluster_network(t *testing.T) {
 }
 
 func TestAccContainerCluster_backend(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -253,6 +277,8 @@ func TestAccContainerCluster_backend(t *testing.T) {
 }
 
 func TestAccContainerCluster_withLogging(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -281,6 +307,8 @@ func TestAccContainerCluster_withLogging(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolBasic(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 	npName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 
@@ -301,6 +329,8 @@ func TestAccContainerCluster_withNodePoolBasic(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolResize(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 	npName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
@@ -329,6 +359,8 @@ func TestAccContainerCluster_withNodePoolResize(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
+	t.Parallel()
+
 	clusterName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 	npName := fmt.Sprintf("tf-cluster-nodepool-test-%s", acctest.RandString(10))
 
@@ -366,6 +398,8 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -383,6 +417,8 @@ func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolMultiple(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -400,6 +436,8 @@ func TestAccContainerCluster_withNodePoolMultiple(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolConflictingNameFields(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -414,6 +452,8 @@ func TestAccContainerCluster_withNodePoolConflictingNameFields(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolNodeConfig(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccContainerNodePool_basic(t *testing.T) {
+	t.Parallel()
+
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 
@@ -33,6 +35,8 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 }
 
 func TestAccContainerNodePool_namePrefix(t *testing.T) {
+	t.Parallel()
+
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -51,6 +55,8 @@ func TestAccContainerNodePool_namePrefix(t *testing.T) {
 }
 
 func TestAccContainerNodePool_noName(t *testing.T) {
+	t.Parallel()
+
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -69,6 +75,8 @@ func TestAccContainerNodePool_noName(t *testing.T) {
 }
 
 func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -85,6 +93,8 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 }
 
 func TestAccContainerNodePool_withNodeConfigScopeAlias(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -101,6 +111,8 @@ func TestAccContainerNodePool_withNodeConfigScopeAlias(t *testing.T) {
 }
 
 func TestAccContainerNodePool_autoscaling(t *testing.T) {
+	t.Parallel()
+
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 
@@ -138,6 +150,8 @@ func TestAccContainerNodePool_autoscaling(t *testing.T) {
 }
 
 func TestAccContainerNodePool_resize(t *testing.T) {
+	t.Parallel()
+
 	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
 

--- a/google/resource_dns_managed_zone_test.go
+++ b/google/resource_dns_managed_zone_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccDnsManagedZone_basic(t *testing.T) {
+	t.Parallel()
+
 	var zone dns.ManagedZone
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_dns_record_set_test.go
+++ b/google/resource_dns_record_set_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccDnsRecordSet_basic(t *testing.T) {
+	t.Parallel()
+
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -28,6 +30,8 @@ func TestAccDnsRecordSet_basic(t *testing.T) {
 }
 
 func TestAccDnsRecordSet_modify(t *testing.T) {
+	t.Parallel()
+
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,6 +64,8 @@ func TestAccDnsRecordSet_modify(t *testing.T) {
 }
 
 func TestAccDnsRecordSet_changeType(t *testing.T) {
+	t.Parallel()
+
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
@@ -44,6 +46,8 @@ func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
 }
 
 func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)

--- a/google/resource_google_folder_test.go
+++ b/google/resource_google_folder_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccGoogleFolder_rename(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
@@ -45,6 +47,8 @@ func TestAccGoogleFolder_rename(t *testing.T) {
 }
 
 func TestAccGoogleFolder_moveParent(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	folder1DisplayName := "tf-test-" + acctest.RandString(10)

--- a/google/resource_google_organization_policy_test.go
+++ b/google/resource_google_organization_policy_test.go
@@ -16,6 +16,8 @@ var DENIED_ORG_POLICIES = []string{
 }
 
 func TestAccGoogleOrganizationPolicy_boolean_enforced(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 
@@ -34,6 +36,8 @@ func TestAccGoogleOrganizationPolicy_boolean_enforced(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_boolean_notEnforced(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 
@@ -51,6 +55,8 @@ func TestAccGoogleOrganizationPolicy_boolean_notEnforced(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_boolean_update(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 
@@ -76,6 +82,8 @@ func TestAccGoogleOrganizationPolicy_boolean_update(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 
@@ -93,6 +101,8 @@ func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 	project := getTestProjectFromEnv()
@@ -111,6 +121,8 @@ func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 
@@ -128,6 +140,8 @@ func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
 }
 
 func TestAccGoogleOrganizationPolicy_list_update(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 	org := os.Getenv("GOOGLE_ORG")
 

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -13,6 +13,8 @@ import (
 
 // Test that an IAM binding can be applied to a project
 func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -41,6 +43,8 @@ func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project, one at a time
 func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -83,6 +87,8 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project all at once
 func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -115,6 +121,8 @@ func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 
 // Test that an IAM binding can be updated once applied to a project
 func TestAccGoogleProjectIamBinding_update(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -163,6 +171,8 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -11,6 +11,8 @@ import (
 
 // Test that an IAM binding can be applied to a project
 func TestAccGoogleProjectIamMember_basic(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -39,6 +41,8 @@ func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project
 func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -77,6 +81,8 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccGoogleProjectIamMember_remove(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_iam_policy_test.go
+++ b/google/resource_google_project_iam_policy_test.go
@@ -222,6 +222,8 @@ func TestSubtractIamPolicy(t *testing.T) {
 
 // Test that an IAM policy can be applied to a project
 func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -256,6 +258,8 @@ func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 
 // Test that a non-collapsed IAM policy doesn't perpetually diff
 func TestAccGoogleProjectIamPolicy_expanded(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_services_test.go
+++ b/google/resource_google_project_services_test.go
@@ -17,6 +17,8 @@ import (
 
 // Test that services can be enabled and disabled on a project
 func TestAccGoogleProjectServices_basic(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	services1 := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services2 := []string{"cloudresourcemanager.googleapis.com"}
@@ -57,6 +59,8 @@ func TestAccGoogleProjectServices_basic(t *testing.T) {
 // Test that services are authoritative when a project has existing
 // sevices not represented in config
 func TestAccGoogleProjectServices_authoritative(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{"cloudresourcemanager.googleapis.com"}
 	oobService := "iam.googleapis.com"
@@ -91,6 +95,8 @@ func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 // sevices, some which are represented in the config and others
 // that are not
 func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	oobServices := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services := []string{"iam.googleapis.com"}
@@ -128,6 +134,8 @@ func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 // don't end up causing diffs when they are enabled as a side-effect of a different service's
 // enablement.
 func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -167,6 +175,8 @@ func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
 }
 
 func TestAccGoogleProjectServices_manyServices(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -26,6 +26,8 @@ var (
 
 // Test that a Project resource can be created without an organization
 func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
+	t.Parallel()
+
 	creds := multiEnvSearch(credsEnvVars)
 	if strings.Contains(creds, "iam.gserviceaccount.com") {
 		t.Skip("Service accounts cannot create projects without a parent. Requires user credentials.")
@@ -50,6 +52,8 @@ func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
 // Test that a Project resource can be created and an IAM policy
 // associated
 func TestAccGoogleProject_create(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -75,6 +79,8 @@ func TestAccGoogleProject_create(t *testing.T) {
 // Test that a Project resource can be created with an associated
 // billing account
 func TestAccGoogleProject_createBilling(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -101,6 +107,8 @@ func TestAccGoogleProject_createBilling(t *testing.T) {
 
 // Test that a Project resource can be created with labels
 func TestAccGoogleProject_createLabels(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -119,6 +127,8 @@ func TestAccGoogleProject_createLabels(t *testing.T) {
 // Test that a Project resource can be created and updated
 // with billing account information
 func TestAccGoogleProject_updateBilling(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t,
 		[]string{
 			"GOOGLE_ORG",
@@ -169,6 +179,8 @@ func TestAccGoogleProject_updateBilling(t *testing.T) {
 // Test that a Project resource merges the IAM policies that already
 // exist, and won't lock people out.
 func TestAccGoogleProject_merge(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -196,6 +208,8 @@ func TestAccGoogleProject_merge(t *testing.T) {
 
 // Test that a Project resource can be updated with labels
 func TestAccGoogleProject_updateLabels(t *testing.T) {
+	t.Parallel()
+
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_service_account_test.go
+++ b/google/resource_google_service_account_test.go
@@ -11,6 +11,8 @@ import (
 
 // Test that a service account resource can be created, updated, and destroyed
 func TestAccGoogleServiceAccount_basic(t *testing.T) {
+	t.Parallel()
+
 	accountId := "a" + acctest.RandString(10)
 	displayName := "Terraform Test"
 	displayName2 := "Terraform Test Update"
@@ -39,6 +41,8 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 // Test that a service account resource can be created with a policy, updated,
 // and destroyed.
 func TestAccGoogleServiceAccount_createPolicy(t *testing.T) {
+	t.Parallel()
+
 	accountId := "a" + acctest.RandString(10)
 	displayName := "Terraform Test"
 	resource.Test(t, resource.TestCase{

--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT")
 
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
@@ -37,6 +39,8 @@ func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
 }
 
 func TestAccLoggingBillingAccountSink_update(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT")
 
 	sinkName := "tf-test-sink-" + acctest.RandString(10)

--- a/google/resource_logging_folder_sink_test.go
+++ b/google/resource_logging_folder_sink_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccLoggingFolderSink_basic(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
@@ -39,6 +41,8 @@ func TestAccLoggingFolderSink_basic(t *testing.T) {
 }
 
 func TestAccLoggingFolderSink_folderAcceptsFullFolderPath(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
@@ -65,6 +69,8 @@ func TestAccLoggingFolderSink_folderAcceptsFullFolderPath(t *testing.T) {
 }
 
 func TestAccLoggingFolderSink_update(t *testing.T) {
+	t.Parallel()
+
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
 	sinkName := "tf-test-sink-" + acctest.RandString(10)

--- a/google/resource_logging_project_sink_test.go
+++ b/google/resource_logging_project_sink_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccLoggingProjectSink_basic(t *testing.T) {
+	t.Parallel()
+
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 
@@ -33,6 +35,8 @@ func TestAccLoggingProjectSink_basic(t *testing.T) {
 }
 
 func TestAccLoggingProjectSink_uniqueWriter(t *testing.T) {
+	t.Parallel()
+
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 
@@ -55,6 +59,8 @@ func TestAccLoggingProjectSink_uniqueWriter(t *testing.T) {
 }
 
 func TestAccLoggingProjectSink_updatePreservesUniqueWriter(t *testing.T) {
+	t.Parallel()
+
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	updatedBucketName := "tf-test-sink-bucket-" + acctest.RandString(10)

--- a/google/resource_pubsub_subscription_test.go
+++ b/google/resource_pubsub_subscription_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccPubsubSubscription_basic(t *testing.T) {
+	t.Parallel()
+
 	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
 	subscription := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(10))
 

--- a/google/resource_pubsub_topic_test.go
+++ b/google/resource_pubsub_topic_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccPubsubTopicCreate(t *testing.T) {
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_runtimeconfig_config_test.go
+++ b/google/resource_runtimeconfig_config_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccRuntimeconfigConfig_basic(t *testing.T) {
+	t.Parallel()
+
 	var runtimeConfig runtimeconfig.RuntimeConfig
 	configName := fmt.Sprintf("runtimeconfig-test-%s", acctest.RandString(10))
 	description := "my test description"
@@ -33,6 +35,8 @@ func TestAccRuntimeconfigConfig_basic(t *testing.T) {
 }
 
 func TestAccRuntimeconfig_update(t *testing.T) {
+	t.Parallel()
+
 	var runtimeConfig runtimeconfig.RuntimeConfig
 	configName := fmt.Sprintf("runtimeconfig-test-%s", acctest.RandString(10))
 	firstDescription := "my test description"
@@ -63,6 +67,8 @@ func TestAccRuntimeconfig_update(t *testing.T) {
 }
 
 func TestAccRuntimeconfig_updateEmptyDescription(t *testing.T) {
+	t.Parallel()
+
 	var runtimeConfig runtimeconfig.RuntimeConfig
 	configName := fmt.Sprintf("runtimeconfig-test-%s", acctest.RandString(10))
 	description := "my test description"

--- a/google/resource_runtimeconfig_variable_test.go
+++ b/google/resource_runtimeconfig_variable_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccRuntimeconfigVariable_basic(t *testing.T) {
+	t.Parallel()
+
 	var variable runtimeconfig.Variable
 
 	varName := fmt.Sprintf("variable-test-%s", acctest.RandString(10))
@@ -37,6 +39,8 @@ func TestAccRuntimeconfigVariable_basic(t *testing.T) {
 }
 
 func TestAccRuntimeconfigVariable_basicUpdate(t *testing.T) {
+	t.Parallel()
+
 	var variable runtimeconfig.Variable
 
 	configName := fmt.Sprintf("some-name-%s", acctest.RandString(10))
@@ -69,6 +73,8 @@ func TestAccRuntimeconfigVariable_basicUpdate(t *testing.T) {
 }
 
 func TestAccRuntimeconfigVariable_basicValue(t *testing.T) {
+	t.Parallel()
+
 	var variable runtimeconfig.Variable
 
 	varName := fmt.Sprintf("variable-test-%s", acctest.RandString(10))
@@ -93,6 +99,8 @@ func TestAccRuntimeconfigVariable_basicValue(t *testing.T) {
 }
 
 func TestAccRuntimeconfigVariable_errorsOnBothValueAndText(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -106,6 +114,8 @@ func TestAccRuntimeconfigVariable_errorsOnBothValueAndText(t *testing.T) {
 }
 
 func TestAccRuntimeconfigVariable_errorsOnMissingValueAndText(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/google/resource_source_repos_repository_test.go
+++ b/google/resource_source_repos_repository_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccSourceRepoRepository_basic(t *testing.T) {
+	t.Parallel()
+
 	repositoryName := fmt.Sprintf("source-repo-repository-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_spanner_database_test.go
+++ b/google/resource_spanner_database_test.go
@@ -85,6 +85,8 @@ func expectInvalidSpannerDbImportId(t *testing.T, id *spannerDatabaseId, e error
 // Acceptance Tests
 
 func TestAccSpannerDatabase_basic(t *testing.T) {
+	t.Parallel()
+
 	var db spanner.Database
 	rnd := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -108,6 +110,8 @@ func TestAccSpannerDatabase_basic(t *testing.T) {
 }
 
 func TestAccSpannerDatabase_basicWithInitialDDL(t *testing.T) {
+	t.Parallel()
+
 	var db spanner.Database
 	rnd := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -128,6 +132,8 @@ func TestAccSpannerDatabase_basicWithInitialDDL(t *testing.T) {
 }
 
 func TestAccSpannerDatabase_duplicateNameError(t *testing.T) {
+	t.Parallel()
+
 	var db spanner.Database
 	rnd := acctest.RandString(10)
 	dbName := fmt.Sprintf("spanner-test-%s", rnd)

--- a/google/resource_spanner_instance_test.go
+++ b/google/resource_spanner_instance_test.go
@@ -139,6 +139,8 @@ func expectEquals(t *testing.T, expected, actual string) {
 // Acceptance Tests
 
 func TestAccSpannerInstance_basic(t *testing.T) {
+	t.Parallel()
+
 	var instance spanner.Instance
 	rnd := acctest.RandString(10)
 	idName := fmt.Sprintf("spanner-test-%s", rnd)
@@ -163,6 +165,8 @@ func TestAccSpannerInstance_basic(t *testing.T) {
 }
 
 func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
+	t.Parallel()
+
 	var instance spanner.Instance
 	rnd := acctest.RandString(10)
 	displayName := fmt.Sprintf("spanner-test-%s-dname", rnd)
@@ -185,6 +189,8 @@ func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
 }
 
 func TestAccSpannerInstance_duplicateNameError(t *testing.T) {
+	t.Parallel()
+
 	var instance spanner.Instance
 	rnd := acctest.RandString(10)
 	idName := fmt.Sprintf("spanner-test-%s", rnd)
@@ -209,6 +215,8 @@ func TestAccSpannerInstance_duplicateNameError(t *testing.T) {
 }
 
 func TestAccSpannerInstance_update(t *testing.T) {
+	t.Parallel()
+
 	var instance spanner.Instance
 	rnd := acctest.RandString(10)
 	dName1 := fmt.Sprintf("spanner-dname1-%s", rnd)

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -121,6 +121,8 @@ func testSweepDatabases(region string) error {
 }
 
 func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
 
@@ -144,6 +146,8 @@ func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 
 	resource.Test(t, resource.TestCase{
@@ -165,6 +169,8 @@ func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_basic3(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
 
@@ -190,6 +196,8 @@ func TestAccGoogleSqlDatabaseInstance_basic3(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseName := "sql-instance-test-" + acctest.RandString(10)
 	failoverName := "sql-instance-test-failover-" + acctest.RandString(10)
@@ -237,6 +245,8 @@ func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.
 }
 
 func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
 
@@ -260,6 +270,8 @@ func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	masterID := acctest.RandInt()
 	slaveID := acctest.RandInt()
@@ -288,6 +300,8 @@ func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	masterID := acctest.RandInt()
 
@@ -311,6 +325,8 @@ func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_maintenance(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	masterID := acctest.RandInt()
 
@@ -334,6 +350,8 @@ func TestAccGoogleSqlDatabaseInstance_maintenance(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
 
@@ -367,6 +385,8 @@ func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabaseInstance_settings_downgrade(t *testing.T) {
+	t.Parallel()
+
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
 
@@ -401,7 +421,10 @@ func TestAccGoogleSqlDatabaseInstance_settings_downgrade(t *testing.T) {
 
 // GH-4222
 func TestAccGoogleSqlDatabaseInstance_authNets(t *testing.T) {
+	t.Parallel(
 	// var instance sqladmin.DatabaseInstance
+	)
+
 	databaseID := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -428,6 +451,8 @@ func TestAccGoogleSqlDatabaseInstance_authNets(t *testing.T) {
 // Tests that a SQL instance can be referenced from more than one other resource without
 // throwing an error during provisioning, see #9018.
 func TestAccGoogleSqlDatabaseInstance_multipleOperations(t *testing.T) {
+	t.Parallel()
+
 	databaseID, instanceID, userID := acctest.RandString(8), acctest.RandString(8), acctest.RandString(8)
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_sql_database_test.go
+++ b/google/resource_sql_database_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccGoogleSqlDatabase_basic(t *testing.T) {
+	t.Parallel()
+
 	var database sqladmin.Database
 
 	resource.Test(t, resource.TestCase{
@@ -34,6 +36,8 @@ func TestAccGoogleSqlDatabase_basic(t *testing.T) {
 }
 
 func TestAccGoogleSqlDatabase_update(t *testing.T) {
+	t.Parallel()
+
 	var database sqladmin.Database
 
 	instance_name := acctest.RandString(10)

--- a/google/resource_sql_user_test.go
+++ b/google/resource_sql_user_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccGoogleSqlUser_basic(t *testing.T) {
+	t.Parallel()
+
 	user := acctest.RandString(10)
 	instance := acctest.RandString(10)
 
@@ -29,6 +31,8 @@ func TestAccGoogleSqlUser_basic(t *testing.T) {
 }
 
 func TestAccGoogleSqlUser_update(t *testing.T) {
+	t.Parallel()
+
 	user := acctest.RandString(10)
 	instance := acctest.RandString(10)
 

--- a/google/resource_storage_bucket_acl_test.go
+++ b/google/resource_storage_bucket_acl_test.go
@@ -26,6 +26,8 @@ func testBucketName() string {
 }
 
 func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	skipIfEnvNotSet(t, "GOOGLE_PROJECT_NUMBER")
 	resource.Test(t, resource.TestCase{
@@ -45,6 +47,8 @@ func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	skipIfEnvNotSet(t, "GOOGLE_PROJECT_NUMBER")
 	resource.Test(t, resource.TestCase{
@@ -81,6 +85,8 @@ func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	skipIfEnvNotSet(t, "GOOGLE_PROJECT_NUMBER")
 	resource.Test(t, resource.TestCase{
@@ -117,6 +123,8 @@ func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageBucketAcl_predefined(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -19,6 +19,8 @@ var objectName = "tf-gce-test"
 var content = "now this is content!"
 
 func TestAccGoogleStorageObject_basic(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	data := []byte("data data data")
 	h := md5.New()
@@ -45,6 +47,8 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_content(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
@@ -77,6 +81,8 @@ func TestAccGoogleStorageObject_content(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
@@ -115,6 +121,8 @@ func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
@@ -146,6 +154,8 @@ func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
 }
 
 func TestAccGoogleStorageObject_storageClass(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAccStorageBucket_basic(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -39,6 +41,8 @@ func TestAccStorageBucket_basic(t *testing.T) {
 }
 
 func TestAccStorageBucket_lowercaseLocation(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -59,6 +63,8 @@ func TestAccStorageBucket_lowercaseLocation(t *testing.T) {
 }
 
 func TestAccStorageBucket_customAttributes(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -83,6 +89,8 @@ func TestAccStorageBucket_customAttributes(t *testing.T) {
 }
 
 func TestAccStorageBucket_lifecycleRules(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acc-bucket-%d", acctest.RandInt())
 
@@ -129,6 +137,8 @@ func TestAccStorageBucket_lifecycleRules(t *testing.T) {
 }
 
 func TestAccStorageBucket_storageClass(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acc-bucket-%d", acctest.RandInt())
 
@@ -171,6 +181,8 @@ func TestAccStorageBucket_storageClass(t *testing.T) {
 }
 
 func TestAccStorageBucket_update(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -286,6 +298,8 @@ func TestAccStorageBucket_update(t *testing.T) {
 }
 
 func TestAccStorageBucket_forceDestroy(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -318,6 +332,8 @@ func TestAccStorageBucket_forceDestroy(t *testing.T) {
 }
 
 func TestAccStorageBucket_versioning(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
@@ -342,6 +358,8 @@ func TestAccStorageBucket_versioning(t *testing.T) {
 }
 
 func TestAccStorageBucket_cors(t *testing.T) {
+	t.Parallel()
+
 	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 

--- a/google/resource_storage_object_acl_test.go
+++ b/google/resource_storage_object_acl_test.go
@@ -20,6 +20,8 @@ func testAclObjectName() string {
 }
 
 func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
@@ -48,6 +50,8 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
@@ -98,6 +102,8 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
@@ -148,6 +154,8 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 }
 
 func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
+	t.Parallel()
+
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")


### PR DESCRIPTION
This allows all acceptance tests to run concurrently.

I added a `t.Parallel()` call to any test that begins with 'TestAcc'. I also have a tool that does this but it's pretty hacked together at the moment; likely a better solution would be some sort of check that warns if an acceptance test does not run in parallel mode.