### PR TITLE
d/dns_managed_zone: Error out if zone is not found

### DIFF
--- a/google/data_source_dns_managed_zone.go
+++ b/google/data_source_dns_managed_zone.go
@@ -41,7 +41,25 @@ func dataSourceDnsManagedZone() *schema.Resource {
 }
 
 func dataSourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
 	d.SetId(d.Get("name").(string))
 
-	return resourceDnsManagedZoneRead(d, meta)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	zone, err := config.clientDns.ManagedZones.Get(
+		project, d.Id()).Do()
+	if err != nil {
+		return err
+	}
+
+	d.Set("name_servers", zone.NameServers)
+	d.Set("name", zone.Name)
+	d.Set("dns_name", zone.DnsName)
+	d.Set("description", zone.Description)
+
+	return nil
 }

--- a/google/data_source_dns_managed_zone_test.go
+++ b/google/data_source_dns_managed_zone_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDataSourceDnsManagedZone_basic,
-				Check:  testAccDataSourceDnsManagedZoneCheck("qa", "foo"),
+				Check:  testAccDataSourceDnsManagedZoneCheck("data.google_dns_managed_zone.qa", "google_dns_managed_zone.foo"),
 			},
 		},
 	})
@@ -24,16 +24,14 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 
 func testAccDataSourceDnsManagedZoneCheck(dsName, rsName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		dsFullName := "data.google_dns_managed_zone." + dsName
-		rsFullName := "google_dns_managed_zone." + rsName
-		ds, ok := s.RootModule().Resources[dsFullName]
+		ds, ok := s.RootModule().Resources[rsName]
 		if !ok {
-			return fmt.Errorf("cant' find resource called %s in state", dsFullName)
+			return fmt.Errorf("can't find resource called %s in state", rsName)
 		}
 
-		rs, ok := s.RootModule().Resources[rsFullName]
+		rs, ok := s.RootModule().Resources[dsName]
 		if !ok {
-			return fmt.Errorf("can't find data source called %s in state", rsFullName)
+			return fmt.Errorf("can't find data source called %s in state", dsName)
 		}
 
 		dsAttr := ds.Primary.Attributes


### PR DESCRIPTION
Data source should almost never silently fail when the resource doesn't exist, because:

a. There's most likely a good reason user chose to use a data source instead of a resource. They don't manage the resource and expect it to be there and rely on it.
b. It leads to confusing errors, e.g. 

```hcl
data "google_dns_managed_zone" "gcp" {
  name = "bla-blah"
}

resource "google_dns_record_set" "www" {
  name = "www.${data.google_dns_managed_zone.gcp.dns_name}"
  type = "A"
  ttl  = 5

  managed_zone = "${data.google_dns_managed_zone.gcp.name}"
  rrdatas = ["10.10.0.2"]
}
```

```
Error applying plan:

1 error(s) occurred:

* google_dns_record_set.www: Resource 'data.google_dns_managed_zone.gcp' not found for variable 'data.google_dns_managed_zone.gcp.name'

```

## Test results

```
TF_ACC=1 go test ./google -v -run=TestAccDataSourceDnsManagedZone_basic -timeout 120m
=== RUN   TestAccDataSourceDnsManagedZone_basic
--- PASS: TestAccDataSourceDnsManagedZone_basic (5.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	5.169s
```