### PR TITLE
r/compute_vpn_tunnel: Mark 'shared_secret' as sensitive

### DIFF
--- a/google/resource_compute_vpn_tunnel.go
+++ b/google/resource_compute_vpn_tunnel.go
@@ -34,9 +34,10 @@ func resourceComputeVpnTunnel() *schema.Resource {
 			},
 
 			"shared_secret": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				ForceNew:  true,
 			},
 
 			"target_vpn_gateway": &schema.Schema{

--- a/website/docs/r/compute_vpn_tunnel.html.markdown
+++ b/website/docs/r/compute_vpn_tunnel.html.markdown
@@ -11,6 +11,9 @@ description: |-
 Manages a VPN Tunnel to the GCE network. For more info, read the
 [documentation](https://cloud.google.com/compute/docs/vpn).
 
+~> **Note:** All arguments including the `shared_secret` will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
This is to avoid exposing the secret in the consul output and warn the user about consequences of keeping such sensitive data in the state.
