### PR TITLE
Fix import for compute_route

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -6,8 +6,11 @@ import (
 )
 
 const (
-	globalLinkTemplate    = "projects/%s/global/%s/%s"
-	globalLinkBasePattern = "projects/(.+)/global/%s/(.+)"
+	globalLinkTemplate          = "projects/%s/global/%s/%s"
+	globalLinkBasePattern       = "projects/(.+)/global/%s/(.+)"
+	zonalLinkTemplate           = "projects/%s/zones/%s/%s/%s"
+	zonalLinkBasePattern        = "projects/(.+)/zones/(.+)/%s/(.+)"
+	zonalPartialLinkBasePattern = "zones/(.+)/%s/(.+)"
 )
 
 // ------------------------------------------------------------
@@ -37,12 +40,14 @@ func (f GlobalFieldValue) RelativeLink() string {
 	return fmt.Sprintf(globalLinkTemplate, f.Project, f.resourceType, f.Name)
 }
 
-// Parses a global field supporting 4 different formats:
-// - https://www.googleapis.com/compute/ANY_VERSION/projects/{my-project}/global/{resource_type}/{resource_name}
-// - projects/{my-project}/global/{resource_type}/{resource_name}
-// - global/{resource_type}/{resource_name} (default project is used)
-// - resource_name (default project is used)
+// Parses a global field supporting 5 different formats:
+// - https://www.googleapis.com/compute/ANY_VERSION/projects/{my_project}/global/{resource_type}/{resource_name}
+// - projects/{my_project}/global/{resource_type}/{resource_name}
+// - global/{resource_type}/{resource_name}
+// - resource_name
 // - "" (empty string). RelativeLink() returns empty if isEmptyValid is true.
+//
+// If the project is not specified, it first tries to get the project from the `projectSchemaField` and then fallback on the default project.
 func parseGlobalFieldValue(resourceType, fieldValue, projectSchemaField string, d TerraformResourceData, config *Config, isEmptyValid bool) (*GlobalFieldValue, error) {
 	if len(fieldValue) == 0 {
 		if isEmptyValid {
@@ -73,6 +78,86 @@ func parseGlobalFieldValue(resourceType, fieldValue, projectSchemaField string, 
 		Project: project,
 		Name:    GetResourceNameFromSelfLink(fieldValue),
 
+		resourceType: resourceType,
+	}, nil
+}
+
+type ZonalFieldValue struct {
+	Project string
+	Zone    string
+	Name    string
+
+	resourceType string
+}
+
+func (f ZonalFieldValue) RelativeLink() string {
+	if len(f.Name) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(zonalLinkTemplate, f.Project, f.Zone, f.resourceType, f.Name)
+}
+
+// Parses a zonal field supporting 5 different formats:
+// - https://www.googleapis.com/compute/ANY_VERSION/projects/{my_project}/zones/{zone}/{resource_type}/{resource_name}
+// - projects/{my_project}/zones/{zone}/{resource_type}/{resource_name}
+// - zones/{zone}/{resource_type}/{resource_name}
+// - resource_name
+// - "" (empty string). RelativeLink() returns empty if isEmptyValid is true.
+//
+// If the project is not specified, it first tries to get the project from the `projectSchemaField` and then fallback on the default project.
+// If the zone is not specified, it takes the value of `zoneSchemaField`.
+
+func parseZonalFieldValue(resourceType, fieldValue, projectSchemaField, zoneSchemaField string, d TerraformResourceData, config *Config, isEmptyValid bool) (*ZonalFieldValue, error) {
+	if len(fieldValue) == 0 {
+		if isEmptyValid {
+			return &ZonalFieldValue{resourceType: resourceType}, nil
+		}
+		return nil, fmt.Errorf("The zonal field for resource %s cannot be empty.", resourceType)
+	}
+
+	r := regexp.MustCompile(fmt.Sprintf(zonalLinkBasePattern, resourceType))
+	if r.MatchString(fieldValue) {
+		parts := r.FindStringSubmatch(fieldValue)
+
+		return &ZonalFieldValue{
+			Project:      parts[1],
+			Zone:         parts[2],
+			Name:         parts[3],
+			resourceType: resourceType,
+		}, nil
+	}
+
+	project, err := getProjectFromSchema(projectSchemaField, d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	r = regexp.MustCompile(fmt.Sprintf(zonalPartialLinkBasePattern, resourceType))
+	if r.MatchString(fieldValue) {
+		parts := r.FindStringSubmatch(fieldValue)
+
+		return &ZonalFieldValue{
+			Project:      project,
+			Zone:         parts[1],
+			Name:         parts[2],
+			resourceType: resourceType,
+		}, nil
+	}
+
+	if len(zoneSchemaField) == 0 {
+		return nil, fmt.Errorf("Invalid field format. Got '%s', expected format '%s'", fieldValue, fmt.Sprintf(globalLinkTemplate, "{project}", resourceType, "{name}"))
+	}
+
+	zone, ok := d.GetOk(zoneSchemaField)
+	if !ok {
+		return nil, fmt.Errorf("A zone must be specified")
+	}
+
+	return &ZonalFieldValue{
+		Project:      project,
+		Zone:         zone.(string),
+		Name:         GetResourceNameFromSelfLink(fieldValue),
 		resourceType: resourceType,
 	}, nil
 }

--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -57,10 +57,7 @@ func parseGlobalFieldValue(resourceType, fieldValue, projectSchemaField string, 
 	}
 
 	r := regexp.MustCompile(fmt.Sprintf(globalLinkBasePattern, resourceType))
-
-	if r.MatchString(fieldValue) {
-		parts := r.FindStringSubmatch(fieldValue)
-
+	if parts := r.FindStringSubmatch(fieldValue); parts != nil {
 		return &GlobalFieldValue{
 			Project: parts[1],
 			Name:    parts[2],
@@ -107,7 +104,6 @@ func (f ZonalFieldValue) RelativeLink() string {
 //
 // If the project is not specified, it first tries to get the project from the `projectSchemaField` and then fallback on the default project.
 // If the zone is not specified, it takes the value of `zoneSchemaField`.
-
 func parseZonalFieldValue(resourceType, fieldValue, projectSchemaField, zoneSchemaField string, d TerraformResourceData, config *Config, isEmptyValid bool) (*ZonalFieldValue, error) {
 	if len(fieldValue) == 0 {
 		if isEmptyValid {
@@ -117,9 +113,7 @@ func parseZonalFieldValue(resourceType, fieldValue, projectSchemaField, zoneSche
 	}
 
 	r := regexp.MustCompile(fmt.Sprintf(zonalLinkBasePattern, resourceType))
-	if r.MatchString(fieldValue) {
-		parts := r.FindStringSubmatch(fieldValue)
-
+	if parts := r.FindStringSubmatch(fieldValue); parts != nil {
 		return &ZonalFieldValue{
 			Project:      parts[1],
 			Zone:         parts[2],
@@ -134,9 +128,7 @@ func parseZonalFieldValue(resourceType, fieldValue, projectSchemaField, zoneSche
 	}
 
 	r = regexp.MustCompile(fmt.Sprintf(zonalPartialLinkBasePattern, resourceType))
-	if r.MatchString(fieldValue) {
-		parts := r.FindStringSubmatch(fieldValue)
-
+	if parts := r.FindStringSubmatch(fieldValue); parts != nil {
 		return &ZonalFieldValue{
 			Project:      project,
 			Zone:         parts[1],

--- a/google/field_helpers_test.go
+++ b/google/field_helpers_test.go
@@ -82,3 +82,105 @@ func TestParseGlobalFieldValue(t *testing.T) {
 		}
 	}
 }
+
+func TestParseZonalFieldValue(t *testing.T) {
+	const resourceType = "instances"
+	cases := map[string]struct {
+		FieldValue           string
+		ExpectedRelativeLink string
+		ExpectedError        bool
+		IsEmptyValid         bool
+		ProjectSchemaField   string
+		ProjectSchemaValue   string
+		ZoneSchemaField      string
+		ZoneSchemaValue      string
+		Config               *Config
+	}{
+		"instance is a full self link": {
+			FieldValue:           "https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-b/instances/my-instance",
+			ExpectedRelativeLink: "projects/myproject/zones/us-central1-b/instances/my-instance",
+		},
+		"instance is a relative self link": {
+			FieldValue:           "projects/myproject/zones/us-central1-b/instances/my-instance",
+			ExpectedRelativeLink: "projects/myproject/zones/us-central1-b/instances/my-instance",
+		},
+		"instance is a partial relative self link": {
+			FieldValue:           "zones/us-central1-b/instances/my-instance",
+			Config:               &Config{Project: "default-project"},
+			ExpectedRelativeLink: "projects/default-project/zones/us-central1-b/instances/my-instance",
+		},
+		"instance is the name only": {
+			FieldValue:           "my-instance",
+			ZoneSchemaField:      "zone",
+			ZoneSchemaValue:      "us-east1-a",
+			Config:               &Config{Project: "default-project"},
+			ExpectedRelativeLink: "projects/default-project/zones/us-east1-a/instances/my-instance",
+		},
+		"instance is the name only and has a project set in schema": {
+			FieldValue:           "my-instance",
+			ProjectSchemaField:   "project",
+			ProjectSchemaValue:   "schema-project",
+			ZoneSchemaField:      "zone",
+			ZoneSchemaValue:      "us-east1-a",
+			Config:               &Config{Project: "default-project"},
+			ExpectedRelativeLink: "projects/schema-project/zones/us-east1-a/instances/my-instance",
+		},
+		"instance is the name only and has a project set in schema but the field is not specified.": {
+			FieldValue:           "my-instance",
+			ProjectSchemaValue:   "schema-project",
+			ZoneSchemaField:      "zone",
+			ZoneSchemaValue:      "us-east1-a",
+			Config:               &Config{Project: "default-project"},
+			ExpectedRelativeLink: "projects/default-project/zones/us-east1-a/instances/my-instance",
+		},
+		"instance is the name only and no zone field is specified": {
+			FieldValue:    "my-instance",
+			Config:        &Config{Project: "default-project"},
+			ExpectedError: true,
+		},
+		"instance is the name only and no value for zone field is specified": {
+			FieldValue:      "my-instance",
+			ZoneSchemaField: "zone",
+			Config:          &Config{Project: "default-project"},
+			ExpectedError:   true,
+		},
+		"instance is empty and it is valid": {
+			FieldValue:           "",
+			IsEmptyValid:         true,
+			ExpectedRelativeLink: "",
+		},
+		"instance is empty and it is not valid": {
+			FieldValue:    "",
+			IsEmptyValid:  false,
+			ExpectedError: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		fieldsInSchema := make(map[string]interface{})
+
+		if len(tc.ProjectSchemaValue) > 0 && len(tc.ProjectSchemaField) > 0 {
+			fieldsInSchema[tc.ProjectSchemaField] = tc.ProjectSchemaValue
+		}
+
+		if len(tc.ZoneSchemaValue) > 0 && len(tc.ZoneSchemaField) > 0 {
+			fieldsInSchema[tc.ZoneSchemaField] = tc.ZoneSchemaValue
+		}
+
+		d := &ResourceDataMock{
+			FieldsInSchema: fieldsInSchema,
+		}
+
+		v, err := parseZonalFieldValue(resourceType, tc.FieldValue, tc.ProjectSchemaField, tc.ZoneSchemaField, d, tc.Config, tc.IsEmptyValid)
+
+		if err != nil {
+			if !tc.ExpectedError {
+				t.Errorf("bad: %s, did not expect an error. Error: %s", tn, err)
+			}
+		} else {
+			if v.RelativeLink() != tc.ExpectedRelativeLink {
+				t.Errorf("bad: %s, expected relative link to be '%s' but got '%s'", tn, tc.ExpectedRelativeLink, v.RelativeLink())
+			}
+		}
+	}
+}

--- a/google/import_compute_route_test.go
+++ b/google/import_compute_route_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestAccComputeRoute_importBasic(t *testing.T) {
 	t.Parallel()
-
-	resourceName := "google_compute_network.foobar"
+	resourceName := "google_compute_route.foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +16,7 @@ func TestAccComputeRoute_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRoute_basic,
+				Config: testAccComputeRoute_basic(),
 			},
 			{
 				ResourceName:      resourceName,
@@ -30,8 +29,7 @@ func TestAccComputeRoute_importBasic(t *testing.T) {
 
 func TestAccComputeRoute_importDefaultInternetGateway(t *testing.T) {
 	t.Parallel()
-
-	resourceName := "google_compute_network.foobar"
+	resourceName := "google_compute_route.foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +37,7 @@ func TestAccComputeRoute_importDefaultInternetGateway(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRoute_defaultInternetGateway,
+				Config: testAccComputeRoute_defaultInternetGateway(),
 			},
 			{
 				ResourceName:      resourceName,

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -18,22 +18,23 @@ func resourceComputeRoute() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"dest_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"network": &schema.Schema{
+			"dest_range": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"network": &schema.Schema{
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"priority": &schema.Schema{
@@ -43,9 +44,10 @@ func resourceComputeRoute() *schema.Resource {
 			},
 
 			"next_hop_gateway": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"next_hop_instance": &schema.Schema{
@@ -130,10 +132,15 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 		nextHopVpnTunnel = v.(string)
 	}
 	if v, ok := d.GetOk("next_hop_instance"); ok {
+		nextHopInstanceFieldValue, err := parseComputeRouteNextHopInstanceFieldValue(v.(string), d, config)
+		if err != nil {
+			return fmt.Errorf("Invalid next_hop_instance: %s", err)
+		}
+
 		nextInstance, err := config.clientCompute.Instances.Get(
 			project,
-			d.Get("next_hop_instance_zone").(string),
-			v.(string)).Do()
+			nextHopInstanceFieldValue.Zone,
+			nextHopInstanceFieldValue.Name).Do()
 		if err != nil {
 			return fmt.Errorf("Error reading instance: %s", err)
 		}
@@ -194,6 +201,21 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d, fmt.Sprintf("Route %q", d.Get("name").(string)))
 	}
 
+	nextHopInstanceFieldValue, err := parseComputeRouteNextHopInstanceFieldValue(route.NextHopInstance, d, config)
+	if err != nil {
+		return fmt.Errorf("Invalid next_hop_instance: %s", err)
+	}
+
+	d.Set("name", route.Name)
+	d.Set("dest_range", route.DestRange)
+	d.Set("network", route.Network)
+	d.Set("priority", route.Priority)
+	d.Set("next_hop_gateway", route.NextHopGateway)
+	d.Set("next_hop_instance", nextHopInstanceFieldValue.Name)
+	d.Set("next_hop_instance_zone", nextHopInstanceFieldValue.Zone)
+	d.Set("next_hop_ip", route.NextHopIp)
+	d.Set("next_hop_vpn_tunnel", route.NextHopVpnTunnel)
+	d.Set("tags", route.Tags)
 	d.Set("next_hop_network", route.NextHopNetwork)
 	d.Set("self_link", route.SelfLink)
 
@@ -222,4 +244,8 @@ func resourceComputeRouteDelete(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId("")
 	return nil
+}
+
+func parseComputeRouteNextHopInstanceFieldValue(nextHopInstance string, d TerraformResourceData, config *Config) (*ZonalFieldValue, error) {
+	return parseZonalFieldValue("instances", nextHopInstance, "project", "next_hop_instance_zone", d, config, true)
 }

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -66,11 +66,6 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"next_hop_network": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"next_hop_vpn_tunnel": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -83,17 +78,22 @@ func resourceComputeRoute() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"self_link": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"tags": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"next_hop_network": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -109,10 +109,9 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	// Look up the network to attach the route to
-	network, err := getNetworkLink(d, config, "network")
+	network, err := ParseNetworkFieldValue(d.Get("network").(string), d, config)
 	if err != nil {
-		return fmt.Errorf("Error reading network: %s", err)
+		return err
 	}
 
 	// Next hop data
@@ -161,7 +160,7 @@ func resourceComputeRouteCreate(d *schema.ResourceData, meta interface{}) error 
 	route := &compute.Route{
 		Name:             d.Get("name").(string),
 		DestRange:        d.Get("dest_range").(string),
-		Network:          network,
+		Network:          network.RelativeLink(),
 		NextHopInstance:  nextHopInstance,
 		NextHopVpnTunnel: nextHopVpnTunnel,
 		NextHopIp:        nextHopIp,

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -21,7 +21,7 @@ func TestAccComputeRoute_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouteDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRoute_basic,
+				Config: testAccComputeRoute_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRouteExists(
 						"google_compute_route.foobar", &route),
@@ -42,10 +42,34 @@ func TestAccComputeRoute_defaultInternetGateway(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouteDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRoute_defaultInternetGateway,
+				Config: testAccComputeRoute_defaultInternetGateway(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRouteExists(
 						"google_compute_route.foobar", &route),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeRoute_hopInstance(t *testing.T) {
+	var route compute.Route
+
+	instanceName := acctest.RandString(10)
+	zone := "us-central1-b"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRoute_hopInstance(instanceName, zone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouteExists(
+						"google_compute_route.foobar", &route),
+					resource.TestCheckResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceName),
+					resource.TestCheckResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceName),
 				),
 			},
 		},
@@ -99,7 +123,8 @@ func testAccCheckComputeRouteExists(n string, route *compute.Route) resource.Tes
 	}
 }
 
-var testAccComputeRoute_basic = fmt.Sprintf(`
+func testAccComputeRoute_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "route-test-%s"
 }
@@ -118,23 +143,43 @@ resource "google_compute_route" "foobar" {
 	next_hop_ip = "10.154.0.1"
 	priority = 100
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
-
-var testAccComputeRoute_defaultInternetGateway = fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-	name = "route-test-%s"
 }
 
-resource "google_compute_subnetwork" "foobar" {
-  name          = "route-test-%s"
-  ip_cidr_range = "10.0.0.0/16"
-  network       = "${google_compute_network.foobar.self_link}"
-  region        = "us-central1"
+func testAccComputeRoute_defaultInternetGateway() string {
+	return fmt.Sprintf(`
+resource "google_compute_route" "foobar" {
+	name = "route-test-%s"
+	dest_range = "0.0.0.0/0"
+	network = "default"
+	next_hop_gateway = "default-internet-gateway"
+	priority = 100
+}`, acctest.RandString(10))
+}
+
+func testAccComputeRoute_hopInstance(instanceName, zone string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foo" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+  zone         = "%s"
+
+  boot_disk {
+    initialize_params{
+      image = "debian-cloud/debian-8"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
 }
 
 resource "google_compute_route" "foobar" {
 	name = "route-test-%s"
 	dest_range = "0.0.0.0/0"
-	network = "${google_compute_network.foobar.name}"
-	next_hop_gateway = "default-internet-gateway"
+	network = "default"
+  	next_hop_instance = "${google_compute_instance.foo.name}"
+  	next_hop_instance_zone = "${google_compute_instance.foo.zone}"
 	priority = 100
-}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}`, instanceName, zone, acctest.RandString(10))
+}

--- a/website/docs/r/compute_route.html.markdown
+++ b/website/docs/r/compute_route.html.markdown
@@ -17,8 +17,14 @@ and
 
 ```hcl
 resource "google_compute_network" "default" {
-  name       = "compute-network"
-  ipv4_range = "10.0.0.0/16"
+  name = "compute-network"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "compute-subnetwork"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "${google_compute_network.default.self_link}"
+  region        = "us-central1"
 }
 
 resource "google_compute_route" "default" {
@@ -34,11 +40,11 @@ resource "google_compute_route" "default" {
 
 The following arguments are supported:
 
-* `dest_range` - (Required) The destination IPv4 address range that this
-    route applies to.
-
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
+
+* `dest_range` - (Required) The destination IPv4 address range that this
+    route applies to.
 
 * `network` - (Required) The name or self_link of the network to attach this route to.
 


### PR DESCRIPTION
Fixes one resource for #431 

* Reorder fields in schema for style consistency
* Add reusable ZonalFieldValue
* Import tests were not testing the right thing. Import was broken. I fixed the import.
* Read state from the API
* Generate network link without calling the API