### PR TITLE
r/compute_instance_template: Make disk.device_name computed

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -70,6 +70,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 						"device_name": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 


### PR DESCRIPTION
This is to address a breaking API change which occurred between yesterday and today. Last night's tests passed, but are now failing.

## Test results (after patch)

```
=== RUN   TestAccComputeInstanceTemplate_importBasic
--- PASS: TestAccComputeInstanceTemplate_importBasic (26.45s)
=== RUN   TestAccComputeInstanceTemplate_importIp
--- PASS: TestAccComputeInstanceTemplate_importIp (47.83s)
=== RUN   TestAccComputeInstanceTemplate_importDisks
--- PASS: TestAccComputeInstanceTemplate_importDisks (27.77s)
=== RUN   TestAccComputeInstanceTemplate_importSubnetAuto
--- PASS: TestAccComputeInstanceTemplate_importSubnetAuto (107.90s)
=== RUN   TestAccComputeInstanceTemplate_importSubnetCustom
--- PASS: TestAccComputeInstanceTemplate_importSubnetCustom (90.38s)
=== RUN   TestAccComputeInstanceTemplate_basic
--- PASS: TestAccComputeInstanceTemplate_basic (24.88s)
=== RUN   TestAccComputeInstanceTemplate_preemptible
--- PASS: TestAccComputeInstanceTemplate_preemptible (25.28s)
=== RUN   TestAccComputeInstanceTemplate_IP
--- PASS: TestAccComputeInstanceTemplate_IP (50.13s)
=== RUN   TestAccComputeInstanceTemplate_networkIP
--- PASS: TestAccComputeInstanceTemplate_networkIP (24.77s)
=== RUN   TestAccComputeInstanceTemplate_disks
--- PASS: TestAccComputeInstanceTemplate_disks (25.09s)
=== RUN   TestAccComputeInstanceTemplate_subnet_auto
--- PASS: TestAccComputeInstanceTemplate_subnet_auto (107.73s)
=== RUN   TestAccComputeInstanceTemplate_subnet_custom
--- PASS: TestAccComputeInstanceTemplate_subnet_custom (89.12s)
```