### PR TITLE
d/compute_lb_ip_ranges: Add new data source

### DIFF
--- a/google/data_source_compute_lb_ip_ranges.go
+++ b/google/data_source_compute_lb_ip_ranges.go
@@ -1,0 +1,45 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleComputeLbIpRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeLbIpRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"network": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"http_ssl_tcp_internal": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeLbIpRangesRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("compute-lb-ip-ranges")
+
+	// https://cloud.google.com/compute/docs/load-balancing/health-checks#health_check_source_ips_and_firewall_rules
+
+	networkIpRanges := []string{
+		"209.85.152.0/22",
+		"209.85.204.0/22",
+		"35.191.0.0/16",
+	}
+	d.Set("network", networkIpRanges)
+
+	httpSslTcpInternalRanges := []string{
+		"130.211.0.0/22",
+		"35.191.0.0/16",
+	}
+	d.Set("http_ssl_tcp_internal", httpSslTcpInternalRanges)
+
+	return nil
+}

--- a/google/data_source_compute_lb_ip_ranges_test.go
+++ b/google/data_source_compute_lb_ip_ranges_test.go
@@ -1,0 +1,34 @@
+package google
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceComputeLbIpRanges_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeLbIpRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_compute_lb_ip_ranges.some",
+						"network.#", regexp.MustCompile("^[1-9]+[0-9]*$")),
+					resource.TestMatchResourceAttr("data.google_compute_lb_ip_ranges.some",
+						"network.0", regexp.MustCompile("^[0-9./]+$")),
+					resource.TestMatchResourceAttr("data.google_compute_lb_ip_ranges.some",
+						"http_ssl_tcp_internal.#", regexp.MustCompile("^[1-9]+[0-9]*$")),
+					resource.TestMatchResourceAttr("data.google_compute_lb_ip_ranges.some",
+						"http_ssl_tcp_internal.0", regexp.MustCompile("^[0-9./]+$")),
+				),
+			},
+		},
+	})
+}
+
+const testAccComputeLbIpRangesConfig = `
+data "google_compute_lb_ip_ranges" "some" {}
+`

--- a/google/provider.go
+++ b/google/provider.go
@@ -51,6 +51,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"google_dns_managed_zone":          dataSourceDnsManagedZone(),
 			"google_client_config":             dataSourceGoogleClientConfig(),
+			"google_compute_lb_ip_ranges":      dataSourceGoogleComputeLbIpRanges(),
 			"google_compute_network":           dataSourceGoogleComputeNetwork(),
 			"google_compute_subnetwork":        dataSourceGoogleComputeSubnetwork(),
 			"google_compute_zones":             dataSourceGoogleComputeZones(),

--- a/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
+++ b/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "google"
+page_title: "Google: google_compute_lb_ip_ranges"
+sidebar_current: "docs-google-datasource-compute-lb-ip-ranges"
+description: |-
+  Get information about the IP ranges used when health-checking load balancers.
+---
+
+# google_compute_lb_ip_ranges
+
+Use this data source to access IP ranges in your firewall rules.
+
+https://cloud.google.com/compute/docs/load-balancing/health-checks#health_check_source_ips_and_firewall_rules
+
+## Example Usage
+
+```tf
+data "google_compute_lb_ip_ranges" "ranges" {}
+
+resource "google_compute_firewall" "lb" {
+  name    = "lb-firewall"
+  network = "${google_compute_network.main.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  source_ranges = ["${data.google_compute_lb_ip_ranges.ranges.network}"]
+  target_tags = [
+    "InstanceBehindLoadBalancer"
+  ]
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `network` - The IP ranges used for health checks when **Network load balancing** is used
+
+* `http_ssl_tcp_internal` - The IP ranges used for health checks when **HTTP(S), SSL proxy, TCP proxy, and Internal load balancing** is used

--- a/website/google.erb
+++ b/website/google.erb
@@ -28,6 +28,9 @@
       <li<%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
       <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
+      <a href="/docs/providers/google/d/google_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-container-versions") %>>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>
       </li>


### PR DESCRIPTION
This is just to make it more convenient and allow folks to have more "idiomatic" configs without hard-coded IP ranges or forcing them to add comments to such hard-coded ranges.

https://cloud.google.com/compute/docs/load-balancing/health-checks#health_check_source_ips_and_firewall_rules

I'm open to suggestions about the data source name, esp. from someone who may be more familiar how health checks are performed in practice (i.e. _what_ sends the probe).

## Test results

```
TF_ACC=1 go test ./google -v -run=TestAccDataSourceComputeLbIpRanges_basic -timeout 120m
=== RUN   TestAccDataSourceComputeLbIpRanges_basic
--- PASS: TestAccDataSourceComputeLbIpRanges_basic (0.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	0.067s
```