### PR TITLE
Add new resource google_compute_target_ssl_proxy 

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -18,6 +18,10 @@ func ParseNetworkFieldValue(network string, d TerraformResourceData, config *Con
 	return parseGlobalFieldValue("networks", network, "project", d, config, true)
 }
 
+func ParseSslCertificateFieldValue(sslCertificate string, d TerraformResourceData, config *Config) (*GlobalFieldValue, error) {
+	return parseGlobalFieldValue("sslCertificates", sslCertificate, "project", d, config, false)
+}
+
 // ------------------------------------------------------------
 // Base helpers used to create helpers for specific fields.
 // ------------------------------------------------------------

--- a/google/import_compute_target_ssl_proxy_test.go
+++ b/google/import_compute_target_ssl_proxy_test.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeTargetSslProxy_import(t *testing.T) {
+	target := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	cert := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	backend := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetSslProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetSslProxy_basic1(target, cert, backend, hc),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_target_ssl_proxy.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -99,6 +99,7 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_target_http_proxy":             resourceComputeTargetHttpProxy(),
 			"google_compute_target_https_proxy":            resourceComputeTargetHttpsProxy(),
 			"google_compute_target_tcp_proxy":              resourceComputeTargetTcpProxy(),
+			"google_compute_target_ssl_proxy":              resourceComputeTargetSslProxy(),
 			"google_compute_target_pool":                   resourceComputeTargetPool(),
 			"google_compute_url_map":                       resourceComputeUrlMap(),
 			"google_compute_vpn_gateway":                   resourceComputeVpnGateway(),

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -1,0 +1,247 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+)
+
+func resourceComputeTargetSslProxy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeTargetSslProxyCreate,
+		Read:   resourceComputeTargetSslProxyRead,
+		Delete: resourceComputeTargetSslProxyDelete,
+		Update: resourceComputeTargetSslProxyUpdate,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"backend_service": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"ssl_certificates": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: compareSelfLinkOrResourceName,
+				},
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"proxy_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "NONE",
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"proxy_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceComputeTargetSslProxyCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	sslCertificates, err := expandSslCertificates(d.Get("ssl_certificates").([]interface{}), d, config)
+	if err != nil {
+		return err
+	}
+
+	proxy := &compute.TargetSslProxy{
+		Name:            d.Get("name").(string),
+		Service:         d.Get("backend_service").(string),
+		ProxyHeader:     d.Get("proxy_header").(string),
+		Description:     d.Get("description").(string),
+		SslCertificates: sslCertificates,
+	}
+
+	log.Printf("[DEBUG] TargetSslProxy insert request: %#v", proxy)
+	op, err := config.clientCompute.TargetSslProxies.Insert(
+		project, proxy).Do()
+	if err != nil {
+		return fmt.Errorf("Error creating TargetSslProxy: %s", err)
+	}
+
+	err = computeOperationWait(config, op, project, "Creating Target Ssl Proxy")
+	if err != nil {
+		return err
+	}
+
+	d.SetId(proxy.Name)
+
+	return resourceComputeTargetSslProxyRead(d, meta)
+}
+
+func resourceComputeTargetSslProxyUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	d.Partial(true)
+
+	if d.HasChange("proxy_header") {
+		proxy_header := d.Get("proxy_header").(string)
+		proxy_header_payload := &compute.TargetSslProxiesSetProxyHeaderRequest{
+			ProxyHeader: proxy_header,
+		}
+		op, err := config.clientCompute.TargetSslProxies.SetProxyHeader(
+			project, d.Id(), proxy_header_payload).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating proxy_header: %s", err)
+		}
+
+		err = computeOperationWait(config, op, project, "Updating Target SSL Proxy")
+		if err != nil {
+			return err
+		}
+
+		d.SetPartial("proxy_header")
+	}
+
+	if d.HasChange("backend_service") {
+		op, err := config.clientCompute.TargetSslProxies.SetBackendService(project, d.Id(), &compute.TargetSslProxiesSetBackendServiceRequest{
+			Service: d.Get("backend_service").(string),
+		}).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error updating backend_service: %s", err)
+		}
+
+		err = computeOperationWait(config, op, project, "Updating Target SSL Proxy")
+		if err != nil {
+			return err
+		}
+
+		d.SetPartial("backend_service")
+	}
+
+	if d.HasChange("ssl_certificates") {
+		sslCertificates, err := expandSslCertificates(d.Get("ssl_certificates").([]interface{}), d, config)
+		if err != nil {
+			return err
+		}
+
+		op, err := config.clientCompute.TargetSslProxies.SetSslCertificates(project, d.Id(), &compute.TargetSslProxiesSetSslCertificatesRequest{
+			SslCertificates: sslCertificates,
+		}).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error updating backend_service: %s", err)
+		}
+
+		err = computeOperationWait(config, op, project, "Updating Target SSL Proxy")
+		if err != nil {
+			return err
+		}
+
+		d.SetPartial("ssl_certificates")
+	}
+
+	d.Partial(false)
+
+	return resourceComputeTargetSslProxyRead(d, meta)
+}
+
+func resourceComputeTargetSslProxyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	proxy, err := config.clientCompute.TargetSslProxies.Get(
+		project, d.Id()).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Target SSL Proxy %q", d.Get("name").(string)))
+	}
+
+	d.Set("name", proxy.Name)
+	d.Set("description", proxy.Description)
+	d.Set("proxy_header", proxy.ProxyHeader)
+	d.Set("backend_service", proxy.Service)
+	d.Set("ssl_certificates", proxy.SslCertificates)
+	d.Set("self_link", proxy.SelfLink)
+	d.Set("proxy_id", strconv.FormatUint(proxy.Id, 10))
+
+	return nil
+}
+
+func resourceComputeTargetSslProxyDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	op, err := config.clientCompute.TargetSslProxies.Delete(
+		project, d.Id()).Do()
+	if err != nil {
+		return fmt.Errorf("Error deleting TargetSslProxy: %s", err)
+	}
+
+	err = computeOperationWait(config, op, project, "Deleting Target SSL Proxy")
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func expandSslCertificates(configured []interface{}, d *schema.ResourceData, config *Config) ([]string, error) {
+	certs := make([]string, 0, len(configured))
+
+	for _, sslCertificate := range configured {
+		sslCertificateFieldValue, err := ParseSslCertificateFieldValue(sslCertificate.(string), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid ssl certificate: %s", err)
+		}
+
+		certs = append(certs, sslCertificateFieldValue.RelativeLink())
+	}
+
+	return certs, nil
+}

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -35,6 +35,7 @@ func resourceComputeTargetSslProxy() *schema.Resource {
 			"ssl_certificates": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
+				MaxItems: 1,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
 					DiffSuppressFunc: compareSelfLinkOrResourceName,

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -80,7 +80,7 @@ func resourceComputeTargetSslProxyCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	sslCertificates, err := expandSslCertificates(d.Get("ssl_certificates").([]interface{}), d, config)
+	sslCertificates, err := expandSslCertificates(d, config)
 	if err != nil {
 		return err
 	}
@@ -121,12 +121,12 @@ func resourceComputeTargetSslProxyUpdate(d *schema.ResourceData, meta interface{
 	d.Partial(true)
 
 	if d.HasChange("proxy_header") {
-		proxy_header := d.Get("proxy_header").(string)
-		proxy_header_payload := &compute.TargetSslProxiesSetProxyHeaderRequest{
-			ProxyHeader: proxy_header,
+		proxyHeader := d.Get("proxy_header").(string)
+		proxyHeaderPayload := &compute.TargetSslProxiesSetProxyHeaderRequest{
+			ProxyHeader: proxyHeader,
 		}
 		op, err := config.clientCompute.TargetSslProxies.SetProxyHeader(
-			project, d.Id(), proxy_header_payload).Do()
+			project, d.Id(), proxyHeaderPayload).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating proxy_header: %s", err)
 		}
@@ -157,7 +157,7 @@ func resourceComputeTargetSslProxyUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("ssl_certificates") {
-		sslCertificates, err := expandSslCertificates(d.Get("ssl_certificates").([]interface{}), d, config)
+		sslCertificates, err := expandSslCertificates(d, config)
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,8 @@ func resourceComputeTargetSslProxyDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func expandSslCertificates(configured []interface{}, d *schema.ResourceData, config *Config) ([]string, error) {
+func expandSslCertificates(d *schema.ResourceData, config *Config) ([]string, error) {
+	configured := d.Get("ssl_certificates").([]interface{})
 	certs := make([]string, 0, len(configured))
 
 	for _, sslCertificate := range configured {

--- a/google/resource_compute_target_ssl_proxy_test.go
+++ b/google/resource_compute_target_ssl_proxy_test.go
@@ -1,0 +1,189 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccComputeTargetSslProxy_basic(t *testing.T) {
+	target := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	cert := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	backend := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetSslProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetSslProxy_basic1(target, cert, backend, hc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeTargetSslProxyExists(
+						"google_compute_target_ssl_proxy.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeTargetSslProxy_update(t *testing.T) {
+	target := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	cert1 := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	cert2 := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	backend1 := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	backend2 := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("tssl-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetSslProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetSslProxy_basic1(target, cert1, backend1, hc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeTargetSslProxyExists(
+						"google_compute_target_ssl_proxy.foobar"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeTargetSslProxy_basic2(target, cert1, cert2, backend1, backend2, hc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeTargetSslProxyExists(
+						"google_compute_target_ssl_proxy.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeTargetSslProxyDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_compute_target_ssl_proxy" {
+			continue
+		}
+
+		_, err := config.clientCompute.TargetSslProxies.Get(
+			config.Project, rs.Primary.ID).Do()
+		if err == nil {
+			return fmt.Errorf("TargetSslProxy still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeTargetSslProxyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.TargetSslProxies.Get(
+			config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("TargetSslProxy not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeTargetSslProxy_basic1(target, sslCert, backend, hc string) string {
+	return fmt.Sprintf(`
+resource "google_compute_target_ssl_proxy" "foobar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "%s"
+	backend_service = "${google_compute_backend_service.foo.self_link}"
+	ssl_certificates = ["${google_compute_ssl_certificate.foo.self_link}"]
+	proxy_header = "NONE"
+}
+
+resource "google_compute_ssl_certificate" "foo" {
+	name = "%s"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+
+resource "google_compute_backend_service" "foo" {
+	name = "%s"
+	protocol    = "SSL"
+	health_checks = ["${google_compute_health_check.zero.self_link}"]
+}
+
+resource "google_compute_health_check" "zero" {
+	name = "%s"
+	check_interval_sec = 1
+	timeout_sec = 1
+	tcp_health_check {
+		port = "443"
+	}
+}
+`, target, sslCert, backend, hc)
+}
+
+func testAccComputeTargetSslProxy_basic2(target, sslCert1, sslCert2, backend1, backend2, hc string) string {
+	return fmt.Sprintf(`
+resource "google_compute_target_ssl_proxy" "foobar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "%s"
+	backend_service = "${google_compute_backend_service.bar.self_link}"
+	ssl_certificates = [
+		"${google_compute_ssl_certificate.foo.self_link}",
+		"${google_compute_ssl_certificate.bar.name}",
+	]
+	proxy_header = "PROXY_V1"
+}
+
+resource "google_compute_ssl_certificate" "foo" {
+	name = "%s"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+
+resource "google_compute_ssl_certificate" "bar" {
+	name = "%s"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+
+resource "google_compute_backend_service" "foo" {
+	name = "%s"
+	protocol    = "SSL"
+	health_checks = ["${google_compute_health_check.zero.self_link}"]
+}
+
+resource "google_compute_backend_service" "bar" {
+	name = "%s"
+	protocol    = "SSL"
+	health_checks = ["${google_compute_health_check.zero.self_link}"]
+}
+
+resource "google_compute_health_check" "zero" {
+	name = "%s"
+	check_interval_sec = 1
+	timeout_sec = 1
+	tcp_health_check {
+		port = "443"
+	}
+}
+`, target, sslCert1, sslCert2, backend1, backend2, hc)
+}

--- a/google/resource_compute_target_ssl_proxy_test.go
+++ b/google/resource_compute_target_ssl_proxy_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"reflect"
 )
 
 func TestAccComputeTargetSslProxy_basic(t *testing.T) {
@@ -25,7 +24,7 @@ func TestAccComputeTargetSslProxy_basic(t *testing.T) {
 				Config: testAccComputeTargetSslProxy_basic1(target, cert, backend, hc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxy(
-						"google_compute_target_ssl_proxy.foobar", "NONE", []string{cert}),
+						"google_compute_target_ssl_proxy.foobar", "NONE", cert),
 				),
 			},
 		},
@@ -49,14 +48,14 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 				Config: testAccComputeTargetSslProxy_basic1(target, cert1, backend1, hc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxy(
-						"google_compute_target_ssl_proxy.foobar", "NONE", []string{cert1}),
+						"google_compute_target_ssl_proxy.foobar", "NONE", cert1),
 				),
 			},
 			resource.TestStep{
 				Config: testAccComputeTargetSslProxy_basic2(target, cert1, cert2, backend1, backend2, hc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetSslProxy(
-						"google_compute_target_ssl_proxy.foobar", "PROXY_V1", []string{cert1, cert2}),
+						"google_compute_target_ssl_proxy.foobar", "PROXY_V1", cert2),
 				),
 			},
 		},
@@ -81,7 +80,7 @@ func testAccCheckComputeTargetSslProxyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeTargetSslProxy(n, proxyHeader string, sslCerts []string) resource.TestCheckFunc {
+func testAccCheckComputeTargetSslProxy(n, proxyHeader, sslCert string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -108,13 +107,9 @@ func testAccCheckComputeTargetSslProxy(n, proxyHeader string, sslCerts []string)
 			return fmt.Errorf("Wrong proxy header. Expected '%s', got '%s'", proxyHeader, found.ProxyHeader)
 		}
 
-		foundCertsName := make([]string, 0, len(found.SslCertificates))
-		for _, foundCert := range found.SslCertificates {
-			foundCertsName = append(foundCertsName, GetResourceNameFromSelfLink(foundCert))
-		}
-
-		if !reflect.DeepEqual(foundCertsName, sslCerts) {
-			return fmt.Errorf("Wrong ssl certificates. Expected '%s', got '%s'", sslCerts, found.SslCertificates)
+		foundCertName := GetResourceNameFromSelfLink(found.SslCertificates[0])
+		if foundCertName != sslCert {
+			return fmt.Errorf("Wrong ssl certificates. Expected '%s', got '%s'", sslCert, foundCertName)
 		}
 
 		return nil
@@ -160,10 +155,7 @@ resource "google_compute_target_ssl_proxy" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	name = "%s"
 	backend_service = "${google_compute_backend_service.bar.self_link}"
-	ssl_certificates = [
-		"${google_compute_ssl_certificate.foo.self_link}",
-		"${google_compute_ssl_certificate.bar.name}",
-	]
+	ssl_certificates = ["${google_compute_ssl_certificate.bar.name}"]
 	proxy_header = "PROXY_V1"
 }
 

--- a/website/docs/r/compute_target_ssl_proxy.html.markdown
+++ b/website/docs/r/compute_target_ssl_proxy.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "google"
+page_title: "Google: google_compute_target_ssl_proxy"
+sidebar_current: "docs-google-compute-target-ssl-proxy"
+description: |-
+  Creates a Target SSL Proxy resource in GCE.
+---
+
+# google\_compute\_target\_ssl\_proxy
+
+Creates a target SSL proxy resource in GCE. For more information see
+[the official
+documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-ssl/) and
+[API](https://cloud.google.com/compute/docs/reference/latest/targetSslProxies).
+
+
+## Example Usage
+
+```hcl
+resource "google_compute_target_ssl_proxy" "default" {
+  name = "test"
+  backend_service = "${google_compute_backend_service.default.self_link}"
+  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+}
+
+resource "google_compute_ssl_certificate" "default" {
+  name = "default-cert"
+  private_key = "${file("path/to/test.key")}"
+  certificate = "${file("path/to/test.crt")}"
+}
+
+resource "google_compute_backend_service" "default" {
+  name = "default-backend"
+  protocol    = "SSL"
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_health_check" "default" {
+  name = "default-health-check"
+  check_interval_sec = 1
+  timeout_sec = 1
+  tcp_health_check {
+    port = "443"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by GCE. Changing
+    this forces a new resource to be created.
+
+* `backend_service` - (Required) The URL of a Backend Service resource to receive the matched traffic.
+
+* `ssl_certificates` - (Required) The URLs of the SSL Certificate resources that
+    authenticate connections between users and load balancing.
+
+- - -
+
+* `proxy_header` - (Optional) Type of proxy header to append before sending
+    data to the backend, either NONE or PROXY_V1 (default NONE).
+
+* `description` - (Optional) A description of this resource. Changing this
+    forces a new resource to be created.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `proxy_id` - A unique ID assigned by GCE.
+
+* `self_link` - The URI of the created resource.
+
+## Import
+
+SSL proxy can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_target_ssl_proxy.default test
+```

--- a/website/google.erb
+++ b/website/google.erb
@@ -226,6 +226,10 @@
       <a href="/docs/providers/google/r/compute_target_https_proxy.html">google_compute_target_https_proxy</a>
       </li>
 
+      <li<%= sidebar_current("docs-google-compute-target-ssl-proxy") %>>
+      <a href="/docs/providers/google/r/compute_target_ssl_proxy.html">google_compute_target_ssl_proxy</a>
+      </li>
+
       <li<%= sidebar_current("docs-google-compute-target-tcp-proxy") %>>
       <a href="/docs/providers/google/r/compute_target_tcp_proxy.html">google_compute_target_tcp_proxy</a>
       </li>


### PR DESCRIPTION
Fixes #62 

```sh
=== RUN   TestAccComputeTargetSslProxy_import
--- PASS: TestAccComputeTargetSslProxy_import (66.96s)
=== RUN   TestAccComputeTargetSslProxy_basic
--- PASS: TestAccComputeTargetSslProxy_basic (66.86s)
=== RUN   TestAccComputeTargetSslProxy_update
=== RUN   TestAccComputeTargetSslProxy_update
--- PASS: TestAccComputeTargetSslProxy_update (110.85s)
```