### PR TITLE
Add support for shared VPC

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -94,6 +94,8 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_router":                        resourceComputeRouter(),
 			"google_compute_router_interface":              resourceComputeRouterInterface(),
 			"google_compute_router_peer":                   resourceComputeRouterPeer(),
+			"google_compute_shared_vpc_host_project":       resourceComputeSharedVpcHostProject(),
+			"google_compute_shared_vpc_service_project":    resourceComputeSharedVpcServiceProject(),
 			"google_compute_ssl_certificate":               resourceComputeSslCertificate(),
 			"google_compute_subnetwork":                    resourceComputeSubnetwork(),
 			"google_compute_target_http_proxy":             resourceComputeTargetHttpProxy(),

--- a/google/resource_compute_shared_vpc_host_project.go
+++ b/google/resource_compute_shared_vpc_host_project.go
@@ -1,0 +1,80 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceComputeSharedVpcHostProject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeSharedVpcHostProjectCreate,
+		Read:   resourceComputeSharedVpcHostProjectRead,
+		Delete: resourceComputeSharedVpcHostProjectDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	hostProject := d.Get("project").(string)
+	op, err := config.clientCompute.Projects.EnableXpnHost(hostProject).Do()
+	if err != nil {
+		return fmt.Errorf("Error enabling Shared VPC Host %q: %s", hostProject, err)
+	}
+
+	d.SetId(hostProject)
+
+	err = computeOperationWait(config, op, hostProject, "Enabling Shared VPC Host")
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	return nil
+}
+
+func resourceComputeSharedVpcHostProjectRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	hostProject := d.Get("project").(string)
+
+	project, err := config.clientCompute.Projects.Get(hostProject).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Project data for project %q", hostProject))
+	}
+
+	if project.XpnProjectStatus != "HOST" {
+		log.Printf("[WARN] Removing Shared VPC host resource %q because it's not enabled server-side", hostProject)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	hostProject := d.Get("project").(string)
+
+	op, err := config.clientCompute.Projects.DisableXpnHost(hostProject).Do()
+	if err != nil {
+		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
+	}
+
+	err = computeOperationWait(config, op, hostProject, "Disabling Shared VPC Host")
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/google/resource_compute_shared_vpc_service_project.go
+++ b/google/resource_compute_shared_vpc_service_project.go
@@ -1,0 +1,101 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"google.golang.org/api/compute/v1"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceComputeSharedVpcServiceProject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeSharedVpcServiceProjectCreate,
+		Read:   resourceComputeSharedVpcServiceProjectRead,
+		Delete: resourceComputeSharedVpcServiceProjectDelete,
+
+		Schema: map[string]*schema.Schema{
+			"host_project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service_project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	hostProject := d.Get("host_project").(string)
+	serviceProject := d.Get("service_project").(string)
+
+	req := &compute.ProjectsEnableXpnResourceRequest{
+		XpnResource: &compute.XpnResourceId{
+			Id:   serviceProject,
+			Type: "PROJECT",
+		},
+	}
+	op, err := config.clientCompute.Projects.EnableXpnResource(hostProject, req).Do()
+	if err != nil {
+		return err
+	}
+	if err = computeOperationWait(config, op, hostProject, "Enabling Shared VPC Resource"); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", hostProject, serviceProject))
+
+	return nil
+}
+
+func resourceComputeSharedVpcServiceProjectRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	hostProject := d.Get("host_project").(string)
+	serviceProject := d.Get("service_project").(string)
+
+	req := config.clientCompute.Projects.GetXpnResources(hostProject)
+	if err := req.Pages(context.Background(), func(page *compute.ProjectsGetXpnResources) error {
+		for _, xpnResourceId := range page.Resources {
+			if xpnResourceId.Type == "PROJECT" && xpnResourceId.Id == serviceProject {
+				return nil
+			}
+		}
+		return fmt.Errorf("%s is not a service project of %s", serviceProject, hostProject)
+	}); err != nil {
+		log.Printf("[WARN] %s", err)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceComputeSharedVpcServiceProjectDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	hostProject := d.Get("host_project").(string)
+	serviceProject := d.Get("service_project").(string)
+
+	req := &compute.ProjectsDisableXpnResourceRequest{
+		XpnResource: &compute.XpnResourceId{
+			Id:   serviceProject,
+			Type: "PROJECT",
+		},
+	}
+	op, err := config.clientCompute.Projects.DisableXpnResource(hostProject, req).Do()
+	if err != nil {
+		return err
+	}
+	if err = computeOperationWait(config, op, hostProject, "Disabling Shared VPC Resource"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/google/resource_compute_shared_vpc_test.go
+++ b/google/resource_compute_shared_vpc_test.go
@@ -83,7 +83,7 @@ func testAccCheckComputeSharedVpcServiceProject(n string) resource.TestCheckFunc
 		}
 
 		if serviceHostProject.Name != hostProject {
-			return fmt.Errorf("Wrong host project for the given service project. Expected '%s', got '%s'", hostProject, serviceHostProject.Id)
+			return fmt.Errorf("Wrong host project for the given service project. Expected '%s', got '%s'", hostProject, serviceHostProject.Name)
 		}
 
 		return nil

--- a/google/resource_compute_shared_vpc_test.go
+++ b/google/resource_compute_shared_vpc_test.go
@@ -1,0 +1,129 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+)
+
+func TestAccComputeSharedVpc_basic(t *testing.T) {
+	skipIfEnvNotSet(t, "GOOGLE_ORG", "GOOGLE_BILLING_ACCOUNT")
+	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+
+	hostProject := "xpn-host-" + acctest.RandString(10)
+	serviceProject := "xpn-service-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeSharedVpc_basic(hostProject, serviceProject, org, billingId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSharedVpcHostProject("google_compute_shared_vpc_host_project.host"),
+					testAccCheckComputeSharedVpcServiceProject("google_compute_shared_vpc_service_project.service"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeSharedVpcHostProject(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.Projects.Get(rs.Primary.ID).Do()
+		if err != nil {
+			return fmt.Errorf("Error reading project %s: %s", rs.Primary.ID, err)
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Project %s not found", rs.Primary.ID)
+		}
+
+		if found.XpnProjectStatus != "HOST" {
+			return fmt.Errorf("Project %q Shared VPC status was not expected, got %q", rs.Primary.ID, found.XpnProjectStatus)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeSharedVpcServiceProject(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		hostProject := rs.Primary.Attributes["host_project"]
+		serviceProject := rs.Primary.Attributes["service_project"]
+
+		serviceHostProject, err := config.clientCompute.Projects.GetXpnHost(serviceProject).Do()
+		if err != nil {
+			return err
+		}
+
+		if serviceHostProject.Name != hostProject {
+			return fmt.Errorf("Wrong host project for the given service project. Expected '%s', got '%s'", hostProject, serviceHostProject.Id)
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeSharedVpc_basic(hostProject, serviceProject, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "host" {
+	project_id      = "%s"
+	name            = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project" "service" {
+	project_id      = "%s"
+	name            = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_services" "host" {
+	project  = "${google_project.host.project_id}"
+	services = ["compute.googleapis.com"]
+}
+
+resource "google_project_services" "service" {
+	project  = "${google_project.service.project_id}"
+	services = ["compute.googleapis.com"]
+}
+
+resource "google_compute_shared_vpc_host_project" "host" {
+	project    = "${google_project.host.project_id}"
+	depends_on = ["google_project_services.host", "google_project_services.service"]
+}
+
+resource "google_compute_shared_vpc_service_project" "service" {
+	host_project    = "${google_project.host.project_id}"
+	service_project = "${google_project.service.project_id}"
+	depends_on      = ["google_compute_shared_vpc_host_project.host"]
+}`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
+}

--- a/google/resource_compute_shared_vpc_test.go
+++ b/google/resource_compute_shared_vpc_test.go
@@ -118,12 +118,12 @@ resource "google_project_services" "service" {
 
 resource "google_compute_shared_vpc_host_project" "host" {
 	project    = "${google_project.host.project_id}"
-	depends_on = ["google_project_services.host", "google_project_services.service"]
+	depends_on = ["google_project_services.host"]
 }
 
 resource "google_compute_shared_vpc_service_project" "service" {
 	host_project    = "${google_project.host.project_id}"
 	service_project = "${google_project.service.project_id}"
-	depends_on      = ["google_compute_shared_vpc_host_project.host"]
+	depends_on      = ["google_compute_shared_vpc_host_project.host", "google_project_services.service"]
 }`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
 }

--- a/google/serviceman_operation.go
+++ b/google/serviceman_operation.go
@@ -40,7 +40,7 @@ func (w *ServiceManagementOperationWaiter) Conf() *resource.StateChangeConf {
 }
 
 func serviceManagementOperationWait(config *Config, op *servicemanagement.Operation, activity string) error {
-	return serviceManagementOperationWaitTime(config, op, activity, 4)
+	return serviceManagementOperationWaitTime(config, op, activity, 10)
 }
 
 func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Operation, activity string, timeoutMin int) error {

--- a/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "google"
+page_title: "Google: google_compute_shared_vpc_host_project"
+sidebar_current: "docs-google-compute-shared-vpc-host-project"
+description: |-
+ Allows enablig and disabling Shared VPC for the host Google Cloud Platform project.
+---
+
+# google\_compute\_shared\_vpc\_host\_project
+
+Allows enablig and disabling Shared VPC for the host Google Cloud Platform project. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/shared-vpc)
+and
+[API](https://cloud.google.com/compute/docs/reference/latest/projects).
+
+## Example Usage
+
+```hcl
+resource "google_compute_shared_vpc_host_project" "host" {
+  project = "your-host-project-id"
+}
+
+resource "google_compute_shared_vpc_service_project" "service1" {
+  project    = "your-service-project-id-1"
+  // The host project must enable shared VPC first
+  depends_on = ["google_compute_shared_vpc_host_project.host"]
+}
+
+resource "google_compute_shared_vpc_service_project" "service2" {
+  project    = "your-service-project-id-2"
+  // The host project must enable shared VPC first
+  depends_on = ["google_compute_shared_vpc_host_project.host"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host_project` - (Required) The host project ID.
+
+* `service_project` - (Required) The service project ID.

--- a/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -3,12 +3,12 @@ layout: "google"
 page_title: "Google: google_compute_shared_vpc_host_project"
 sidebar_current: "docs-google-compute-shared-vpc-host-project"
 description: |-
- Allows enablig and disabling Shared VPC for the host Google Cloud Platform project.
+ Allows enabling and disabling Shared VPC for the host Google Cloud Platform project.
 ---
 
 # google\_compute\_shared\_vpc\_host\_project
 
-Allows enablig and disabling Shared VPC for the host Google Cloud Platform project. For more information see
+Allows enabling and disabling Shared VPC for the host Google Cloud Platform project. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/shared-vpc)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/projects).

--- a/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -1,0 +1,28 @@
+---
+layout: "google"
+page_title: "Google: google_compute_shared_vpc_service_project"
+sidebar_current: "docs-google-compute-shared-vpc-service-project"
+description: |-
+ Allows enablig and disabling Shared VPC for a service Google Cloud Platform project.
+---
+
+# google\_compute\_shared\_vpc\_service\_project
+
+Allows enablig and disabling Shared VPC for a service Google Cloud Platform project. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/shared-vpc)
+and
+[API](https://cloud.google.com/compute/docs/reference/latest/projects).
+
+## Example Usage
+
+```hcl
+resource "google_compute_shared_vpc_host_project" "host" {
+  project     = "your-project-id"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The host project ID.

--- a/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -3,12 +3,12 @@ layout: "google"
 page_title: "Google: google_compute_shared_vpc_service_project"
 sidebar_current: "docs-google-compute-shared-vpc-service-project"
 description: |-
- Allows enablig and disabling Shared VPC for a service Google Cloud Platform project.
+ Allows enabling and disabling Shared VPC for a service Google Cloud Platform project.
 ---
 
 # google\_compute\_shared\_vpc\_service\_project
 
-Allows enablig and disabling Shared VPC for a service Google Cloud Platform project. For more information see
+Allows enabling and disabling Shared VPC for a service Google Cloud Platform project. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/shared-vpc)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/projects).

--- a/website/google.erb
+++ b/website/google.erb
@@ -206,6 +206,14 @@
       <a href="/docs/providers/google/r/compute_router_peer.html">google_compute_router_peer</a>
       </li>
 
+      <li<%= sidebar_current("docs-google-compute-shared-vpc-host-project") %>>
+      <a href="/docs/providers/google/r/compute_shared_vpc_host_project.html">google_compute_shared_vpc_host_project</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-compute-shared-vpc-service-project") %>>
+      <a href="/docs/providers/google/r/compute_shared_vpc_service_project.html">google_compute_shared_vpc_service_project</a>
+      </li>
+
       <li<%= sidebar_current("docs-google-compute-snapshot") %>>
 			<a href="/docs/providers/google/r/compute_snapshot.html">google_compute_snapshot</a>
 			</li>


### PR DESCRIPTION
Fixes #452 

Introduced two new sources:
* `google_compute_shared_vpc_host_project`
* `google_compute_shared_vpc_service_project`

```sh
TF_ACC=1 go test ./google -v -run TestAccComputeSharedVpc_basic -timeout 120m
=== RUN   TestAccComputeSharedVpc_basic
--- PASS: TestAccComputeSharedVpc_basic (176.18s)
PASS
```