### PR TITLE
Change group back to Optional in `google_compute_backend_service`

### DIFF
--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -342,6 +342,7 @@ func expandBackendService(d *schema.ResourceData) (*compute.BackendService, erro
 		HealthChecks: healthChecks,
 	}
 
+	var err error
 	if v, ok := d.GetOk("backend"); ok {
 		service.Backends, err = expandBackends(v.(*schema.Set).List())
 		if err != nil {

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 
@@ -44,7 +45,7 @@ func resourceComputeBackendService() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"group": &schema.Schema{
 							Type:             schema.TypeString,
-							Required:         true,
+							Optional:         true,
 							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 						"balancing_mode": &schema.Schema{
@@ -150,7 +151,10 @@ func resourceComputeBackendService() *schema.Resource {
 func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	service := expandBackendService(d)
+	service, err := expandBackendService(d)
+	if err != nil {
+		return err
+	}
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -159,7 +163,7 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Creating new Backend Service: %#v", service)
 	op, err := config.clientCompute.BackendServices.Insert(
-		project, &service).Do()
+		project, service).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating backend service: %s", err)
 	}
@@ -214,7 +218,10 @@ func resourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{})
 func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	service := expandBackendService(d)
+	service, err := expandBackendService(d)
+	if err != nil {
+		return err
+	}
 	service.Fingerprint = d.Get("fingerprint").(string)
 
 	project, err := getProject(d, config)
@@ -224,7 +231,7 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Updating existing Backend Service %q: %#v", d.Id(), service)
 	op, err := config.clientCompute.BackendServices.Update(
-		project, d.Id(), &service).Do()
+		project, d.Id(), service).Do()
 	if err != nil {
 		return fmt.Errorf("Error updating backend service: %s", err)
 	}
@@ -263,14 +270,19 @@ func resourceComputeBackendServiceDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func expandBackends(configured []interface{}) []*compute.Backend {
+func expandBackends(configured []interface{}) ([]*compute.Backend, error) {
 	backends := make([]*compute.Backend, 0, len(configured))
 
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
 
+		g, ok := data["group"]
+		if !ok {
+			return nil, errors.New("google_compute_backend_service.backend.group must be set")
+		}
+
 		b := compute.Backend{
-			Group: data["group"].(string),
+			Group: g.(string),
 		}
 
 		if v, ok := data["balancing_mode"]; ok {
@@ -295,7 +307,7 @@ func expandBackends(configured []interface{}) []*compute.Backend {
 		backends = append(backends, &b)
 	}
 
-	return backends
+	return backends, nil
 }
 
 func flattenBackends(backends []*compute.Backend) []map[string]interface{} {
@@ -318,20 +330,23 @@ func flattenBackends(backends []*compute.Backend) []map[string]interface{} {
 	return result
 }
 
-func expandBackendService(d *schema.ResourceData) compute.BackendService {
+func expandBackendService(d *schema.ResourceData) (*compute.BackendService, error) {
 	hc := d.Get("health_checks").(*schema.Set).List()
 	healthChecks := make([]string, 0, len(hc))
 	for _, v := range hc {
 		healthChecks = append(healthChecks, v.(string))
 	}
 
-	service := compute.BackendService{
+	service := &compute.BackendService{
 		Name:         d.Get("name").(string),
 		HealthChecks: healthChecks,
 	}
 
 	if v, ok := d.GetOk("backend"); ok {
-		service.Backends = expandBackends(v.(*schema.Set).List())
+		service.Backends, err = expandBackends(v.(*schema.Set).List())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -365,7 +380,7 @@ func expandBackendService(d *schema.ResourceData) compute.BackendService {
 
 	service.ConnectionDraining = connectionDraining
 
-	return service
+	return service, nil
 }
 
 func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -122,7 +122,10 @@ func resourceComputeRegionBackendServiceCreate(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("backend"); ok {
-		service.Backends = expandBackends(v.(*schema.Set).List())
+		service.Backends, err = expandBackends(v.(*schema.Set).List())
+		if err != nil {
+			return err
+		}
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -239,7 +242,10 @@ func resourceComputeRegionBackendServiceUpdate(d *schema.ResourceData, meta inte
 
 	// Optional things
 	if v, ok := d.GetOk("backend"); ok {
-		service.Backends = expandBackends(v.(*schema.Set).List())
+		service.Backends, err = expandBackends(v.(*schema.Set).List())
+		if err != nil {
+			return err
+		}
 	}
 	if v, ok := d.GetOk("description"); ok {
 		service.Description = v.(string)

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -121,6 +121,7 @@ func resourceComputeRegionBackendServiceCreate(d *schema.ResourceData, meta inte
 		LoadBalancingScheme: "INTERNAL",
 	}
 
+	var err error
 	if v, ok := d.GetOk("backend"); ok {
 		service.Backends, err = expandBackends(v.(*schema.Set).List())
 		if err != nil {


### PR DESCRIPTION
#522 changed group to Required, since it would fail at apply-time anyway if it isn't set. However, this actually breaks our published modules (https://github.com/hashicorp/terraform/issues/16306). To avoid that breakage for the next release, I changed it back to Optional and while I was there, added some extra checks to ensure it's actually set so it fails with an actual error message instead of a panic.

```
$ make testacc TEST=./google TESTARGS='-run=TestAccComputeBackendService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeBackendService -timeout 120m
=== RUN   TestAccComputeBackendService_importBasic
--- PASS: TestAccComputeBackendService_importBasic (44.82s)
=== RUN   TestAccComputeBackendService_basic
--- PASS: TestAccComputeBackendService_basic (66.33s)
=== RUN   TestAccComputeBackendService_withBackend
--- PASS: TestAccComputeBackendService_withBackend (91.32s)
=== RUN   TestAccComputeBackendService_withBackendAndUpdate
--- PASS: TestAccComputeBackendService_withBackendAndUpdate (113.24s)
=== RUN   TestAccComputeBackendService_updatePreservesOptionalParameters
--- PASS: TestAccComputeBackendService_updatePreservesOptionalParameters (54.94s)
=== RUN   TestAccComputeBackendService_withConnectionDraining
--- PASS: TestAccComputeBackendService_withConnectionDraining (43.62s)
=== RUN   TestAccComputeBackendService_withConnectionDrainingAndUpdate
--- PASS: TestAccComputeBackendService_withConnectionDrainingAndUpdate (55.09s)
=== RUN   TestAccComputeBackendService_withHttpsHealthCheck
--- PASS: TestAccComputeBackendService_withHttpsHealthCheck (43.17s)
=== RUN   TestAccComputeBackendService_withCDNEnabled
--- PASS: TestAccComputeBackendService_withCDNEnabled (43.51s)
=== RUN   TestAccComputeBackendService_withSessionAffinity
--- PASS: TestAccComputeBackendService_withSessionAffinity (55.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	611.229s
```