### PR TITLE
Fix cluster version upgrades

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -312,16 +312,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.InitialClusterVersion = v.(string)
 	}
 
+	// Only allow setting node_version on create if it's set to the equivalent master version,
+	// since `InitialClusterVersion` only accepts valid master-style versions.
 	if v, ok := d.GetOk("node_version"); ok {
-		if cluster.InitialClusterVersion != "" {
-			// ignore -gke.X suffix for now. if it becomes a problem later, we can fix it.
-			mv := strings.Split(cluster.InitialClusterVersion, "-")[0]
-			nv := strings.Split(v.(string), "-")[0]
-			if mv != nv {
-				return fmt.Errorf("node_version and min_master_version must be set to equivalent values on create")
-			}
-		} else {
-			cluster.InitialClusterVersion = v.(string)
+		// ignore -gke.X suffix for now. if it becomes a problem later, we can fix it.
+		mv := strings.Split(cluster.InitialClusterVersion, "-")[0]
+		nv := strings.Split(v.(string), "-")[0]
+		if mv != nv {
+			return fmt.Errorf("node_version and min_master_version must be set to equivalent values on create")
 		}
 	}
 

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -843,7 +843,7 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.2}"
 	initial_node_count = 1
 
 	master_auth {
@@ -862,8 +862,8 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
-	node_version = "${data.google_container_engine_versions.central1a.latest_node_version}"
+	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	node_version = "${data.google_container_engine_versions.central1a.valid_node_versions.1}"
 	initial_node_count = 1
 
 	master_auth {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -824,7 +824,7 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
+	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 	initial_node_count = 1
 
 	master_auth {
@@ -843,7 +843,7 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
+	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
 	initial_node_count = 1
 
 	master_auth {
@@ -862,7 +862,7 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
+	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 	node_version = "${data.google_container_engine_versions.central1a.latest_node_version}"
 	initial_node_count = 1
 

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -13,10 +13,6 @@ Creates a GKE cluster. For more information see
 and
 [API](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters).
 
-!> **Warning:** Due to limitations of the API, all arguments except
-`node_version` are non-updateable. Changing any will cause recreation of the
-whole cluster!
-
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
@@ -84,6 +80,12 @@ resource "google_container_cluster" "primary" {
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com` and
     `none`. Defaults to `logging.googleapis.com`
+
+* `min_master_version` - (Optional) The minimum version of the master. GKE
+    will auto-update the master to new versions, so this does not guarantee the
+    current master version--use the read-only `master_version` field to obtain that.
+    If unset, the cluster's version will be set by GKE to the version of the most recent
+    official release (which is not necessarily the latest version).
 
 * `monitoring_service` - (Optional) The monitoring service that the cluster
     should write metrics to. Available options include
@@ -208,6 +210,10 @@ exported:
 
 * `master_auth.cluster_ca_certificate` - Base64 encoded public certificate
     that is the root of trust for the cluster
+
+* `master_version` - The current version of the master in the cluster. This may
+    be different than the `min_master_version` set in the config if the master
+    has been updated by GKE.
 
 <a id="timeouts"></a>
 ## Timeouts


### PR DESCRIPTION
This PR does two things (each in a separate commit):
1. Adds a retry when reading the cluster to make sure it's in the RUNNING state. This (sort of) solves the issue of trying to upgrade a cluster while it's already upgrading. Though it would make sense to have the retry be on the upgrade, I don't want users to get confused when they run plan, see a certain version, and then run upgrade and find out they were at a different version. Let me know your thoughts on whether this should actually be in read or in update (or in both).

2. Adds a new field, `min_master_version` and sets `master_version` to computed. As per discussions with @rosbo and @paddycarver, having just one `master_version` field doesn't work when the master gets upgraded automatically. This allows the users to set the minimum master version while also using the current master version for interpolation in other resources.

@paddycarver is in charge of running tests and adding documentation because I have to go catch my bus :)