### PR TITLE
feat: allow subnet link lookup via field, project and region

### DIFF
--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -146,6 +146,12 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 		ports = append(ports, v.(string))
 	}
 
+	subnetwork, err := getSubnetworkLinkWithRegionAndProject(d, config, region, project)
+
+	if err != nil {
+		return err
+	}
+
 	frule := &compute.ForwardingRule{
 		BackendService:      d.Get("backend_service").(string),
 		IPAddress:           d.Get("ip_address").(string),
@@ -156,7 +162,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 		Network:             network.RelativeLink(),
 		PortRange:           d.Get("port_range").(string),
 		Ports:               ports,
-		Subnetwork:          d.Get("subnetwork").(string),
+		Subnetwork:          subnetwork,
 		Target:              d.Get("target").(string),
 	}
 

--- a/google/utils.go
+++ b/google/utils.go
@@ -193,6 +193,26 @@ func getSubnetworkLink(d *schema.ResourceData, config *Config, subnetworkField, 
 	return "", nil
 }
 
+func getSubnetworkLinkWithRegionAndProject(d *schema.ResourceData, config *Config, region string, project string) (string, error) {
+	if v, ok := d.GetOk("subnetwork"); ok {
+		subnetwork := v.(string)
+		r := regexp.MustCompile(SubnetworkLinkRegex)
+		if r.MatchString(subnetwork) {
+			return subnetwork, nil
+		}
+
+		subnet, err := config.clientCompute.Subnetworks.Get(project, region, subnetwork).Do()
+		if err != nil {
+			return "", fmt.Errorf(
+				"Error referencing subnetwork '%s' in region '%s': %s",
+				subnetwork, region, err)
+		}
+
+		return subnet.SelfLink, nil
+	}
+	return "", nil
+}
+
 // getNetworkName reads the "network" field from the given resource data and if the value:
 // - is a resource URL, extracts the network name from the URL and returns it
 // - is the network name only (i.e not prefixed with http://www.googleapis.com/compute/...), is returned unchanged


### PR DESCRIPTION
`resource_compute_forwarding_rule` doesn't support a string configuration, its not really ideal as Id like to have the network layer of Terraform separate.

I've functionally tested this and its working. I feel like long term `getSubnetworkLink` might need refactoring because it assumes Zonal configuration to get the region rather than just having region as an argument.

It seems like `getSubnetworkLink` should actually be called something else and more specific to its use case.. for now though Ive done this however

Without this change you get the following error.
```bash
google_compute_forwarding_rule.default: Error creating ForwardingRule: googleapi: Error 400: Invalid value for field 'resource.subnetwork': 'xxxx'. The URL is malformed., invalid
```