### PR TITLE
Give addresses beta support, add internal addresses

### DIFF
--- a/google/import_compute_address_test.go
+++ b/google/import_compute_address_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -17,7 +18,7 @@ func TestAccComputeAddress_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeAddress_basic,
+				Config: testAccComputeAddress_basic(acctest.RandString(10)),
 			},
 
 			resource.TestStep{
@@ -40,7 +41,7 @@ func TestAccComputeAddress_importInternal(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeAddress_internal,
+				Config: testAccComputeAddress_internal(acctest.RandString(10)),
 			},
 
 			resource.TestStep{

--- a/google/import_compute_address_test.go
+++ b/google/import_compute_address_test.go
@@ -30,6 +30,9 @@ func TestAccComputeAddress_importBasic(t *testing.T) {
 	})
 }
 
+/* Disabled pending support for importing beta resources. See:
+   https://github.com/terraform-providers/terraform-provider-google/issues/694
+
 func TestAccComputeAddress_importInternal(t *testing.T) {
 	t.Parallel()
 
@@ -62,3 +65,5 @@ func TestAccComputeAddress_importInternal(t *testing.T) {
 		},
 	})
 }
+
+*/

--- a/google/import_compute_address_test.go
+++ b/google/import_compute_address_test.go
@@ -33,8 +33,6 @@ func TestAccComputeAddress_importBasic(t *testing.T) {
 func TestAccComputeAddress_importInternal(t *testing.T) {
 	t.Parallel()
 
-	resourceName := "google_compute_address.internal_with_subnet"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -45,7 +43,19 @@ func TestAccComputeAddress_importInternal(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "google_compute_address.internal",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			resource.TestStep{
+				ResourceName:      "google_compute_address.internal_with_subnet",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			resource.TestStep{
+				ResourceName:      "google_compute_address.internal_with_subnet_and_address",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/google/import_compute_address_test.go
+++ b/google/import_compute_address_test.go
@@ -28,3 +28,26 @@ func TestAccComputeAddress_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeAddress_importInternal(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "google_compute_address.internal_with_subnet"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeAddressDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeAddress_internal,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -17,6 +17,7 @@ var (
 	computeAddressLinkRegex  = regexp.MustCompile("projects/(.+)/regions/(.+)/addresses/(.+)$")
 	AddressBaseApiVersion    = v1
 	AddressVersionedFeatures = []Feature{
+		{Version: v0beta, Item: "address"},
 		{Version: v0beta, Item: "address_type"},
 		{Version: v0beta, Item: "subnetwork"},
 	}
@@ -60,8 +61,12 @@ func resourceComputeAddress() *schema.Resource {
 				DiffSuppressFunc: linkDiffSuppress,
 			},
 
+			// address will be computed unless it is specified explicitly.
+			// address may only be specified for the INTERNAL address_type.
 			"address": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
 
@@ -105,6 +110,10 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 		Name:        d.Get("name").(string),
 		AddressType: d.Get("address_type").(string),
 		Subnetwork:  d.Get("subnetwork").(string),
+	}
+
+	if desired, ok := d.GetOk("address"); ok {
+		v0BetaAddress.Address = desired.(string)
 	}
 
 	var op interface{}

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -12,13 +12,18 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+const (
+	addressTypeExternal = "EXTERNAL"
+	addressTypeInternal = "INTERNAL"
+)
+
 var (
 	computeAddressIdTemplate = "projects/%s/regions/%s/addresses/%s"
 	computeAddressLinkRegex  = regexp.MustCompile("projects/(.+)/regions/(.+)/addresses/(.+)$")
 	AddressBaseApiVersion    = v1
 	AddressVersionedFeatures = []Feature{
 		{Version: v0beta, Item: "address"},
-		{Version: v0beta, Item: "address_type"},
+		{Version: v0beta, Item: "address_type", DefaultValue: addressTypeExternal},
 		{Version: v0beta, Item: "subnetwork"},
 	}
 )
@@ -48,9 +53,9 @@ func resourceComputeAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "EXTERNAL",
+				Default:  addressTypeExternal,
 				ValidateFunc: validation.StringInSlice(
-					[]string{"INTERNAL", "EXTERNAL"}, false),
+					[]string{addressTypeInternal, addressTypeExternal}, false),
 			},
 
 			"subnetwork": &schema.Schema{
@@ -187,7 +192,7 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	// been converted to v0beta, and thus an EXTERNAL address.
 	d.Set("address_type", addr.AddressType)
 	if addr.AddressType == "" {
-		d.Set("address_type", "EXTERNAL")
+		d.Set("address_type", addressTypeExternal)
 	}
 	d.Set("subnetwork", ConvertSelfLinkToV1(addr.Subnetwork))
 	d.Set("address", addr.Address)

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -22,7 +22,6 @@ var (
 	computeAddressLinkRegex  = regexp.MustCompile("projects/(.+)/regions/(.+)/addresses/(.+)$")
 	AddressBaseApiVersion    = v1
 	AddressVersionedFeatures = []Feature{
-		{Version: v0beta, Item: "address"},
 		{Version: v0beta, Item: "address_type", DefaultValue: addressTypeExternal},
 		{Version: v0beta, Item: "subnetwork"},
 	}
@@ -247,10 +246,6 @@ func resourceComputeAddressImportState(d *schema.ResourceData, meta interface{})
 	}
 
 	d.SetId(addressId.canonicalId())
-
-	if err := resourceComputeAddressRead(d, meta); err != nil {
-		return nil, err
-	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -248,6 +248,10 @@ func resourceComputeAddressImportState(d *schema.ResourceData, meta interface{})
 
 	d.SetId(addressId.canonicalId())
 
+	if err := resourceComputeAddressRead(d, meta); err != nil {
+		return nil, err
+	}
+
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -181,7 +181,8 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("address", addr.Address)
-	d.Set("self_link", addr.SelfLink)
+	d.Set("address_type", addr.AddressType)
+	d.Set("self_link", ConvertSelfLinkToV1(addr.SelfLink))
 	d.Set("name", addr.Name)
 	d.Set("region", GetResourceNameFromSelfLink(addr.Region))
 

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -86,7 +86,7 @@ func TestAccComputeAddress_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeAddress_basic,
+				Config: testAccComputeAddress_basic(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeAddressExists(
 						"google_compute_address.foobar", &addr),
@@ -105,7 +105,7 @@ func TestAccComputeAddress_internal(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeAddress_internal,
+				Config: testAccComputeAddress_internal(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeBetaAddressExists("google_compute_address.internal", &addr),
 					testAccCheckComputeBetaAddressExists("google_compute_address.internal_with_subnet", &addr),
@@ -202,14 +202,17 @@ func testAccCheckComputeBetaAddressExists(n string, addr *computeBeta.Address) r
 	}
 }
 
-var testAccComputeAddress_basic = fmt.Sprintf(`
+func testAccComputeAddress_basic(i string) string {
+	return fmt.Sprintf(`
 resource "google_compute_address" "foobar" {
 	name = "address-test-%s"
-}`, acctest.RandString(10))
+}`, i)
+}
 
-var testAccComputeAddress_internal = fmt.Sprintf(`
+func testAccComputeAddress_internal(i string) string {
+	return fmt.Sprintf(`
 resource "google_compute_address" "internal" {
-  name         = "address-test-%s"
+  name         = "address-test-internal-%s"
   address_type = "INTERNAL"
   region       = "us-east1"
 }
@@ -226,7 +229,7 @@ resource "google_compute_subnetwork" "foo" {
 }
 
 resource "google_compute_address" "internal_with_subnet" {
-  name         = "address-test-%s"
+  name         = "address-test-internal-with-subnet-%s"
   subnetwork   = "${google_compute_subnetwork.foo.self_link}"
   address_type = "INTERNAL"
   region       = "us-east1"
@@ -235,15 +238,16 @@ resource "google_compute_address" "internal_with_subnet" {
 // We can't test the address alone, because we don't know what IP range the
 // default subnetwork uses.
 resource "google_compute_address" "internal_with_subnet_and_address" {
-  name         = "address-test-%s"
+  name         = "address-test-internal-with-subnet-and-address-%s"
   subnetwork   = "${google_compute_subnetwork.foo.self_link}"
   address_type = "INTERNAL"
   address      = "10.0.42.42"
   region       = "us-east1"
 }`,
-	acctest.RandString(10), // google_compute_address.internal name
-	acctest.RandString(10), // google_compute_network.default name
-	acctest.RandString(10), // google_compute_subnetwork.foo name
-	acctest.RandString(10), // google_compute_address.internal_with_subnet_name
-	acctest.RandString(10), // google_compute_address.internal_with_subnet_and_address name
-)
+		i, // google_compute_address.internal name
+		i, // google_compute_network.default name
+		i, // google_compute_subnetwork.foo name
+		i, // google_compute_address.internal_with_subnet_name
+		i, // google_compute_address.internal_with_subnet_and_address name
+	)
+}

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -9,8 +9,11 @@ description: |-
 # google\_compute\_address
 
 Creates a static IP address resource for Google Compute Engine. For more information see
-[the official documentation](https://cloud.google.com/compute/docs/instances-and-network) and
-[API](https://cloud.google.com/compute/docs/reference/latest/addresses).
+the official documentation for
+[external](https://cloud.google.com/compute/docs/instances-and-network) and
+[internal](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
+static IP reservations, as well as the
+[API](https://cloud.google.com/compute/docs/reference/beta/addresses/insert).
 
 
 ## Example Usage
@@ -35,6 +38,14 @@ The following arguments are supported:
 
 * `region` - (Optional) The Region in which the created address should reside.
     If it is not provided, the provider region is used.
+
+* `address_type` - (Optional) The Address Type that should be configured.
+    Specify INTERNAL to reserve an internal static IP address EXTERNAL to
+    specify an external static IP address. Defaults to EXTERNAL if omitted.
+
+* `subnetwork` - (Optional) The self link URI of the subnetwork in which to
+    create the address. A subnetwork may only be specified for INTERNAL
+    addresses.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -45,7 +45,11 @@ The following arguments are supported:
 
 * `subnetwork` - (Optional) The self link URI of the subnetwork in which to
     create the address. A subnetwork may only be specified for INTERNAL
-    addresses.
+    address types.
+
+* `address` - (Optional) The IP address to reserve. An address may only be
+    specified for INTERNAL address types. The IP address must be inside the
+    specified subnetwork, if any.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR (hopefully) ties together the existing work in #488. Specifically it:

* Adds support for specifying the internal IP address you wish to reserve per #525 
* Adds documentation for all the new knobs
* Addresses some PR feedback that came in after #488 was approved.
* Resolves some merge conflicts

I haven't contributed to Terraform before, but I'm pretty sure this works as expected:
```bash
$ GOOGLE_XPN_HOST_PROJECT=REDACTED \
   GOOGLE_PROJECT=REDACTED \
   GOOGLE_REGION=us-central1 \
   GOOGLE_USE_DEFAULT_CREDENTIALS=1 \
   TF_ACC=1 \
   go test -v . -run "^TestAccComputeAddress_internal"
=== RUN   TestAccComputeAddress_internal
--- PASS: TestAccComputeAddress_internal (114.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 114.153s
```