### PR TITLE
post-migration disk cleanup

### DIFF
--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -244,7 +244,7 @@ func TestAccComputeInstance_attachedDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceDisk(&instance, diskName, false, true),
+					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
 		},

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -3,7 +3,6 @@ package google
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -295,24 +294,6 @@ func TestAccComputeInstance_bootDisk_type(t *testing.T) {
 						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceBootDiskType(instanceName, diskType),
 				),
-			},
-		},
-	})
-}
-
-func TestAccComputeInstance_noDisk(t *testing.T) {
-	t.Parallel()
-
-	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeInstanceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config:      testAccComputeInstance_noDisk(instanceName),
-				ExpectError: regexp.MustCompile("At least one disk, attached_disk, or boot_disk must be set"),
 			},
 		},
 	})
@@ -1006,9 +987,6 @@ func testAccCheckComputeInstanceDiskEncryptionKey(n string, instance *compute.In
 		for i, disk := range instance.Disks {
 			if disk.Boot {
 				attr := rs.Primary.Attributes["boot_disk.0.disk_encryption_key_sha256"]
-				if attr == "" {
-					attr = rs.Primary.Attributes[fmt.Sprintf("disk.%d.disk_encryption_key_sha256", i)]
-				}
 				if attr != bootDiskEncryptionKey {
 					return fmt.Errorf("Boot disk has wrong encryption key in state.\nExpected: %s\nActual: %s", bootDiskEncryptionKey, attr)
 				}
@@ -1566,6 +1544,12 @@ resource "google_compute_instance" "foobar" {
 	machine_type = "n1-standard-1"
 	zone         = "us-central1-a"
 
+	boot_disk {
+		initialize_params {
+			image = "debian-8-jessie-v20160803"
+		}
+	}
+
 	attached_disk {
 		source = "${google_compute_disk.foobar.self_link}"
 	}
@@ -1624,24 +1608,6 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, instance, diskType)
-}
-
-func testAccComputeInstance_noDisk(instance string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance" "foobar" {
-	name         = "%s"
-	machine_type = "n1-standard-1"
-	zone         = "us-central1-a"
-
-	network_interface {
-		network = "default"
-	}
-
-	metadata {
-		foo = "bar"
-	}
-}
-`, instance)
 }
 
 func testAccComputeInstance_scratchDisk(instance string) string {


### PR DESCRIPTION
* Makes `boot_disk` required
* Removes all references to the old `disk` field outside the schema
* Removes some checks regarding the expected number of disks

Fixes #355 
Fixes #141