### PR TITLE
Expand docs for auto_healing_policies for Instance Group Managers

### DIFF
--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -18,8 +18,21 @@ and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupMa
 ## Example Usage
 
 ```hcl
+resource "google_compute_health_check" "autohealing" {
+  name                = "autohealing-health-check"
+  check_interval_sec  = 5
+  timeout_sec         = 5
+  healthy_threshold   = 2
+  unhealthy_threshold = 10                         # 50 seconds
+
+  http_health_check {
+    request_path = "/healthz"
+    port         = "8080"
+  }
+}
+
 resource "google_compute_instance_group_manager" "appserver" {
-  name        = "appserver-igm"
+  name = "appserver-igm"
 
   base_instance_name = "app"
   instance_template  = "${google_compute_instance_template.appserver.self_link}"
@@ -32,6 +45,11 @@ resource "google_compute_instance_group_manager" "appserver" {
   named_port {
     name = "customHTTP"
     port = 8888
+  }
+
+  auto_healing_policies {
+    health_check      = "${google_compute_health_check.autohealing.self_link}"
+    initial_delay_sec = 300
   }
 }
 ```
@@ -86,7 +104,7 @@ The following arguments are supported:
 ---
 
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
-group. You can specify only one value. Structure is documented below.
+group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
 
 The `named_port` block supports: (Include a `named_port` block for each named-port required).
 
@@ -96,7 +114,7 @@ The `named_port` block supports: (Include a `named_port` block for each named-po
 
 The `auto_healing_policies` block supports:
 
-* `health_check` - (Required) The health check that signals autohealing.
+* `health_check` - (Required) The health check resource that signals autohealing.
 
 * `initial_delay_sec` - (Required) The number of seconds that the managed instance group waits before
  it applies autohealing policies to new instances or recently recreated instances. Between 0 and 3600.


### PR DESCRIPTION
This should make it clearer what is required for setting up `auto_healing_policies`, especially that the `health_check` URL is a link to a resource, not to the health check URL directly.