### PR TITLE
Update docs to mark compute_http(s)_health_check as legacy resources

### DIFF
--- a/website/docs/r/compute_http_health_check.html.markdown
+++ b/website/docs/r/compute_http_health_check.html.markdown
@@ -11,9 +11,11 @@ description: |-
 Manages an HTTP health check within GCE. This is used to monitor instances
 behind load balancers. Timeouts or HTTP errors cause the instance to be
 removed from the pool. For more information, see [the official
-documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks)
+documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/httpHealthChecks).
+
+~> **Note:** HttpHealthChecks/HTTPSHealthChecks are legacy health checks. The newer [google_compute_health_check](/docs/providers/google/r/compute_health_check.html) should be preferred for all uses except except [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/) which still require the legacy HttpHealthChecks.
 
 ## Example Usage
 

--- a/website/docs/r/compute_https_health_check.html.markdown
+++ b/website/docs/r/compute_https_health_check.html.markdown
@@ -11,9 +11,11 @@ description: |-
 Manages an HTTPS health check within GCE. This is used to monitor instances
 behind load balancers. Timeouts or HTTPS errors cause the instance to be
 removed from the pool. For more information, see [the official
-documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks)
+documentation](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
 and
 [API](https://cloud.google.com/compute/docs/reference/latest/httpsHealthChecks).
+
+~> **Note:** HTTPSHealthChecks/HttpHealthChecks are legacy health checks. The newer [google_compute_health_check](/docs/providers/google/r/compute_health_check.html) should be preferred for all uses except except [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/) which still require the legacy HttpHealthChecks.
 
 ## Example Usage
 


### PR DESCRIPTION
See https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks
for more info.