### PR TITLE
Add support for CPU Platform in `google_container_node_pool`

### DIFF
--- a/google/node_config.go
+++ b/google/node_config.go
@@ -91,6 +91,12 @@ var schemaNodeConfig = &schema.Schema{
 				ForceNew: true,
 				Default:  false,
 			},
+
+			"min_cpu_platform": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	},
 }
@@ -158,6 +164,10 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 	// Preemptible Is Optional+Default, so it always has a value
 	nc.Preemptible = nodeConfig["preemptible"].(bool)
 
+	if v, ok := nodeConfig["min_cpu_platform"]; ok {
+		nc.MinCpuPlatform = v.(string)
+	}
+
 	return nc
 }
 
@@ -169,15 +179,16 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 	}
 
 	config = append(config, map[string]interface{}{
-		"machine_type":    c.MachineType,
-		"disk_size_gb":    c.DiskSizeGb,
-		"local_ssd_count": c.LocalSsdCount,
-		"service_account": c.ServiceAccount,
-		"metadata":        c.Metadata,
-		"image_type":      c.ImageType,
-		"labels":          c.Labels,
-		"tags":            c.Tags,
-		"preemptible":     c.Preemptible,
+		"machine_type":     c.MachineType,
+		"disk_size_gb":     c.DiskSizeGb,
+		"local_ssd_count":  c.LocalSsdCount,
+		"service_account":  c.ServiceAccount,
+		"metadata":         c.Metadata,
+		"image_type":       c.ImageType,
+		"labels":           c.Labels,
+		"tags":             c.Tags,
+		"preemptible":      c.Preemptible,
+		"min_cpu_platform": c.MinCpuPlatform,
 	})
 
 	if len(c.OauthScopes) > 0 {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -591,6 +591,7 @@ func testAccCheckContainerCluster(n string) resource.TestCheckFunc {
 			{"node_config.0.labels", cluster.NodeConfig.Labels},
 			{"node_config.0.tags", cluster.NodeConfig.Tags},
 			{"node_config.0.preemptible", cluster.NodeConfig.Preemptible},
+			{"node_config.0.min_cpu_platform", cluster.NodeConfig.MinCpuPlatform},
 			{"node_version", cluster.CurrentNodeVersion},
 		}
 
@@ -1006,6 +1007,7 @@ resource "google_container_cluster" "with_node_config" {
 		}
 		tags = ["foo", "bar"]
 		preemptible = true
+		min_cpu_platform = "Intel Broadwell"
 	}
 }`, acctest.RandString(10))
 

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -238,6 +238,7 @@ func testAccCheckContainerNodePoolMatches(n string) resource.TestCheckFunc {
 			{"node_config.0.labels", nodepool.Config.Labels},
 			{"node_config.0.tags", nodepool.Config.Tags},
 			{"node_config.0.preemptible", nodepool.Config.Preemptible},
+			{"node_config.0.min_cpu_platform", nodepool.Config.MinCpuPlatform},
 		}
 
 		for _, attrs := range nodepoolTests {
@@ -517,6 +518,7 @@ resource "google_container_node_pool" "np_with_node_config" {
 			"https://www.googleapis.com/auth/monitoring"
 		]
 		preemptible = true
+		min_cpu_platform = "Intel Broadwell"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
 

--- a/vendor/google.golang.org/api/container/v1/container-api.json
+++ b/vendor/google.golang.org/api/container/v1/container-api.json
@@ -1,24 +1,31 @@
 {
+  "batchPath": "batch",
+  "documentationLink": "https://cloud.google.com/container-engine/",
+  "revision": "20170929",
+  "id": "container:v1",
+  "title": "Google Container Engine API",
+  "discoveryVersion": "v1",
+  "ownerName": "Google",
   "resources": {
     "projects": {
       "resources": {
         "zones": {
           "methods": {
             "getServerconfig": {
-              "httpMethod": "GET",
+              "response": {
+                "$ref": "ServerConfig"
+              },
               "parameterOrder": [
                 "projectId",
                 "zone"
               ],
-              "response": {
-                "$ref": "ServerConfig"
-              },
+              "httpMethod": "GET",
               "parameters": {
                 "projectId": {
+                  "location": "path",
                   "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
                   "type": "string",
-                  "required": true,
-                  "location": "path"
+                  "required": true
                 },
                 "zone": {
                   "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available)\nto return operations for.",
@@ -31,66 +38,38 @@
                 "https://www.googleapis.com/auth/cloud-platform"
               ],
               "flatPath": "v1/projects/{projectId}/zones/{zone}/serverconfig",
-              "path": "v1/projects/{projectId}/zones/{zone}/serverconfig",
               "id": "container.projects.zones.getServerconfig",
+              "path": "v1/projects/{projectId}/zones/{zone}/serverconfig",
               "description": "Returns configuration info about the Container Engine service."
             }
           },
           "resources": {
-            "clusters": {
+            "operations": {
               "methods": {
-                "logging": {
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/logging",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/logging",
-                  "id": "container.projects.zones.clusters.logging",
+                "cancel": {
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel",
+                  "id": "container.projects.zones.operations.cancel",
+                  "path": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel",
+                  "description": "Cancels the specified operation.",
                   "request": {
-                    "$ref": "SetLoggingServiceRequest"
+                    "$ref": "CancelOperationRequest"
                   },
-                  "description": "Sets the logging service of a specific cluster.",
-                  "httpMethod": "POST",
+                  "response": {
+                    "$ref": "Empty"
+                  },
                   "parameterOrder": [
                     "projectId",
                     "zone",
-                    "clusterId"
+                    "operationId"
                   ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
+                  "httpMethod": "POST",
                   "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                    "operationId": {
+                      "location": "path",
+                      "description": "The server-assigned `name` of the operation.",
                       "type": "string",
-                      "required": true,
-                      "location": "path"
+                      "required": true
                     },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  }
-                },
-                "list": {
-                  "description": "Lists all clusters owned by a project in either the specified zone or all\nzones.",
-                  "httpMethod": "GET",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone"
-                  ],
-                  "response": {
-                    "$ref": "ListClustersResponse"
-                  },
-                  "parameters": {
                     "projectId": {
                       "location": "path",
                       "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
@@ -98,999 +77,16 @@
                       "required": true
                     },
                     "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides, or \"-\" for all zones.",
                       "type": "string",
                       "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters",
-                  "id": "container.projects.zones.clusters.list"
-                },
-                "create": {
-                  "request": {
-                    "$ref": "CreateClusterRequest"
-                  },
-                  "description": "Creates a cluster, consisting of the specified number and type of Google\nCompute Engine instances.\n\nBy default, the cluster is created in the project's\n[default network](/compute/docs/networks-and-firewalls#networks).\n\nOne firewall is added for the cluster. After cluster creation,\nthe cluster creates routes for each node to allow the containers\non that node to communicate with all other instances in the\ncluster.\n\nFinally, an entry is added to the project's global metadata indicating\nwhich CIDR range is being used by the cluster.",
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone"
-                  ],
-                  "httpMethod": "POST",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters",
-                  "id": "container.projects.zones.clusters.create",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters"
-                },
-                "resourceLabels": {
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameters": {
-                    "projectId": {
                       "location": "path",
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                      "type": "string",
-                      "required": true
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/resourceLabels",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/resourceLabels",
-                  "id": "container.projects.zones.clusters.resourceLabels",
-                  "description": "Sets labels on a cluster.",
-                  "request": {
-                    "$ref": "SetLabelsRequest"
-                  }
-                },
-                "completeIpRotation": {
-                  "request": {
-                    "$ref": "CompleteIPRotationRequest"
-                  },
-                  "description": "Completes master IP rotation.",
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "location": "path",
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                      "type": "string",
-                      "required": true
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:completeIpRotation",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:completeIpRotation",
-                  "id": "container.projects.zones.clusters.completeIpRotation"
-                },
-                "get": {
-                  "description": "Gets the details of a specific cluster.",
-                  "response": {
-                    "$ref": "Cluster"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "GET",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "location": "path",
-                      "description": "The name of the cluster to retrieve.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
-                  "id": "container.projects.zones.clusters.get",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}"
-                },
-                "legacyAbac": {
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/legacyAbac",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/legacyAbac",
-                  "id": "container.projects.zones.clusters.legacyAbac",
-                  "request": {
-                    "$ref": "SetLegacyAbacRequest"
-                  },
-                  "description": "Enables or disables the ABAC authorization mechanism on a cluster.",
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "location": "path",
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to update.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  }
-                },
-                "setNetworkPolicy": {
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setNetworkPolicy",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setNetworkPolicy",
-                  "id": "container.projects.zones.clusters.setNetworkPolicy",
-                  "request": {
-                    "$ref": "SetNetworkPolicyRequest"
-                  },
-                  "description": "Enables/Disables Network Policy for a cluster.",
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  }
-                },
-                "startIpRotation": {
-                  "description": "Start master IP rotation.",
-                  "request": {
-                    "$ref": "StartIPRotationRequest"
-                  },
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "location": "path",
-                      "description": "The name of the cluster.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:startIpRotation",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:startIpRotation",
-                  "id": "container.projects.zones.clusters.startIpRotation"
-                },
-                "addons": {
-                  "description": "Sets the addons of a specific cluster.",
-                  "request": {
-                    "$ref": "SetAddonsConfigRequest"
-                  },
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "POST",
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/addons",
-                  "id": "container.projects.zones.clusters.addons",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/addons"
-                },
-                "delete": {
-                  "description": "Deletes the cluster, including the Kubernetes endpoint and all worker\nnodes.\n\nFirewalls and routes that were configured during cluster creation\nare also deleted.\n\nOther Google Compute Engine resources that might be in use by the cluster\n(e.g. load balancer resources) will not be deleted if they weren't present\nat the initial create time.",
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "DELETE",
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to delete.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
-                  "id": "container.projects.zones.clusters.delete",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}"
-                },
-                "locations": {
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/locations",
-                  "id": "container.projects.zones.clusters.locations",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/locations",
-                  "description": "Sets the locations of a specific cluster.",
-                  "request": {
-                    "$ref": "SetLocationsRequest"
-                  },
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "POST",
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "location": "path",
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the operation resides."
                     }
                   },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
                   ]
                 },
-                "update": {
-                  "request": {
-                    "$ref": "UpdateClusterRequest"
-                  },
-                  "description": "Updates the settings of a specific cluster.",
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "PUT",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "location": "path",
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "location": "path",
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
-                  "id": "container.projects.zones.clusters.update",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}"
-                },
-                "monitoring": {
-                  "request": {
-                    "$ref": "SetMonitoringServiceRequest"
-                  },
-                  "description": "Sets the monitoring service of a specific cluster.",
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "httpMethod": "POST",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "location": "path",
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/monitoring",
-                  "id": "container.projects.zones.clusters.monitoring",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/monitoring"
-                },
-                "master": {
-                  "request": {
-                    "$ref": "UpdateMasterRequest"
-                  },
-                  "description": "Updates the master of a specific cluster.",
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "location": "path",
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/master",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/master",
-                  "id": "container.projects.zones.clusters.master"
-                },
-                "setMasterAuth": {
-                  "description": "Used to set master auth materials. Currently supports :-\nChanging the admin password of a specific cluster.\nThis can be either via password generation or explicitly set the password.",
-                  "request": {
-                    "$ref": "SetMasterAuthRequest"
-                  },
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "zone",
-                    "clusterId"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameters": {
-                    "projectId": {
-                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterId": {
-                      "description": "The name of the cluster to upgrade.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMasterAuth",
-                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMasterAuth",
-                  "id": "container.projects.zones.clusters.setMasterAuth"
-                }
-              },
-              "resources": {
-                "nodePools": {
-                  "methods": {
-                    "autoscaling": {
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/autoscaling",
-                      "id": "container.projects.zones.clusters.nodePools.autoscaling",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/autoscaling",
-                      "description": "Sets the autoscaling settings of a specific node pool.",
-                      "request": {
-                        "$ref": "SetNodePoolAutoscalingRequest"
-                      },
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "httpMethod": "POST",
-                      "parameters": {
-                        "projectId": {
-                          "location": "path",
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                          "type": "string",
-                          "required": true
-                        },
-                        "zone": {
-                          "location": "path",
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "clusterId": {
-                          "description": "The name of the cluster to upgrade.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "nodePoolId": {
-                          "description": "The name of the node pool to upgrade.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        }
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ]
-                    },
-                    "get": {
-                      "description": "Retrieves the node pool requested.",
-                      "httpMethod": "GET",
-                      "response": {
-                        "$ref": "NodePool"
-                      },
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "parameters": {
-                        "nodePoolId": {
-                          "location": "path",
-                          "description": "The name of the node pool.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "projectId": {
-                          "location": "path",
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                          "type": "string",
-                          "required": true
-                        },
-                        "zone": {
-                          "location": "path",
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "clusterId": {
-                          "description": "The name of the cluster.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        }
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
-                      "id": "container.projects.zones.clusters.nodePools.get"
-                    },
-                    "update": {
-                      "description": "Updates the version and/or image type of a specific node pool.",
-                      "request": {
-                        "$ref": "UpdateNodePoolRequest"
-                      },
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "httpMethod": "POST",
-                      "parameters": {
-                        "projectId": {
-                          "location": "path",
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                          "type": "string",
-                          "required": true
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "location": "path",
-                          "description": "The name of the cluster to upgrade.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "nodePoolId": {
-                          "description": "The name of the node pool to upgrade.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        }
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/update",
-                      "id": "container.projects.zones.clusters.nodePools.update",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/update"
-                    },
-                    "delete": {
-                      "description": "Deletes a node pool from a cluster.",
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "httpMethod": "DELETE",
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "parameters": {
-                        "projectId": {
-                          "location": "path",
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                          "type": "string",
-                          "required": true
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "location": "path",
-                          "description": "The name of the cluster.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "nodePoolId": {
-                          "location": "path",
-                          "description": "The name of the node pool to delete.",
-                          "type": "string",
-                          "required": true
-                        }
-                      },
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
-                      "id": "container.projects.zones.clusters.nodePools.delete",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}"
-                    },
-                    "setSize": {
-                      "request": {
-                        "$ref": "SetNodePoolSizeRequest"
-                      },
-                      "description": "Sets the size of a specific node pool.",
-                      "httpMethod": "POST",
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "parameters": {
-                        "nodePoolId": {
-                          "location": "path",
-                          "description": "The name of the node pool to update.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "projectId": {
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "description": "The name of the cluster to update.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        }
-                      },
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setSize",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setSize",
-                      "id": "container.projects.zones.clusters.nodePools.setSize"
-                    },
-                    "setManagement": {
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement",
-                      "id": "container.projects.zones.clusters.nodePools.setManagement",
-                      "request": {
-                        "$ref": "SetNodePoolManagementRequest"
-                      },
-                      "description": "Sets the NodeManagement options for a node pool.",
-                      "httpMethod": "POST",
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "parameters": {
-                        "projectId": {
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "description": "The name of the cluster to update.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "nodePoolId": {
-                          "location": "path",
-                          "description": "The name of the node pool to update.",
-                          "type": "string",
-                          "required": true
-                        }
-                      }
-                    },
-                    "list": {
-                      "httpMethod": "GET",
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId"
-                      ],
-                      "response": {
-                        "$ref": "ListNodePoolsResponse"
-                      },
-                      "parameters": {
-                        "projectId": {
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "location": "path",
-                          "description": "The name of the cluster.",
-                          "type": "string",
-                          "required": true
-                        }
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
-                      "id": "container.projects.zones.clusters.nodePools.list",
-                      "description": "Lists the node pools for a cluster."
-                    },
-                    "rollback": {
-                      "description": "Roll back the previously Aborted or Failed NodePool upgrade.\nThis will be an no-op if the last upgrade successfully completed.",
-                      "request": {
-                        "$ref": "RollbackNodePoolUpgradeRequest"
-                      },
-                      "httpMethod": "POST",
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId",
-                        "nodePoolId"
-                      ],
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "parameters": {
-                        "nodePoolId": {
-                          "description": "The name of the node pool to rollback.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "projectId": {
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "zone": {
-                          "location": "path",
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true
-                        },
-                        "clusterId": {
-                          "location": "path",
-                          "description": "The name of the cluster to rollback.",
-                          "type": "string",
-                          "required": true
-                        }
-                      },
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
-                      "id": "container.projects.zones.clusters.nodePools.rollback"
-                    },
-                    "create": {
-                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
-                      "id": "container.projects.zones.clusters.nodePools.create",
-                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
-                      "request": {
-                        "$ref": "CreateNodePoolRequest"
-                      },
-                      "description": "Creates a node pool for a cluster.",
-                      "response": {
-                        "$ref": "Operation"
-                      },
-                      "parameterOrder": [
-                        "projectId",
-                        "zone",
-                        "clusterId"
-                      ],
-                      "httpMethod": "POST",
-                      "scopes": [
-                        "https://www.googleapis.com/auth/cloud-platform"
-                      ],
-                      "parameters": {
-                        "projectId": {
-                          "location": "path",
-                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
-                          "type": "string",
-                          "required": true
-                        },
-                        "zone": {
-                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        },
-                        "clusterId": {
-                          "description": "The name of the cluster.",
-                          "type": "string",
-                          "required": true,
-                          "location": "path"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "operations": {
-              "methods": {
                 "get": {
                   "response": {
                     "$ref": "Operation"
@@ -1103,10 +99,10 @@
                   "httpMethod": "GET",
                   "parameters": {
                     "operationId": {
+                      "location": "path",
                       "description": "The server-assigned `name` of the operation.",
                       "type": "string",
-                      "required": true,
-                      "location": "path"
+                      "required": true
                     },
                     "projectId": {
                       "location": "path",
@@ -1115,10 +111,10 @@
                       "required": true
                     },
                     "zone": {
-                      "location": "path",
                       "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
                       "type": "string",
-                      "required": true
+                      "required": true,
+                      "location": "path"
                     }
                   },
                   "scopes": [
@@ -1130,6 +126,7 @@
                   "description": "Gets the specified operation."
                 },
                 "list": {
+                  "description": "Lists all operations in a project in a specific zone or all zones.",
                   "httpMethod": "GET",
                   "parameterOrder": [
                     "projectId",
@@ -1157,30 +154,631 @@
                   ],
                   "flatPath": "v1/projects/{projectId}/zones/{zone}/operations",
                   "path": "v1/projects/{projectId}/zones/{zone}/operations",
-                  "id": "container.projects.zones.operations.list",
-                  "description": "Lists all operations in a project in a specific zone or all zones."
-                },
-                "cancel": {
+                  "id": "container.projects.zones.operations.list"
+                }
+              }
+            },
+            "clusters": {
+              "methods": {
+                "locations": {
+                  "id": "container.projects.zones.clusters.locations",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/locations",
                   "request": {
-                    "$ref": "CancelOperationRequest"
+                    "$ref": "SetLocationsRequest"
                   },
-                  "description": "Cancels the specified operation.",
+                  "description": "Sets the locations of a specific cluster.",
                   "response": {
-                    "$ref": "Empty"
+                    "$ref": "Operation"
                   },
                   "parameterOrder": [
                     "projectId",
                     "zone",
-                    "operationId"
+                    "clusterId"
                   ],
                   "httpMethod": "POST",
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
                   ],
                   "parameters": {
-                    "operationId": {
+                    "projectId": {
                       "location": "path",
-                      "description": "The server-assigned `name` of the operation.",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "description": "The name of the cluster to upgrade.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/locations"
+                },
+                "update": {
+                  "request": {
+                    "$ref": "UpdateClusterRequest"
+                  },
+                  "description": "Updates the settings of a specific cluster.",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "PUT",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "clusterId": {
+                      "description": "The name of the cluster to upgrade.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
+                  "id": "container.projects.zones.clusters.update",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}"
+                },
+                "monitoring": {
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "description": "The name of the cluster to upgrade.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/monitoring",
+                  "id": "container.projects.zones.clusters.monitoring",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/monitoring",
+                  "request": {
+                    "$ref": "SetMonitoringServiceRequest"
+                  },
+                  "description": "Sets the monitoring service of a specific cluster."
+                },
+                "master": {
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameters": {
+                    "clusterId": {
+                      "type": "string",
+                      "required": true,
+                      "location": "path",
+                      "description": "The name of the cluster to upgrade."
+                    },
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/master",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/master",
+                  "id": "container.projects.zones.clusters.master",
+                  "description": "Updates the master of a specific cluster.",
+                  "request": {
+                    "$ref": "UpdateMasterRequest"
+                  }
+                },
+                "setMasterAuth": {
+                  "id": "container.projects.zones.clusters.setMasterAuth",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMasterAuth",
+                  "request": {
+                    "$ref": "SetMasterAuthRequest"
+                  },
+                  "description": "Used to set master auth materials. Currently supports :-\nChanging the admin password of a specific cluster.\nThis can be either via password generation or explicitly set the password.",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster to upgrade.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMasterAuth"
+                },
+                "logging": {
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "type": "string",
+                      "required": true,
+                      "location": "path",
+                      "description": "The name of the cluster to upgrade."
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/logging",
+                  "id": "container.projects.zones.clusters.logging",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/logging",
+                  "description": "Sets the logging service of a specific cluster.",
+                  "request": {
+                    "$ref": "SetLoggingServiceRequest"
+                  }
+                },
+                "list": {
+                  "description": "Lists all clusters owned by a project in either the specified zone or all\nzones.",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone"
+                  ],
+                  "response": {
+                    "$ref": "ListClustersResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "type": "string",
+                      "required": true,
+                      "location": "path",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840)."
+                    },
+                    "zone": {
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides, or \"-\" for all zones.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters",
+                  "id": "container.projects.zones.clusters.list"
+                },
+                "create": {
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters",
+                  "id": "container.projects.zones.clusters.create",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters",
+                  "description": "Creates a cluster, consisting of the specified number and type of Google\nCompute Engine instances.\n\nBy default, the cluster is created in the project's\n[default network](/compute/docs/networks-and-firewalls#networks).\n\nOne firewall is added for the cluster. After cluster creation,\nthe cluster creates routes for each node to allow the containers\non that node to communicate with all other instances in the\ncluster.\n\nFinally, an entry is added to the project's global metadata indicating\nwhich CIDR range is being used by the cluster.",
+                  "request": {
+                    "$ref": "CreateClusterRequest"
+                  },
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "resourceLabels": {
+                  "request": {
+                    "$ref": "SetLabelsRequest"
+                  },
+                  "description": "Sets labels on a cluster.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/resourceLabels",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/resourceLabels",
+                  "id": "container.projects.zones.clusters.resourceLabels"
+                },
+                "completeIpRotation": {
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:completeIpRotation",
+                  "id": "container.projects.zones.clusters.completeIpRotation",
+                  "request": {
+                    "$ref": "CompleteIPRotationRequest"
+                  },
+                  "description": "Completes master IP rotation.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:completeIpRotation"
+                },
+                "setNetworkPolicy": {
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "description": "The name of the cluster.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setNetworkPolicy",
+                  "id": "container.projects.zones.clusters.setNetworkPolicy",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setNetworkPolicy",
+                  "description": "Enables/Disables Network Policy for a cluster.",
+                  "request": {
+                    "$ref": "SetNetworkPolicyRequest"
+                  }
+                },
+                "legacyAbac": {
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/legacyAbac",
+                  "id": "container.projects.zones.clusters.legacyAbac",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/legacyAbac",
+                  "description": "Enables or disables the ABAC authorization mechanism on a cluster.",
+                  "request": {
+                    "$ref": "SetLegacyAbacRequest"
+                  },
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster to update.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "get": {
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
+                  "id": "container.projects.zones.clusters.get",
+                  "description": "Gets the details of a specific cluster.",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "response": {
+                    "$ref": "Cluster"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "description": "The name of the cluster to retrieve.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  }
+                },
+                "startIpRotation": {
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "description": "The name of the cluster.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:startIpRotation",
+                  "id": "container.projects.zones.clusters.startIpRotation",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:startIpRotation",
+                  "request": {
+                    "$ref": "StartIPRotationRequest"
+                  },
+                  "description": "Start master IP rotation."
+                },
+                "setMaintenancePolicy": {
+                  "id": "container.projects.zones.clusters.setMaintenancePolicy",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMaintenancePolicy",
+                  "description": "Sets the maintenance policy for a cluster.",
+                  "request": {
+                    "$ref": "SetMaintenancePolicyRequest"
+                  },
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                      "type": "string",
+                      "required": true
+                    },
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster to update.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMaintenancePolicy"
+                },
+                "addons": {
+                  "description": "Sets the addons of a specific cluster.",
+                  "request": {
+                    "$ref": "SetAddonsConfigRequest"
+                  },
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameters": {
+                    "zone": {
+                      "location": "path",
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster to upgrade.",
                       "type": "string",
                       "required": true
                     },
@@ -1189,17 +787,467 @@
                       "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
                       "type": "string",
                       "required": true
-                    },
-                    "zone": {
-                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the operation resides.",
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/addons",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/addons",
+                  "id": "container.projects.zones.clusters.addons"
+                },
+                "delete": {
+                  "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
+                  "id": "container.projects.zones.clusters.delete",
+                  "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}",
+                  "description": "Deletes the cluster, including the Kubernetes endpoint and all worker\nnodes.\n\nFirewalls and routes that were configured during cluster creation\nare also deleted.\n\nOther Google Compute Engine resources that might be in use by the cluster\n(e.g. load balancer resources) will not be deleted if they weren't present\nat the initial create time.",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "zone",
+                    "clusterId"
+                  ],
+                  "httpMethod": "DELETE",
+                  "parameters": {
+                    "projectId": {
+                      "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
                       "type": "string",
                       "required": true,
                       "location": "path"
+                    },
+                    "zone": {
+                      "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "clusterId": {
+                      "location": "path",
+                      "description": "The name of the cluster to delete.",
+                      "type": "string",
+                      "required": true
                     }
                   },
-                  "flatPath": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel",
-                  "id": "container.projects.zones.operations.cancel",
-                  "path": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel"
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                }
+              },
+              "resources": {
+                "nodePools": {
+                  "methods": {
+                    "get": {
+                      "id": "container.projects.zones.clusters.nodePools.get",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
+                      "description": "Retrieves the node pool requested.",
+                      "response": {
+                        "$ref": "NodePool"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "GET",
+                      "parameters": {
+                        "projectId": {
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "zone": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides."
+                        },
+                        "clusterId": {
+                          "description": "The name of the cluster.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "nodePoolId": {
+                          "description": "The name of the node pool.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}"
+                    },
+                    "update": {
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "projectId": {
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "zone": {
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "clusterId": {
+                          "location": "path",
+                          "description": "The name of the cluster to upgrade.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "nodePoolId": {
+                          "description": "The name of the node pool to upgrade.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/update",
+                      "id": "container.projects.zones.clusters.nodePools.update",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/update",
+                      "description": "Updates the version and/or image type of a specific node pool.",
+                      "request": {
+                        "$ref": "UpdateNodePoolRequest"
+                      }
+                    },
+                    "setSize": {
+                      "request": {
+                        "$ref": "SetNodePoolSizeRequest"
+                      },
+                      "description": "Sets the size of a specific node pool.",
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "POST",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "projectId": {
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "zone": {
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "clusterId": {
+                          "location": "path",
+                          "description": "The name of the cluster to update.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "nodePoolId": {
+                          "description": "The name of the node pool to update.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setSize",
+                      "id": "container.projects.zones.clusters.nodePools.setSize",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setSize"
+                    },
+                    "setManagement": {
+                      "id": "container.projects.zones.clusters.nodePools.setManagement",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement",
+                      "request": {
+                        "$ref": "SetNodePoolManagementRequest"
+                      },
+                      "description": "Sets the NodeManagement options for a node pool.",
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "POST",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "clusterId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The name of the cluster to update."
+                        },
+                        "nodePoolId": {
+                          "location": "path",
+                          "description": "The name of the node pool to update.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "projectId": {
+                          "location": "path",
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                          "type": "string",
+                          "required": true
+                        },
+                        "zone": {
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement"
+                    },
+                    "delete": {
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
+                      "id": "container.projects.zones.clusters.nodePools.delete",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}",
+                      "description": "Deletes a node pool from a cluster.",
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "DELETE",
+                      "parameters": {
+                        "clusterId": {
+                          "description": "The name of the cluster.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "nodePoolId": {
+                          "location": "path",
+                          "description": "The name of the node pool to delete.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "projectId": {
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber).",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "zone": {
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "list": {
+                      "description": "Lists the node pools for a cluster.",
+                      "response": {
+                        "$ref": "ListNodePoolsResponse"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId"
+                      ],
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "projectId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber)."
+                        },
+                        "zone": {
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "clusterId": {
+                          "description": "The name of the cluster.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
+                      "id": "container.projects.zones.clusters.nodePools.list",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools"
+                    },
+                    "rollback": {
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
+                      "id": "container.projects.zones.clusters.nodePools.rollback",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
+                      "description": "Roll back the previously Aborted or Failed NodePool upgrade.\nThis will be an no-op if the last upgrade successfully completed.",
+                      "request": {
+                        "$ref": "RollbackNodePoolUpgradeRequest"
+                      },
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "zone": {
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "clusterId": {
+                          "location": "path",
+                          "description": "The name of the cluster to rollback.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "nodePoolId": {
+                          "description": "The name of the node pool to rollback.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "projectId": {
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "create": {
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId"
+                      ],
+                      "httpMethod": "POST",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "zone": {
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+                          "type": "string",
+                          "required": true
+                        },
+                        "clusterId": {
+                          "description": "The name of the cluster.",
+                          "type": "string",
+                          "required": true,
+                          "location": "path"
+                        },
+                        "projectId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://developers.google.com/console/help/new/#projectnumber)."
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
+                      "id": "container.projects.zones.clusters.nodePools.create",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools",
+                      "request": {
+                        "$ref": "CreateNodePoolRequest"
+                      },
+                      "description": "Creates a node pool for a cluster."
+                    },
+                    "autoscaling": {
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "projectId",
+                        "zone",
+                        "clusterId",
+                        "nodePoolId"
+                      ],
+                      "response": {
+                        "$ref": "Operation"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "clusterId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The name of the cluster to upgrade."
+                        },
+                        "nodePoolId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The name of the node pool to upgrade."
+                        },
+                        "projectId": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840)."
+                        },
+                        "zone": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides."
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/autoscaling",
+                      "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/autoscaling",
+                      "id": "container.projects.zones.clusters.nodePools.autoscaling",
+                      "request": {
+                        "$ref": "SetNodePoolAutoscalingRequest"
+                      },
+                      "description": "Sets the autoscaling settings of a specific node pool."
+                    }
+                  }
                 }
               }
             }
@@ -1209,77 +1257,6 @@
     }
   },
   "parameters": {
-    "pp": {
-      "description": "Pretty-print response.",
-      "default": "true",
-      "type": "boolean",
-      "location": "query"
-    },
-    "bearer_token": {
-      "description": "OAuth bearer token.",
-      "type": "string",
-      "location": "query"
-    },
-    "oauth_token": {
-      "location": "query",
-      "description": "OAuth 2.0 token for the current user.",
-      "type": "string"
-    },
-    "upload_protocol": {
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "type": "string",
-      "location": "query"
-    },
-    "prettyPrint": {
-      "description": "Returns response with indentations and line breaks.",
-      "default": "true",
-      "type": "boolean",
-      "location": "query"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "type": "string",
-      "location": "query"
-    },
-    "uploadType": {
-      "location": "query",
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "type": "string"
-    },
-    "$.xgafv": {
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "description": "V1 error format.",
-      "type": "string"
-    },
-    "callback": {
-      "description": "JSONP",
-      "type": "string",
-      "location": "query"
-    },
-    "alt": {
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "type": "string",
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "description": "Data format for response.",
-      "default": "json"
-    },
     "key": {
       "location": "query",
       "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
@@ -1291,17 +1268,226 @@
       "type": "string"
     },
     "quotaUser": {
+      "location": "query",
       "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "default": "true",
+      "type": "boolean",
+      "location": "query"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
       "type": "string",
+      "location": "query"
+    },
+    "bearer_token": {
+      "description": "OAuth bearer token.",
+      "type": "string",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "type": "boolean"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "callback": {
+      "description": "JSONP",
+      "type": "string",
+      "location": "query"
+    },
+    "$.xgafv": {
+      "location": "query",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "description": "V1 error format.",
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ]
+    },
+    "alt": {
+      "description": "Data format for response.",
+      "default": "json",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
       "location": "query"
     }
   },
   "schemas": {
-    "CancelOperationRequest": {
-      "description": "CancelOperationRequest cancels a single operation.",
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }\n\nThe JSON representation for `Empty` is empty JSON object `{}`.",
       "type": "object",
       "properties": {},
-      "id": "CancelOperationRequest"
+      "id": "Empty"
+    },
+    "ListNodePoolsResponse": {
+      "description": "ListNodePoolsResponse is the result of ListNodePoolsRequest.",
+      "type": "object",
+      "properties": {
+        "nodePools": {
+          "description": "A list of node pools for a cluster.",
+          "items": {
+            "$ref": "NodePool"
+          },
+          "type": "array"
+        }
+      },
+      "id": "ListNodePoolsResponse"
+    },
+    "CompleteIPRotationRequest": {
+      "id": "CompleteIPRotationRequest",
+      "description": "CompleteIPRotationRequest moves the cluster master back into single-IP mode.",
+      "type": "object",
+      "properties": {}
+    },
+    "StartIPRotationRequest": {
+      "type": "object",
+      "properties": {},
+      "id": "StartIPRotationRequest",
+      "description": "StartIPRotationRequest creates a new IP for the cluster and then performs\na node upgrade on each node pool to point to the new IP."
+    },
+    "SetLabelsRequest": {
+      "description": "SetLabelsRequest sets the Google Cloud Platform labels on a Google Container\nEngine cluster, which will in turn set them for Google Compute Engine\nresources used by that cluster",
+      "type": "object",
+      "properties": {
+        "resourceLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The labels to set for that cluster.",
+          "type": "object"
+        },
+        "labelFingerprint": {
+          "description": "The fingerprint of the previous set of labels for this resource,\nused to detect conflicts. The fingerprint is initially generated by\nContainer Engine and changes after every request to modify or update\nlabels. You must always provide an up-to-date fingerprint hash when\nupdating or changing labels. Make a \u003ccode\u003eget()\u003c/code\u003e request to the\nresource to get the latest fingerprint.",
+          "type": "string"
+        }
+      },
+      "id": "SetLabelsRequest"
+    },
+    "NodePool": {
+      "properties": {
+        "status": {
+          "enumDescriptions": [
+            "Not set.",
+            "The PROVISIONING state indicates the node pool is being created.",
+            "The RUNNING state indicates the node pool has been created\nand is fully usable.",
+            "The RUNNING_WITH_ERROR state indicates the node pool has been created\nand is partially usable. Some error state has occurred and some\nfunctionality may be impaired. Customer may need to reissue a request\nor trigger a new update.",
+            "The RECONCILING state indicates that some work is actively being done on\nthe node pool, such as upgrading node software. Details can\nbe found in the `statusMessage` field.",
+            "The STOPPING state indicates the node pool is being deleted.",
+            "The ERROR state indicates the node pool may be unusable. Details\ncan be found in the `statusMessage` field."
+          ],
+          "enum": [
+            "STATUS_UNSPECIFIED",
+            "PROVISIONING",
+            "RUNNING",
+            "RUNNING_WITH_ERROR",
+            "RECONCILING",
+            "STOPPING",
+            "ERROR"
+          ],
+          "description": "[Output only] The status of the nodes in this pool instance.",
+          "type": "string"
+        },
+        "config": {
+          "description": "The node configuration of the pool.",
+          "$ref": "NodeConfig"
+        },
+        "statusMessage": {
+          "description": "[Output only] Additional information about the current status of this\nnode pool instance, if available.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the node pool.",
+          "type": "string"
+        },
+        "autoscaling": {
+          "description": "Autoscaler configuration for this NodePool. Autoscaler is enabled\nonly if a valid configuration is present.",
+          "$ref": "NodePoolAutoscaling"
+        },
+        "management": {
+          "description": "NodeManagement configuration for this NodePool.",
+          "$ref": "NodeManagement"
+        },
+        "initialNodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The initial node count for the pool. You must ensure that your\nCompute Engine \u003ca href=\"/compute/docs/resource-quotas\"\u003eresource quota\u003c/a\u003e\nis sufficient for this number of instances. You must also have available\nfirewall and routes quota."
+        },
+        "selfLink": {
+          "description": "[Output only] Server-defined URL for the resource.",
+          "type": "string"
+        },
+        "instanceGroupUrls": {
+          "description": "[Output only] The resource URLs of [instance\ngroups](/compute/docs/instance-groups/) associated with this\nnode pool.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "description": "[Output only] The version of the Kubernetes of this node.",
+          "type": "string"
+        }
+      },
+      "id": "NodePool",
+      "description": "NodePool contains the name and configuration for a cluster's node pool.\nNode pools are a set of nodes (i.e. VM's), with a common configuration and\nspecification, under the control of the cluster master. They may have a set\nof Kubernetes labels applied to them, which may be used to reference them\nduring pod scheduling. They may also be resized up or down, to accommodate\nthe workload.",
+      "type": "object"
+    },
+    "NodeManagement": {
+      "description": "NodeManagement defines the set of node management services turned on for the\nnode pool.",
+      "type": "object",
+      "properties": {
+        "autoRepair": {
+          "description": "A flag that specifies whether the node auto-repair is enabled for the node\npool. If enabled, the nodes in this node pool will be monitored and, if\nthey fail health checks too many times, an automatic repair action will be\ntriggered.",
+          "type": "boolean"
+        },
+        "autoUpgrade": {
+          "description": "A flag that specifies whether node auto-upgrade is enabled for the node\npool. If enabled, node auto-upgrade helps keep the nodes in your node pool\nup to date with the latest release version of Kubernetes.",
+          "type": "boolean"
+        },
+        "upgradeOptions": {
+          "$ref": "AutoUpgradeOptions",
+          "description": "Specifies the Auto Upgrade knobs for the node pool."
+        }
+      },
+      "id": "NodeManagement"
+    },
+    "CancelOperationRequest": {
+      "id": "CancelOperationRequest",
+      "description": "CancelOperationRequest cancels a single operation.",
+      "type": "object",
+      "properties": {}
     },
     "KubernetesDashboard": {
       "description": "Configuration for the Kubernetes Dashboard.",
@@ -1314,17 +1500,6 @@
       },
       "id": "KubernetesDashboard"
     },
-    "SetLegacyAbacRequest": {
-      "description": "SetLegacyAbacRequest enables or disables the ABAC authorization mechanism for\na cluster.",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "description": "Whether ABAC authorization will be enabled in the cluster.",
-          "type": "boolean"
-        }
-      },
-      "id": "SetLegacyAbacRequest"
-    },
     "Operation": {
       "description": "This operation resource represents operations that may have happened or are\nhappening on the cluster. All fields are output only.",
       "type": "object",
@@ -1333,16 +1508,16 @@
           "description": "Server-defined URL for the resource.",
           "type": "string"
         },
-        "endTime": {
-          "description": "[Output only] The time the operation completed, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
+        "detail": {
+          "description": "Detailed operation progress, if available.",
           "type": "string"
         },
         "targetLink": {
           "description": "Server-defined URL for the target of the operation.",
           "type": "string"
         },
-        "detail": {
-          "description": "Detailed operation progress, if available.",
+        "endTime": {
+          "description": "[Output only] The time the operation completed, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
           "type": "string"
         },
         "operationType": {
@@ -1364,7 +1539,8 @@
             "Set labels.",
             "Set/generate master auth materials",
             "Set node pool size.",
-            "Updates network policy for a cluster."
+            "Updates network policy for a cluster.",
+            "Set the maintenance policy."
           ],
           "enum": [
             "TYPE_UNSPECIFIED",
@@ -1382,7 +1558,8 @@
             "SET_LABELS",
             "SET_MASTER_AUTH",
             "SET_NODE_POOL_SIZE",
-            "SET_NETWORK_POLICY"
+            "SET_NETWORK_POLICY",
+            "SET_MAINTENANCE_POLICY"
           ]
         },
         "startTime": {
@@ -1394,6 +1571,7 @@
           "type": "string"
         },
         "status": {
+          "type": "string",
           "enumDescriptions": [
             "Not set.",
             "The operation has been created.",
@@ -1408,52 +1586,29 @@
             "DONE",
             "ABORTING"
           ],
-          "description": "The current status of the operation.",
+          "description": "The current status of the operation."
+        },
+        "name": {
+          "description": "The server-assigned ID for the operation.",
           "type": "string"
         },
         "statusMessage": {
           "description": "If an error has occurred, a textual description of the error.",
           "type": "string"
-        },
-        "name": {
-          "description": "The server-assigned ID for the operation.",
-          "type": "string"
         }
       },
       "id": "Operation"
     },
-    "AddonsConfig": {
-      "description": "Configuration for the addons that can be automatically spun up in the\ncluster, enabling additional functionality.",
+    "MaintenanceWindow": {
+      "id": "MaintenanceWindow",
+      "description": "MaintenanceWindow defines the maintenance window to be used for the cluster.",
       "type": "object",
       "properties": {
-        "kubernetesDashboard": {
-          "description": "Configuration for the Kubernetes Dashboard.",
-          "$ref": "KubernetesDashboard"
-        },
-        "horizontalPodAutoscaling": {
-          "description": "Configuration for the horizontal pod autoscaling feature, which\nincreases or decreases the number of replica pods a replication controller\nhas based on the resource usage of the existing pods.",
-          "$ref": "HorizontalPodAutoscaling"
-        },
-        "httpLoadBalancing": {
-          "$ref": "HttpLoadBalancing",
-          "description": "Configuration for the HTTP (L7) load balancing controller addon, which\nmakes it easy to set up HTTP load balancers for services in a cluster."
+        "dailyMaintenanceWindow": {
+          "description": "DailyMaintenanceWindow specifies a daily maintenance operation window.",
+          "$ref": "DailyMaintenanceWindow"
         }
-      },
-      "id": "AddonsConfig"
-    },
-    "SetLocationsRequest": {
-      "description": "SetLocationsRequest sets the locations of the cluster.",
-      "type": "object",
-      "properties": {
-        "locations": {
-          "description": "The desired list of Google Compute Engine\n[locations](/compute/docs/zones#available) in which the cluster's nodes\nshould be located. Changing the locations a cluster is in will result\nin nodes being either created or removed from the cluster, depending on\nwhether locations are being added or removed.\n\nThis list must always include the cluster's primary zone.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "id": "SetLocationsRequest"
+      }
     },
     "RollbackNodePoolUpgradeRequest": {
       "description": "RollbackNodePoolUpgradeRequest rollbacks the previously Aborted or Failed\nNodePool upgrade. This will be an no-op if the last upgrade successfully\ncompleted.",
@@ -1461,38 +1616,14 @@
       "properties": {},
       "id": "RollbackNodePoolUpgradeRequest"
     },
-    "SetNodePoolSizeRequest": {
-      "description": "SetNodePoolSizeRequest sets the size a node\npool.",
-      "type": "object",
-      "properties": {
-        "nodeCount": {
-          "format": "int32",
-          "description": "The desired node count for the pool.",
-          "type": "integer"
-        }
-      },
-      "id": "SetNodePoolSizeRequest"
-    },
-    "UpdateClusterRequest": {
-      "description": "UpdateClusterRequest updates the settings of a cluster.",
-      "type": "object",
-      "properties": {
-        "update": {
-          "description": "A description of the update.",
-          "$ref": "ClusterUpdate"
-        }
-      },
-      "id": "UpdateClusterRequest"
-    },
     "NetworkPolicy": {
-      "description": "Configuration options for the NetworkPolicy feature.\nhttps://kubernetes.io/docs/concepts/services-networking/networkpolicies/",
-      "type": "object",
       "properties": {
         "enabled": {
           "description": "Whether network policy is enabled on the cluster.",
           "type": "boolean"
         },
         "provider": {
+          "type": "string",
           "enumDescriptions": [
             "Not set",
             "Tigera (Calico Felix)."
@@ -1501,11 +1632,12 @@
             "PROVIDER_UNSPECIFIED",
             "CALICO"
           ],
-          "description": "The selected network policy provider.",
-          "type": "string"
+          "description": "The selected network policy provider."
         }
       },
-      "id": "NetworkPolicy"
+      "id": "NetworkPolicy",
+      "description": "Configuration options for the NetworkPolicy feature.\nhttps://kubernetes.io/docs/concepts/services-networking/networkpolicies/",
+      "type": "object"
     },
     "UpdateMasterRequest": {
       "description": "UpdateMasterRequest updates the master of the cluster.",
@@ -1517,191 +1649,6 @@
         }
       },
       "id": "UpdateMasterRequest"
-    },
-    "Cluster": {
-      "description": "A Google Container Engine cluster.",
-      "type": "object",
-      "properties": {
-        "createTime": {
-          "description": "[Output only] The time the cluster was created, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
-          "type": "string"
-        },
-        "clusterIpv4Cidr": {
-          "description": "The IP address range of the container pods in this cluster, in\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `10.96.0.0/14`). Leave blank to have\none automatically chosen or specify a `/14` block in `10.0.0.0/8`.",
-          "type": "string"
-        },
-        "initialNodeCount": {
-          "format": "int32",
-          "description": "The number of nodes to create in this cluster. You must ensure that your\nCompute Engine \u003ca href=\"/compute/docs/resource-quotas\"\u003eresource quota\u003c/a\u003e\nis sufficient for this number of instances. You must also have available\nfirewall and routes quota.\nFor requests, this field should only be used in lieu of a\n\"node_pool\" object, since this configuration (along with the\n\"node_config\") will be used to create a \"NodePool\" object with an\nauto-generated name. Do not use this and a node_pool at the same time.",
-          "type": "integer"
-        },
-        "selfLink": {
-          "description": "[Output only] Server-defined URL for the resource.",
-          "type": "string"
-        },
-        "nodePools": {
-          "description": "The node pools associated with this cluster.\nThis field should not be set if \"node_config\" or \"initial_node_count\" are\nspecified.",
-          "items": {
-            "$ref": "NodePool"
-          },
-          "type": "array"
-        },
-        "locations": {
-          "description": "The list of Google Compute Engine\n[locations](/compute/docs/zones#available) in which the cluster's nodes\nshould be located.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "instanceGroupUrls": {
-          "description": "[Output only] The resource URLs of [instance\ngroups](/compute/docs/instance-groups/) associated with this\ncluster.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "networkPolicy": {
-          "description": "Configuration options for the NetworkPolicy feature.",
-          "$ref": "NetworkPolicy"
-        },
-        "servicesIpv4Cidr": {
-          "description": "[Output only] The IP address range of the Kubernetes services in\nthis cluster, in\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `1.2.3.4/29`). Service addresses are\ntypically put in the last `/16` from the container CIDR.",
-          "type": "string"
-        },
-        "enableKubernetesAlpha": {
-          "description": "Kubernetes alpha features are enabled on this cluster. This includes alpha\nAPI groups (e.g. v1alpha1) and features that may not be production ready in\nthe kubernetes version of the master and nodes.\nThe cluster has no SLA for uptime and master/node upgrades are disabled.\nAlpha enabled clusters are automatically deleted thirty days after\ncreation.",
-          "type": "boolean"
-        },
-        "description": {
-          "description": "An optional description of this cluster.",
-          "type": "string"
-        },
-        "currentNodeCount": {
-          "format": "int32",
-          "description": "[Output only] The number of nodes currently in the cluster.",
-          "type": "integer"
-        },
-        "monitoringService": {
-          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* `monitoring.googleapis.com` - the Google Cloud Monitoring service.\n* `none` - no metrics will be exported from the cluster.\n* if left as an empty string, `monitoring.googleapis.com` will be used.",
-          "type": "string"
-        },
-        "network": {
-          "description": "The name of the Google Compute Engine\n[network](/compute/docs/networks-and-firewalls#networks) to which the\ncluster is connected. If left unspecified, the `default` network\nwill be used.",
-          "type": "string"
-        },
-        "labelFingerprint": {
-          "description": "The fingerprint of the set of labels for this cluster.",
-          "type": "string"
-        },
-        "zone": {
-          "description": "[Output only] The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
-          "type": "string"
-        },
-        "expireTime": {
-          "description": "[Output only] The time the cluster will be automatically\ndeleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
-          "type": "string"
-        },
-        "nodeIpv4CidrSize": {
-          "format": "int32",
-          "description": "[Output only] The size of the address space on each node for hosting\ncontainers. This is provisioned from within the `container_ipv4_cidr`\nrange.",
-          "type": "integer"
-        },
-        "loggingService": {
-          "description": "The logging service the cluster should use to write logs.\nCurrently available options:\n\n* `logging.googleapis.com` - the Google Cloud Logging service.\n* `none` - no logs will be exported from the cluster.\n* if left as an empty string,`logging.googleapis.com` will be used.",
-          "type": "string"
-        },
-        "masterAuthorizedNetworksConfig": {
-          "description": "Master authorized networks is a Beta feature.\nThe configuration options for master authorized networks feature.",
-          "$ref": "MasterAuthorizedNetworksConfig"
-        },
-        "statusMessage": {
-          "description": "[Output only] Additional information about the current status of this\ncluster, if available.",
-          "type": "string"
-        },
-        "masterAuth": {
-          "description": "The authentication information for accessing the master endpoint.",
-          "$ref": "MasterAuth"
-        },
-        "currentMasterVersion": {
-          "description": "[Output only] The current software version of the master endpoint.",
-          "type": "string"
-        },
-        "nodeConfig": {
-          "$ref": "NodeConfig",
-          "description": "Parameters used in creating the cluster's nodes.\nSee `nodeConfig` for the description of its properties.\nFor requests, this field should only be used in lieu of a\n\"node_pool\" object, since this configuration (along with the\n\"initial_node_count\") will be used to create a \"NodePool\" object with an\nauto-generated name. Do not use this and a node_pool at the same time.\nFor responses, this field will be populated with the node configuration of\nthe first node pool.\n\nIf unspecified, the defaults are used."
-        },
-        "addonsConfig": {
-          "description": "Configurations for the various addons available to run in the cluster.",
-          "$ref": "AddonsConfig"
-        },
-        "status": {
-          "enumDescriptions": [
-            "Not set.",
-            "The PROVISIONING state indicates the cluster is being created.",
-            "The RUNNING state indicates the cluster has been created and is fully\nusable.",
-            "The RECONCILING state indicates that some work is actively being done on\nthe cluster, such as upgrading the master or node software. Details can\nbe found in the `statusMessage` field.",
-            "The STOPPING state indicates the cluster is being deleted.",
-            "The ERROR state indicates the cluster may be unusable. Details\ncan be found in the `statusMessage` field."
-          ],
-          "enum": [
-            "STATUS_UNSPECIFIED",
-            "PROVISIONING",
-            "RUNNING",
-            "RECONCILING",
-            "STOPPING",
-            "ERROR"
-          ],
-          "description": "[Output only] The current status of this cluster.",
-          "type": "string"
-        },
-        "subnetwork": {
-          "description": "The name of the Google Compute Engine\n[subnetwork](/compute/docs/subnetworks) to which the\ncluster is connected.",
-          "type": "string"
-        },
-        "currentNodeVersion": {
-          "description": "[Output only] The current version of the node software components.\nIf they are currently at multiple versions because they're in the process\nof being upgraded, this reflects the minimum version of all nodes.",
-          "type": "string"
-        },
-        "name": {
-          "description": "The name of this cluster. The name must be unique within this project\nand zone, and can be up to 40 characters with the following restrictions:\n\n* Lowercase letters, numbers, and hyphens only.\n* Must start with a letter.\n* Must end with a number or a letter.",
-          "type": "string"
-        },
-        "resourceLabels": {
-          "description": "The resource labels for the cluster to use to annotate any related\nGoogle Compute Engine resources.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "initialClusterVersion": {
-          "description": "The initial Kubernetes version for this cluster.  Valid versions are those\nfound in validMasterVersions returned by getServerConfig.  The version can\nbe upgraded over time; such upgrades are reflected in\ncurrentMasterVersion and currentNodeVersion.",
-          "type": "string"
-        },
-        "ipAllocationPolicy": {
-          "description": "Configuration for cluster IP allocation.",
-          "$ref": "IPAllocationPolicy"
-        },
-        "legacyAbac": {
-          "$ref": "LegacyAbac",
-          "description": "Configuration for the legacy ABAC authorization mode."
-        },
-        "endpoint": {
-          "description": "[Output only] The IP address of this cluster's master endpoint.\nThe endpoint can be accessed from the internet at\n`https://username:password@endpoint/`.\n\nSee the `masterAuth` property of this resource for username and\npassword information.",
-          "type": "string"
-        }
-      },
-      "id": "Cluster"
-    },
-    "CreateNodePoolRequest": {
-      "description": "CreateNodePoolRequest creates a node pool for a cluster.",
-      "type": "object",
-      "properties": {
-        "nodePool": {
-          "description": "The node pool to create.",
-          "$ref": "NodePool"
-        }
-      },
-      "id": "CreateNodePoolRequest"
     },
     "ListOperationsResponse": {
       "description": "ListOperationsResponse is the result of ListOperationsRequest.",
@@ -1729,8 +1676,8 @@
       "type": "object",
       "properties": {
         "monitoringService": {
-          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* \"monitoring.googleapis.com\" - the Google Cloud Monitoring service\n* \"none\" - no metrics will be exported from the cluster",
-          "type": "string"
+          "type": "string",
+          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* \"monitoring.googleapis.com\" - the Google Cloud Monitoring service\n* \"none\" - no metrics will be exported from the cluster"
         }
       },
       "id": "SetMonitoringServiceRequest"
@@ -1739,27 +1686,28 @@
       "description": "CidrBlock contains an optional name and one CIDR block.",
       "type": "object",
       "properties": {
-        "displayName": {
-          "description": "display_name is an optional field for users to identify CIDR blocks.",
-          "type": "string"
-        },
         "cidrBlock": {
           "description": "cidr_block must be specified in CIDR notation.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "display_name is an optional field for users to identify CIDR blocks.",
           "type": "string"
         }
       },
       "id": "CidrBlock"
     },
     "ServerConfig": {
+      "id": "ServerConfig",
       "description": "Container Engine service configuration.",
       "type": "object",
       "properties": {
         "validMasterVersions": {
-          "description": "List of valid master versions.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "List of valid master versions."
         },
         "defaultImageType": {
           "description": "Default image type.",
@@ -1783,35 +1731,16 @@
           },
           "type": "array"
         }
-      },
-      "id": "ServerConfig"
+      }
     },
     "NodeConfig": {
       "description": "Parameters that describe the nodes in a cluster.",
       "type": "object",
       "properties": {
-        "metadata": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "The metadata key/value pairs assigned to instances in the cluster.\n\nKeys must conform to the regexp [a-zA-Z0-9-_]+ and be less than 128 bytes\nin length. These are reflected as part of a URL in the metadata server.\nAdditionally, to avoid ambiguity, keys must not conflict with any other\nmetadata keys for the project or be one of the four reserved keys:\n\"instance-template\", \"kube-env\", \"startup-script\", and \"user-data\"\n\nValues are free-form strings, and only have meaning as interpreted by\nthe image running in the instance. The only restriction placed on them is\nthat each value's size must be less than or equal to 32 KB.\n\nThe total size of all keys and values must be less than 512 KB.",
-          "type": "object"
-        },
         "diskSizeGb": {
           "format": "int32",
           "description": "Size of the disk attached to each node, specified in GB.\nThe smallest allowed disk size is 10GB.\n\nIf unspecified, the default disk size is 100GB.",
           "type": "integer"
-        },
-        "tags": {
-          "description": "The list of instance tags applied to all nodes. Tags are used to identify\nvalid sources or targets for network firewalls and are specified by\nthe client during cluster or node pool creation. Each tag within the list\nmust comply with RFC1035.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "serviceAccount": {
-          "description": "The Google Cloud Platform Service Account to be used by the node VMs. If\nno Service Account is specified, the \"default\" service account is used.",
-          "type": "string"
         },
         "accelerators": {
           "description": "A list of hardware accelerators to be attached to each node.\nSee https://cloud.google.com/compute/docs/gpus for more information about\nsupport for GPUs.",
@@ -1822,6 +1751,37 @@
         },
         "machineType": {
           "description": "The name of a Google Compute Engine [machine\ntype](/compute/docs/machine-types) (e.g.\n`n1-standard-1`).\n\nIf unspecified, the default machine type is\n`n1-standard-1`.",
+          "type": "string"
+        },
+        "minCpuPlatform": {
+          "description": "Minimum CPU platform to be used by this instance. The instance may be\nscheduled on the specified or newer CPU platform. Applicable values are the\nfriendly names of CPU platforms, such as\n\u003ccode\u003eminCpuPlatform: &quot;Intel Haswell&quot;\u003c/code\u003e or\n\u003ccode\u003eminCpuPlatform: &quot;Intel Sandy Bridge&quot;\u003c/code\u003e. For more\ninformation, read [how to specify min CPU platform](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)",
+          "type": "string"
+        },
+        "preemptible": {
+          "description": "Whether the nodes are created as preemptible VM instances. See:\nhttps://cloud.google.com/compute/docs/instances/preemptible for more\ninformation about preemptible VM instances.",
+          "type": "boolean"
+        },
+        "localSsdCount": {
+          "format": "int32",
+          "description": "The number of local SSD disks to be attached to the node.\n\nThe limit for this value is dependant upon the maximum number of\ndisks available on a machine per zone. See:\nhttps://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits\nfor more information.",
+          "type": "integer"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The metadata key/value pairs assigned to instances in the cluster.\n\nKeys must conform to the regexp [a-zA-Z0-9-_]+ and be less than 128 bytes\nin length. These are reflected as part of a URL in the metadata server.\nAdditionally, to avoid ambiguity, keys must not conflict with any other\nmetadata keys for the project or be one of the four reserved keys:\n\"instance-template\", \"kube-env\", \"startup-script\", and \"user-data\"\n\nValues are free-form strings, and only have meaning as interpreted by\nthe image running in the instance. The only restriction placed on them is\nthat each value's size must be less than or equal to 32 KB.\n\nThe total size of all keys and values must be less than 512 KB.",
+          "type": "object"
+        },
+        "tags": {
+          "description": "The list of instance tags applied to all nodes. Tags are used to identify\nvalid sources or targets for network firewalls and are specified by\nthe client during cluster or node pool creation. Each tag within the list\nmust comply with RFC1035.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "serviceAccount": {
+          "description": "The Google Cloud Platform Service Account to be used by the node VMs. If\nno Service Account is specified, the \"default\" service account is used.",
           "type": "string"
         },
         "imageType": {
@@ -1835,66 +1795,26 @@
           },
           "type": "array"
         },
-        "preemptible": {
-          "description": "Whether the nodes are created as preemptible VM instances. See:\nhttps://cloud.google.com/compute/docs/instances/preemptible for more\ninformation about preemptible VM instances.",
-          "type": "boolean"
-        },
         "labels": {
-          "description": "The map of Kubernetes labels (key/value pairs) to be applied to each node.\nThese will added in addition to any default label(s) that\nKubernetes may apply to the node.\nIn case of conflict in label keys, the applied set may differ depending on\nthe Kubernetes version -- it's best to assume the behavior is undefined\nand conflicts should be avoided.\nFor more information, including usage and the valid values, see:\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
-        },
-        "localSsdCount": {
-          "format": "int32",
-          "description": "The number of local SSD disks to be attached to the node.\n\nThe limit for this value is dependant upon the maximum number of\ndisks available on a machine per zone. See:\nhttps://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits\nfor more information.",
-          "type": "integer"
+          },
+          "description": "The map of Kubernetes labels (key/value pairs) to be applied to each node.\nThese will added in addition to any default label(s) that\nKubernetes may apply to the node.\nIn case of conflict in label keys, the applied set may differ depending on\nthe Kubernetes version -- it's best to assume the behavior is undefined\nand conflicts should be avoided.\nFor more information, including usage and the valid values, see:\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
         }
       },
       "id": "NodeConfig"
-    },
-    "MasterAuth": {
-      "description": "The authentication information for accessing the master endpoint.\nAuthentication can be done using HTTP basic auth or using client\ncertificates.",
-      "type": "object",
-      "properties": {
-        "clientCertificateConfig": {
-          "$ref": "ClientCertificateConfig",
-          "description": "Configuration for client certificate authentication on the cluster.  If no\nconfiguration is specified, a client certificate is issued."
-        },
-        "password": {
-          "description": "The password to use for HTTP basic authentication to the master endpoint.\nBecause the master endpoint is open to the Internet, you should create a\nstrong password.  If a password is provided for cluster creation, username\nmust be non-empty.",
-          "type": "string"
-        },
-        "clientKey": {
-          "description": "[Output only] Base64-encoded private key used by clients to authenticate\nto the cluster endpoint.",
-          "type": "string"
-        },
-        "clusterCaCertificate": {
-          "description": "[Output only] Base64-encoded public certificate that is the root of\ntrust for the cluster.",
-          "type": "string"
-        },
-        "clientCertificate": {
-          "description": "[Output only] Base64-encoded public certificate used by clients to\nauthenticate to the cluster endpoint.",
-          "type": "string"
-        },
-        "username": {
-          "description": "The username to use for HTTP basic authentication to the master endpoint.\nFor clusters v1.6.0 and later, you can disable basic authentication by\nproviding an empty username.",
-          "type": "string"
-        }
-      },
-      "id": "MasterAuth"
     },
     "AutoUpgradeOptions": {
       "description": "AutoUpgradeOptions defines the set of options for the user to control how\nthe Auto Upgrades will proceed.",
       "type": "object",
       "properties": {
+        "autoUpgradeStartTime": {
+          "type": "string",
+          "description": "[Output only] This field is set when upgrades are about to commence\nwith the approximate start time for the upgrades, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format."
+        },
         "description": {
           "description": "[Output only] This field is set when upgrades are about to commence\nwith the description of the upgrade.",
-          "type": "string"
-        },
-        "autoUpgradeStartTime": {
-          "description": "[Output only] This field is set when upgrades are about to commence\nwith the approximate start time for the upgrades, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
           "type": "string"
         }
       },
@@ -1904,17 +1824,17 @@
       "description": "ListClustersResponse is the result of ListClustersRequest.",
       "type": "object",
       "properties": {
-        "clusters": {
-          "description": "A list of clusters in the project in the specified zone, or\nacross all ones.",
-          "items": {
-            "$ref": "Cluster"
-          },
-          "type": "array"
-        },
         "missingZones": {
           "description": "If any zones are listed here, the list of clusters returned\nmay be missing those zones.",
           "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "clusters": {
+          "description": "A list of clusters in the project in the specified zone, or\nacross all ones.",
+          "items": {
+            "$ref": "Cluster"
           },
           "type": "array"
         }
@@ -1943,67 +1863,62 @@
       },
       "id": "SetNetworkPolicyRequest"
     },
-    "SetMasterAuthRequest": {
-      "description": "SetMasterAuthRequest updates the admin password of a cluster.",
-      "type": "object",
-      "properties": {
-        "update": {
-          "description": "A description of the update.",
-          "$ref": "MasterAuth"
-        },
-        "action": {
-          "description": "The exact form of action to be taken on the master auth",
-          "type": "string",
-          "enumDescriptions": [
-            "Operation is unknown and will error out",
-            "Set the password to a user generated value.",
-            "Generate a new password and set it to that."
-          ],
-          "enum": [
-            "UNKNOWN",
-            "SET_PASSWORD",
-            "GENERATE_PASSWORD"
-          ]
-        }
-      },
-      "id": "SetMasterAuthRequest"
-    },
     "NodePoolAutoscaling": {
       "description": "NodePoolAutoscaling contains information required by cluster autoscaler to\nadjust the size of the node pool to the current cluster usage.",
       "type": "object",
       "properties": {
-        "enabled": {
-          "description": "Is autoscaling enabled for this node pool.",
-          "type": "boolean"
-        },
         "maxNodeCount": {
+          "type": "integer",
           "format": "int32",
-          "description": "Maximum number of nodes in the NodePool. Must be \u003e= min_node_count. There\nhas to enough quota to scale up the cluster.",
-          "type": "integer"
+          "description": "Maximum number of nodes in the NodePool. Must be \u003e= min_node_count. There\nhas to enough quota to scale up the cluster."
         },
         "minNodeCount": {
           "format": "int32",
           "description": "Minimum number of nodes in the NodePool. Must be \u003e= 1 and \u003c=\nmax_node_count.",
           "type": "integer"
+        },
+        "enabled": {
+          "description": "Is autoscaling enabled for this node pool.",
+          "type": "boolean"
         }
       },
       "id": "NodePoolAutoscaling"
     },
-    "ClientCertificateConfig": {
-      "description": "Configuration for client certificates on the cluster.",
+    "SetMasterAuthRequest": {
+      "description": "SetMasterAuthRequest updates the admin password of a cluster.",
       "type": "object",
       "properties": {
-        "issueClientCertificate": {
-          "description": "Issue a client certificate.",
-          "type": "boolean"
+        "action": {
+          "description": "The exact form of action to be taken on the master auth.",
+          "type": "string",
+          "enumDescriptions": [
+            "Operation is unknown and will error out.",
+            "Set the password to a user generated value.",
+            "Generate a new password and set it to that.",
+            "Set the username.  If an empty username is provided, basic authentication\nis disabled for the cluster.  If a non-empty username is provided, basic\nauthentication is enabled, with either a provided password or a generated\none."
+          ],
+          "enum": [
+            "UNKNOWN",
+            "SET_PASSWORD",
+            "GENERATE_PASSWORD",
+            "SET_USERNAME"
+          ]
+        },
+        "update": {
+          "$ref": "MasterAuth",
+          "description": "A description of the update."
         }
       },
-      "id": "ClientCertificateConfig"
+      "id": "SetMasterAuthRequest"
     },
     "IPAllocationPolicy": {
       "description": "Configuration for controlling how IPs are allocated in the cluster.",
       "type": "object",
       "properties": {
+        "nodeIpv4Cidr": {
+          "type": "string",
+          "description": "This field is deprecated, use node_ipv4_cidr_block."
+        },
         "clusterIpv4CidrBlock": {
           "description": "The IP address range for the cluster pod IPs. If this field is set, then\n`cluster.cluster_ipv4_cidr` must be left blank.\n\nThis field is only applicable when `use_ip_aliases` is true.\n\nSet to blank to have a range chosen with the default size.\n\nSet to /netmask (e.g. `/14`) to have a range chosen with a specific\nnetmask.\n\nSet to a\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.\n`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range\nto use.",
           "type": "string"
@@ -2032,29 +1947,32 @@
           "description": "The name of the secondary range to be used as for the services\nCIDR block.  The secondary range will be used for service\nClusterIPs. This must be an existing secondary range associated\nwith the cluster subnetwork.\n\nThis field is only applicable with use_ip_aliases is true and\ncreate_subnetwork is false.",
           "type": "string"
         },
-        "servicesIpv4CidrBlock": {
-          "description": "The IP address range of the services IPs in this cluster. If blank, a range\nwill be automatically chosen with the default size.\n\nThis field is only applicable when `use_ip_aliases` is true.\n\nSet to blank to have a range chosen with the default size.\n\nSet to /netmask (e.g. `/14`) to have a range chosen with a specific\nnetmask.\n\nSet to a\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.\n`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range\nto use.",
-          "type": "string"
-        },
         "subnetworkName": {
           "description": "A custom subnetwork name to be used if `create_subnetwork` is true.  If\nthis field is empty, then an automatic name will be chosen for the new\nsubnetwork.",
           "type": "string"
         },
-        "clusterIpv4Cidr": {
-          "description": "This field is deprecated, use cluster_ipv4_cidr_block.",
+        "servicesIpv4CidrBlock": {
+          "description": "The IP address range of the services IPs in this cluster. If blank, a range\nwill be automatically chosen with the default size.\n\nThis field is only applicable when `use_ip_aliases` is true.\n\nSet to blank to have a range chosen with the default size.\n\nSet to /netmask (e.g. `/14`) to have a range chosen with a specific\nnetmask.\n\nSet to a\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.\n`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range\nto use.",
           "type": "string"
         },
-        "nodeIpv4Cidr": {
-          "description": "This field is deprecated, use node_ipv4_cidr_block.",
+        "clusterIpv4Cidr": {
+          "description": "This field is deprecated, use cluster_ipv4_cidr_block.",
           "type": "string"
         }
       },
       "id": "IPAllocationPolicy"
     },
     "ClusterUpdate": {
-      "description": "ClusterUpdate describes an update to the cluster. Exactly one update can\nbe applied to a cluster with each request, so at most one field can be\nprovided.",
       "type": "object",
       "properties": {
+        "desiredImageType": {
+          "description": "The desired image type for the node pool.\nNOTE: Set the \"desired_node_pool\" field as well.",
+          "type": "string"
+        },
+        "desiredAddonsConfig": {
+          "$ref": "AddonsConfig",
+          "description": "Configurations for the various addons available to run in the cluster."
+        },
         "desiredNodePoolId": {
           "description": "The node pool to be upgraded. This field is mandatory if\n\"desired_node_version\", \"desired_image_family\" or\n\"desired_node_pool_autoscaling\" is specified and there is more than one\nnode pool on the cluster.",
           "type": "string"
@@ -2064,12 +1982,16 @@
           "type": "string"
         },
         "desiredMasterVersion": {
-          "description": "The Kubernetes version to change the master to. The only valid value is the\nlatest supported version. Use \"-\" to have the server automatically select\nthe latest version.",
-          "type": "string"
+          "type": "string",
+          "description": "The Kubernetes version to change the master to. The only valid value is the\nlatest supported version. Use \"-\" to have the server automatically select\nthe latest version."
         },
         "desiredMasterAuthorizedNetworksConfig": {
           "$ref": "MasterAuthorizedNetworksConfig",
           "description": "Master authorized networks is a Beta feature.\nThe desired configuration options for master authorized networks feature."
+        },
+        "desiredNodePoolAutoscaling": {
+          "$ref": "NodePoolAutoscaling",
+          "description": "Autoscaler configuration for the node pool specified in\ndesired_node_pool_id. If there is only one pool in the\ncluster and desired_node_pool_id is not provided then\nthe change applies to that single node pool."
         },
         "desiredLocations": {
           "description": "The desired list of Google Compute Engine\n[locations](/compute/docs/zones#available) in which the cluster's nodes\nshould be located. Changing the locations a cluster is in will result\nin nodes being either created or removed from the cluster, depending on\nwhether locations are being added or removed.\n\nThis list must always include the cluster's primary zone.",
@@ -2078,35 +2000,13 @@
           },
           "type": "array"
         },
-        "desiredNodePoolAutoscaling": {
-          "description": "Autoscaler configuration for the node pool specified in\ndesired_node_pool_id. If there is only one pool in the\ncluster and desired_node_pool_id is not provided then\nthe change applies to that single node pool.",
-          "$ref": "NodePoolAutoscaling"
-        },
         "desiredMonitoringService": {
-          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* \"monitoring.googleapis.com\" - the Google Cloud Monitoring service\n* \"none\" - no metrics will be exported from the cluster",
-          "type": "string"
-        },
-        "desiredImageType": {
-          "description": "The desired image type for the node pool.\nNOTE: Set the \"desired_node_pool\" field as well.",
-          "type": "string"
-        },
-        "desiredAddonsConfig": {
-          "$ref": "AddonsConfig",
-          "description": "Configurations for the various addons available to run in the cluster."
+          "type": "string",
+          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* \"monitoring.googleapis.com\" - the Google Cloud Monitoring service\n* \"none\" - no metrics will be exported from the cluster"
         }
       },
-      "id": "ClusterUpdate"
-    },
-    "SetLoggingServiceRequest": {
-      "description": "SetLoggingServiceRequest sets the logging service of a cluster.",
-      "type": "object",
-      "properties": {
-        "loggingService": {
-          "description": "The logging service the cluster should use to write metrics.\nCurrently available options:\n\n* \"logging.googleapis.com\" - the Google Cloud Logging service\n* \"none\" - no metrics will be exported from the cluster",
-          "type": "string"
-        }
-      },
-      "id": "SetLoggingServiceRequest"
+      "id": "ClusterUpdate",
+      "description": "ClusterUpdate describes an update to the cluster. Exactly one update can\nbe applied to a cluster with each request, so at most one field can be\nprovided."
     },
     "HorizontalPodAutoscaling": {
       "description": "Configuration options for the horizontal pod autoscaling feature, which\nincreases or decreases the number of replica pods a replication controller\nhas based on the resource usage of the existing pods.",
@@ -2120,7 +2020,6 @@
       "id": "HorizontalPodAutoscaling"
     },
     "MasterAuthorizedNetworksConfig": {
-      "description": "Master authorized networks is a Beta feature.\nConfiguration options for the master authorized networks feature. Enabled\nmaster authorized networks will disallow all external traffic to access\nKubernetes master through HTTPS except traffic from the given CIDR blocks,\nGoogle Compute Engine Public IPs and Google Prod IPs.",
       "type": "object",
       "properties": {
         "enabled": {
@@ -2135,13 +2034,8 @@
           "type": "array"
         }
       },
-      "id": "MasterAuthorizedNetworksConfig"
-    },
-    "Empty": {
-      "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }\n\nThe JSON representation for `Empty` is empty JSON object `{}`.",
-      "type": "object",
-      "properties": {},
-      "id": "Empty"
+      "id": "MasterAuthorizedNetworksConfig",
+      "description": "Master authorized networks is a Beta feature.\nConfiguration options for the master authorized networks feature. Enabled\nmaster authorized networks will disallow all external traffic to access\nKubernetes master through HTTPS except traffic from the given CIDR blocks,\nGoogle Compute Engine Public IPs and Google Prod IPs."
     },
     "SetNodePoolManagementRequest": {
       "description": "SetNodePoolManagementRequest sets the node management properties of a node\npool.",
@@ -2176,43 +2070,6 @@
       },
       "id": "CreateClusterRequest"
     },
-    "ListNodePoolsResponse": {
-      "description": "ListNodePoolsResponse is the result of ListNodePoolsRequest.",
-      "type": "object",
-      "properties": {
-        "nodePools": {
-          "description": "A list of node pools for a cluster.",
-          "items": {
-            "$ref": "NodePool"
-          },
-          "type": "array"
-        }
-      },
-      "id": "ListNodePoolsResponse"
-    },
-    "CompleteIPRotationRequest": {
-      "description": "CompleteIPRotationRequest moves the cluster master back into single-IP mode.",
-      "type": "object",
-      "properties": {},
-      "id": "CompleteIPRotationRequest"
-    },
-    "StartIPRotationRequest": {
-      "description": "StartIPRotationRequest creates a new IP for the cluster and then performs\na node upgrade on each node pool to point to the new IP.",
-      "type": "object",
-      "properties": {},
-      "id": "StartIPRotationRequest"
-    },
-    "LegacyAbac": {
-      "description": "Configuration for the legacy Attribute Based Access Control authorization\nmode.",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "description": "Whether the ABAC authorizer is enabled for this cluster. When enabled,\nidentities in the system, including service accounts, nodes, and\ncontrollers, will have statically granted permissions beyond those\nprovided by the RBAC configuration or IAM.",
-          "type": "boolean"
-        }
-      },
-      "id": "LegacyAbac"
-    },
     "UpdateNodePoolRequest": {
       "description": "UpdateNodePoolRequests update a node pool's image and/or version.",
       "type": "object",
@@ -2244,128 +2101,394 @@
       },
       "id": "AcceleratorConfig"
     },
+    "LegacyAbac": {
+      "description": "Configuration for the legacy Attribute Based Access Control authorization\nmode.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether the ABAC authorizer is enabled for this cluster. When enabled,\nidentities in the system, including service accounts, nodes, and\ncontrollers, will have statically granted permissions beyond those\nprovided by the RBAC configuration or IAM.",
+          "type": "boolean"
+        }
+      },
+      "id": "LegacyAbac"
+    },
     "SetAddonsConfigRequest": {
+      "properties": {
+        "addonsConfig": {
+          "$ref": "AddonsConfig",
+          "description": "The desired configurations for the various addons available to run in the\ncluster."
+        }
+      },
+      "id": "SetAddonsConfigRequest",
       "description": "SetAddonsConfigRequest sets the addons associated with the cluster.",
+      "type": "object"
+    },
+    "SetLegacyAbacRequest": {
+      "description": "SetLegacyAbacRequest enables or disables the ABAC authorization mechanism for\na cluster.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether ABAC authorization will be enabled in the cluster.",
+          "type": "boolean"
+        }
+      },
+      "id": "SetLegacyAbacRequest"
+    },
+    "AddonsConfig": {
+      "description": "Configuration for the addons that can be automatically spun up in the\ncluster, enabling additional functionality.",
+      "type": "object",
+      "properties": {
+        "networkPolicyConfig": {
+          "description": "Configuration for NetworkPolicy. This only tracks whether the addon\nis enabled or not on the Master, it does not track whether network policy\nis enabled for the nodes.",
+          "$ref": "NetworkPolicyConfig"
+        },
+        "horizontalPodAutoscaling": {
+          "$ref": "HorizontalPodAutoscaling",
+          "description": "Configuration for the horizontal pod autoscaling feature, which\nincreases or decreases the number of replica pods a replication controller\nhas based on the resource usage of the existing pods."
+        },
+        "httpLoadBalancing": {
+          "$ref": "HttpLoadBalancing",
+          "description": "Configuration for the HTTP (L7) load balancing controller addon, which\nmakes it easy to set up HTTP load balancers for services in a cluster."
+        },
+        "kubernetesDashboard": {
+          "$ref": "KubernetesDashboard",
+          "description": "Configuration for the Kubernetes Dashboard."
+        }
+      },
+      "id": "AddonsConfig"
+    },
+    "SetLocationsRequest": {
+      "properties": {
+        "locations": {
+          "description": "The desired list of Google Compute Engine\n[locations](/compute/docs/zones#available) in which the cluster's nodes\nshould be located. Changing the locations a cluster is in will result\nin nodes being either created or removed from the cluster, depending on\nwhether locations are being added or removed.\n\nThis list must always include the cluster's primary zone.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "id": "SetLocationsRequest",
+      "description": "SetLocationsRequest sets the locations of the cluster.",
+      "type": "object"
+    },
+    "SetNodePoolSizeRequest": {
+      "type": "object",
+      "properties": {
+        "nodeCount": {
+          "format": "int32",
+          "description": "The desired node count for the pool.",
+          "type": "integer"
+        }
+      },
+      "id": "SetNodePoolSizeRequest",
+      "description": "SetNodePoolSizeRequest sets the size a node\npool."
+    },
+    "NetworkPolicyConfig": {
+      "properties": {
+        "disabled": {
+          "description": "Whether NetworkPolicy is enabled for this cluster.",
+          "type": "boolean"
+        }
+      },
+      "id": "NetworkPolicyConfig",
+      "description": "Configuration for NetworkPolicy. This only tracks whether the addon\nis enabled or not on the Master, it does not track whether network policy\nis enabled for the nodes.",
+      "type": "object"
+    },
+    "UpdateClusterRequest": {
+      "description": "UpdateClusterRequest updates the settings of a cluster.",
+      "type": "object",
+      "properties": {
+        "update": {
+          "description": "A description of the update.",
+          "$ref": "ClusterUpdate"
+        }
+      },
+      "id": "UpdateClusterRequest"
+    },
+    "Cluster": {
+      "description": "A Google Container Engine cluster.",
       "type": "object",
       "properties": {
         "addonsConfig": {
-          "description": "The desired configurations for the various addons available to run in the\ncluster.",
-          "$ref": "AddonsConfig"
-        }
-      },
-      "id": "SetAddonsConfigRequest"
-    },
-    "SetLabelsRequest": {
-      "description": "SetLabelsRequest sets the Google Cloud Platform labels on a Google Container\nEngine cluster, which will in turn set them for Google Compute Engine\nresources used by that cluster",
-      "type": "object",
-      "properties": {
+          "$ref": "AddonsConfig",
+          "description": "Configurations for the various addons available to run in the cluster."
+        },
+        "status": {
+          "enum": [
+            "STATUS_UNSPECIFIED",
+            "PROVISIONING",
+            "RUNNING",
+            "RECONCILING",
+            "STOPPING",
+            "ERROR"
+          ],
+          "description": "[Output only] The current status of this cluster.",
+          "type": "string",
+          "enumDescriptions": [
+            "Not set.",
+            "The PROVISIONING state indicates the cluster is being created.",
+            "The RUNNING state indicates the cluster has been created and is fully\nusable.",
+            "The RECONCILING state indicates that some work is actively being done on\nthe cluster, such as upgrading the master or node software. Details can\nbe found in the `statusMessage` field.",
+            "The STOPPING state indicates the cluster is being deleted.",
+            "The ERROR state indicates the cluster may be unusable. Details\ncan be found in the `statusMessage` field."
+          ]
+        },
+        "subnetwork": {
+          "description": "The name of the Google Compute Engine\n[subnetwork](/compute/docs/subnetworks) to which the\ncluster is connected.",
+          "type": "string"
+        },
+        "currentNodeVersion": {
+          "description": "[Output only] The current version of the node software components.\nIf they are currently at multiple versions because they're in the process\nof being upgraded, this reflects the minimum version of all nodes.",
+          "type": "string"
+        },
+        "maintenancePolicy": {
+          "description": "Configure the maintenance policy for this cluster.",
+          "$ref": "MaintenancePolicy"
+        },
         "resourceLabels": {
+          "description": "The resource labels for the cluster to use to annotate any related\nGoogle Compute Engine resources.",
+          "type": "object",
           "additionalProperties": {
             "type": "string"
-          },
-          "description": "The labels to set for that cluster.",
-          "type": "object"
+          }
         },
-        "labelFingerprint": {
-          "description": "The fingerprint of the previous set of labels for this resource,\nused to detect conflicts. The fingerprint is initially generated by\nContainer Engine and changes after every request to modify or update\nlabels. You must always provide an up-to-date fingerprint hash when\nupdating or changing labels. Make a \u003ccode\u003eget()\u003c/code\u003e request to the\nresource to get the latest fingerprint.",
+        "name": {
+          "description": "The name of this cluster. The name must be unique within this project\nand zone, and can be up to 40 characters with the following restrictions:\n\n* Lowercase letters, numbers, and hyphens only.\n* Must start with a letter.\n* Must end with a number or a letter.",
           "type": "string"
-        }
-      },
-      "id": "SetLabelsRequest"
-    },
-    "NodePool": {
-      "description": "NodePool contains the name and configuration for a cluster's node pool.\nNode pools are a set of nodes (i.e. VM's), with a common configuration and\nspecification, under the control of the cluster master. They may have a set\nof Kubernetes labels applied to them, which may be used to reference them\nduring pod scheduling. They may also be resized up or down, to accommodate\nthe workload.",
-      "type": "object",
-      "properties": {
-        "autoscaling": {
-          "description": "Autoscaler configuration for this NodePool. Autoscaler is enabled\nonly if a valid configuration is present.",
-          "$ref": "NodePoolAutoscaling"
         },
-        "management": {
-          "$ref": "NodeManagement",
-          "description": "NodeManagement configuration for this NodePool."
+        "initialClusterVersion": {
+          "description": "The initial Kubernetes version for this cluster.  Valid versions are those\nfound in validMasterVersions returned by getServerConfig.  The version can\nbe upgraded over time; such upgrades are reflected in\ncurrentMasterVersion and currentNodeVersion.",
+          "type": "string"
+        },
+        "ipAllocationPolicy": {
+          "$ref": "IPAllocationPolicy",
+          "description": "Configuration for cluster IP allocation."
+        },
+        "endpoint": {
+          "description": "[Output only] The IP address of this cluster's master endpoint.\nThe endpoint can be accessed from the internet at\n`https://username:password@endpoint/`.\n\nSee the `masterAuth` property of this resource for username and\npassword information.",
+          "type": "string"
+        },
+        "legacyAbac": {
+          "$ref": "LegacyAbac",
+          "description": "Configuration for the legacy ABAC authorization mode."
+        },
+        "createTime": {
+          "type": "string",
+          "description": "[Output only] The time the cluster was created, in\n[RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format."
+        },
+        "clusterIpv4Cidr": {
+          "type": "string",
+          "description": "The IP address range of the container pods in this cluster, in\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `10.96.0.0/14`). Leave blank to have\none automatically chosen or specify a `/14` block in `10.0.0.0/8`."
         },
         "initialNodeCount": {
           "format": "int32",
-          "description": "The initial node count for the pool. You must ensure that your\nCompute Engine \u003ca href=\"/compute/docs/resource-quotas\"\u003eresource quota\u003c/a\u003e\nis sufficient for this number of instances. You must also have available\nfirewall and routes quota.",
+          "description": "The number of nodes to create in this cluster. You must ensure that your\nCompute Engine \u003ca href=\"/compute/docs/resource-quotas\"\u003eresource quota\u003c/a\u003e\nis sufficient for this number of instances. You must also have available\nfirewall and routes quota.\nFor requests, this field should only be used in lieu of a\n\"node_pool\" object, since this configuration (along with the\n\"node_config\") will be used to create a \"NodePool\" object with an\nauto-generated name. Do not use this and a node_pool at the same time.",
           "type": "integer"
+        },
+        "nodePools": {
+          "description": "The node pools associated with this cluster.\nThis field should not be set if \"node_config\" or \"initial_node_count\" are\nspecified.",
+          "items": {
+            "$ref": "NodePool"
+          },
+          "type": "array"
+        },
+        "locations": {
+          "description": "The list of Google Compute Engine\n[locations](/compute/docs/zones#available) in which the cluster's nodes\nshould be located.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "selfLink": {
           "description": "[Output only] Server-defined URL for the resource.",
           "type": "string"
         },
         "instanceGroupUrls": {
-          "description": "[Output only] The resource URLs of [instance\ngroups](/compute/docs/instance-groups/) associated with this\nnode pool.",
+          "description": "[Output only] The resource URLs of [instance\ngroups](/compute/docs/instance-groups/) associated with this\ncluster.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "version": {
-          "description": "[Output only] The version of the Kubernetes of this node.",
+        "servicesIpv4Cidr": {
+          "description": "[Output only] The IP address range of the Kubernetes services in\nthis cluster, in\n[CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)\nnotation (e.g. `1.2.3.4/29`). Service addresses are\ntypically put in the last `/16` from the container CIDR.",
           "type": "string"
         },
-        "status": {
-          "enumDescriptions": [
-            "Not set.",
-            "The PROVISIONING state indicates the node pool is being created.",
-            "The RUNNING state indicates the node pool has been created\nand is fully usable.",
-            "The RUNNING_WITH_ERROR state indicates the node pool has been created\nand is partially usable. Some error state has occurred and some\nfunctionality may be impaired. Customer may need to reissue a request\nor trigger a new update.",
-            "The RECONCILING state indicates that some work is actively being done on\nthe node pool, such as upgrading node software. Details can\nbe found in the `statusMessage` field.",
-            "The STOPPING state indicates the node pool is being deleted.",
-            "The ERROR state indicates the node pool may be unusable. Details\ncan be found in the `statusMessage` field."
-          ],
-          "enum": [
-            "STATUS_UNSPECIFIED",
-            "PROVISIONING",
-            "RUNNING",
-            "RUNNING_WITH_ERROR",
-            "RECONCILING",
-            "STOPPING",
-            "ERROR"
-          ],
-          "description": "[Output only] The status of the nodes in this pool instance.",
+        "networkPolicy": {
+          "$ref": "NetworkPolicy",
+          "description": "Configuration options for the NetworkPolicy feature."
+        },
+        "enableKubernetesAlpha": {
+          "description": "Kubernetes alpha features are enabled on this cluster. This includes alpha\nAPI groups (e.g. v1alpha1) and features that may not be production ready in\nthe kubernetes version of the master and nodes.\nThe cluster has no SLA for uptime and master/node upgrades are disabled.\nAlpha enabled clusters are automatically deleted thirty days after\ncreation.",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "An optional description of this cluster.",
           "type": "string"
         },
-        "config": {
-          "description": "The node configuration of the pool.",
-          "$ref": "NodeConfig"
+        "currentNodeCount": {
+          "format": "int32",
+          "description": "[Output only] The number of nodes currently in the cluster.",
+          "type": "integer"
         },
-        "name": {
-          "description": "The name of the node pool.",
+        "monitoringService": {
+          "description": "The monitoring service the cluster should use to write metrics.\nCurrently available options:\n\n* `monitoring.googleapis.com` - the Google Cloud Monitoring service.\n* `none` - no metrics will be exported from the cluster.\n* if left as an empty string, `monitoring.googleapis.com` will be used.",
           "type": "string"
+        },
+        "network": {
+          "description": "The name of the Google Compute Engine\n[network](/compute/docs/networks-and-firewalls#networks) to which the\ncluster is connected. If left unspecified, the `default` network\nwill be used.",
+          "type": "string"
+        },
+        "labelFingerprint": {
+          "description": "The fingerprint of the set of labels for this cluster.",
+          "type": "string"
+        },
+        "zone": {
+          "description": "[Output only] The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+          "type": "string"
+        },
+        "loggingService": {
+          "description": "The logging service the cluster should use to write logs.\nCurrently available options:\n\n* `logging.googleapis.com` - the Google Cloud Logging service.\n* `none` - no logs will be exported from the cluster.\n* if left as an empty string,`logging.googleapis.com` will be used.",
+          "type": "string"
+        },
+        "expireTime": {
+          "description": "[Output only] The time the cluster will be automatically\ndeleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.",
+          "type": "string"
+        },
+        "nodeIpv4CidrSize": {
+          "format": "int32",
+          "description": "[Output only] The size of the address space on each node for hosting\ncontainers. This is provisioned from within the `container_ipv4_cidr`\nrange.",
+          "type": "integer"
+        },
+        "masterAuthorizedNetworksConfig": {
+          "$ref": "MasterAuthorizedNetworksConfig",
+          "description": "Master authorized networks is a Beta feature.\nThe configuration options for master authorized networks feature."
         },
         "statusMessage": {
-          "description": "[Output only] Additional information about the current status of this\nnode pool instance, if available.",
+          "description": "[Output only] Additional information about the current status of this\ncluster, if available.",
+          "type": "string"
+        },
+        "masterAuth": {
+          "description": "The authentication information for accessing the master endpoint.",
+          "$ref": "MasterAuth"
+        },
+        "currentMasterVersion": {
+          "description": "[Output only] The current software version of the master endpoint.",
+          "type": "string"
+        },
+        "nodeConfig": {
+          "description": "Parameters used in creating the cluster's nodes.\nSee `nodeConfig` for the description of its properties.\nFor requests, this field should only be used in lieu of a\n\"node_pool\" object, since this configuration (along with the\n\"initial_node_count\") will be used to create a \"NodePool\" object with an\nauto-generated name. Do not use this and a node_pool at the same time.\nFor responses, this field will be populated with the node configuration of\nthe first node pool.\n\nIf unspecified, the defaults are used.",
+          "$ref": "NodeConfig"
+        }
+      },
+      "id": "Cluster"
+    },
+    "CreateNodePoolRequest": {
+      "id": "CreateNodePoolRequest",
+      "description": "CreateNodePoolRequest creates a node pool for a cluster.",
+      "type": "object",
+      "properties": {
+        "nodePool": {
+          "description": "The node pool to create.",
+          "$ref": "NodePool"
+        }
+      }
+    },
+    "MasterAuth": {
+      "properties": {
+        "username": {
+          "description": "The username to use for HTTP basic authentication to the master endpoint.\nFor clusters v1.6.0 and later, you can disable basic authentication by\nproviding an empty username.",
+          "type": "string"
+        },
+        "password": {
+          "description": "The password to use for HTTP basic authentication to the master endpoint.\nBecause the master endpoint is open to the Internet, you should create a\nstrong password.  If a password is provided for cluster creation, username\nmust be non-empty.",
+          "type": "string"
+        },
+        "clientCertificateConfig": {
+          "$ref": "ClientCertificateConfig",
+          "description": "Configuration for client certificate authentication on the cluster.  If no\nconfiguration is specified, a client certificate is issued."
+        },
+        "clientKey": {
+          "description": "[Output only] Base64-encoded private key used by clients to authenticate\nto the cluster endpoint.",
+          "type": "string"
+        },
+        "clusterCaCertificate": {
+          "description": "[Output only] Base64-encoded public certificate that is the root of\ntrust for the cluster.",
+          "type": "string"
+        },
+        "clientCertificate": {
+          "type": "string",
+          "description": "[Output only] Base64-encoded public certificate used by clients to\nauthenticate to the cluster endpoint."
+        }
+      },
+      "id": "MasterAuth",
+      "description": "The authentication information for accessing the master endpoint.\nAuthentication can be done using HTTP basic auth or using client\ncertificates.",
+      "type": "object"
+    },
+    "DailyMaintenanceWindow": {
+      "id": "DailyMaintenanceWindow",
+      "description": "Time window specified for daily maintenance operations.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "[Output only] Duration of the time window, automatically chosen to be\nsmallest possible in the given scenario.\nDuration will be in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)\nformat \"PTnHnMnS\".",
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Time within the maintenance window to start the maintenance operations.\nTime format should be in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)\nformat \"HH:MM”, where HH : [00-23] and MM : [00-59] GMT."
+        }
+      }
+    },
+    "MaintenancePolicy": {
+      "id": "MaintenancePolicy",
+      "description": "MaintenancePolicy defines the maintenance policy to be used for the cluster.",
+      "type": "object",
+      "properties": {
+        "window": {
+          "$ref": "MaintenanceWindow",
+          "description": "Specifies the maintenance window in which maintenance may be performed."
+        }
+      }
+    },
+    "ClientCertificateConfig": {
+      "description": "Configuration for client certificates on the cluster.",
+      "type": "object",
+      "properties": {
+        "issueClientCertificate": {
+          "description": "Issue a client certificate.",
+          "type": "boolean"
+        }
+      },
+      "id": "ClientCertificateConfig"
+    },
+    "SetLoggingServiceRequest": {
+      "description": "SetLoggingServiceRequest sets the logging service of a cluster.",
+      "type": "object",
+      "properties": {
+        "loggingService": {
+          "description": "The logging service the cluster should use to write metrics.\nCurrently available options:\n\n* \"logging.googleapis.com\" - the Google Cloud Logging service\n* \"none\" - no metrics will be exported from the cluster",
           "type": "string"
         }
       },
-      "id": "NodePool"
+      "id": "SetLoggingServiceRequest"
     },
-    "NodeManagement": {
-      "description": "NodeManagement defines the set of node management services turned on for the\nnode pool.",
+    "SetMaintenancePolicyRequest": {
       "type": "object",
       "properties": {
-        "autoRepair": {
-          "description": "A flag that specifies whether the node auto-repair is enabled for the node\npool. If enabled, the nodes in this node pool will be monitored and, if\nthey fail health checks too many times, an automatic repair action will be\ntriggered.",
-          "type": "boolean"
-        },
-        "autoUpgrade": {
-          "description": "A flag that specifies whether node auto-upgrade is enabled for the node\npool. If enabled, node auto-upgrade helps keep the nodes in your node pool\nup to date with the latest release version of Kubernetes.",
-          "type": "boolean"
-        },
-        "upgradeOptions": {
-          "$ref": "AutoUpgradeOptions",
-          "description": "Specifies the Auto Upgrade knobs for the node pool."
+        "maintenancePolicy": {
+          "$ref": "MaintenancePolicy",
+          "description": "The maintenance policy to be set for the cluster. An empty field\nclears the existing maintenance policy."
         }
       },
-      "id": "NodeManagement"
+      "id": "SetMaintenancePolicyRequest",
+      "description": "SetMaintenancePolicyRequest sets the maintenance policy for a cluster."
     }
   },
   "protocol": "rest",
   "icons": {
-    "x32": "http://www.google.com/images/icons/product/search-32.gif",
-    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
   },
   "version": "v1",
   "baseUrl": "https://container.googleapis.com/",
@@ -2379,18 +2502,11 @@
       }
     }
   },
-  "servicePath": "",
   "description": "The Google Container Engine API is used for building and managing container based applications, powered by the open source Kubernetes technology.",
+  "servicePath": "",
   "kind": "discovery#restDescription",
   "rootUrl": "https://container.googleapis.com/",
   "basePath": "",
   "ownerDomain": "google.com",
-  "name": "container",
-  "batchPath": "batch",
-  "id": "container:v1",
-  "documentationLink": "https://cloud.google.com/container-engine/",
-  "revision": "20170825",
-  "title": "Google Container Engine API",
-  "discoveryVersion": "v1",
-  "ownerName": "Google"
+  "name": "container"
 }

--- a/vendor/google.golang.org/api/container/v1/container-gen.go
+++ b/vendor/google.golang.org/api/container/v1/container-gen.go
@@ -188,6 +188,13 @@ type AddonsConfig struct {
 	// KubernetesDashboard: Configuration for the Kubernetes Dashboard.
 	KubernetesDashboard *KubernetesDashboard `json:"kubernetesDashboard,omitempty"`
 
+	// NetworkPolicyConfig: Configuration for NetworkPolicy. This only
+	// tracks whether the addon
+	// is enabled or not on the Master, it does not track whether network
+	// policy
+	// is enabled for the nodes.
+	NetworkPolicyConfig *NetworkPolicyConfig `json:"networkPolicyConfig,omitempty"`
+
 	// ForceSendFields is a list of field names (e.g.
 	// "HorizontalPodAutoscaling") to unconditionally include in API
 	// requests. By default, fields with empty values are omitted from API
@@ -445,6 +452,9 @@ type Cluster struct {
 	// * `none` - no logs will be exported from the cluster.
 	// * if left as an empty string,`logging.googleapis.com` will be used.
 	LoggingService string `json:"loggingService,omitempty"`
+
+	// MaintenancePolicy: Configure the maintenance policy for this cluster.
+	MaintenancePolicy *MaintenancePolicy `json:"maintenancePolicy,omitempty"`
 
 	// MasterAuth: The authentication information for accessing the master
 	// endpoint.
@@ -754,6 +764,47 @@ type CreateNodePoolRequest struct {
 
 func (s *CreateNodePoolRequest) MarshalJSON() ([]byte, error) {
 	type noMethod CreateNodePoolRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DailyMaintenanceWindow: Time window specified for daily maintenance
+// operations.
+type DailyMaintenanceWindow struct {
+	// Duration: [Output only] Duration of the time window, automatically
+	// chosen to be
+	// smallest possible in the given scenario.
+	// Duration will be in
+	// [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)
+	// format "PTnHnMnS".
+	Duration string `json:"duration,omitempty"`
+
+	// StartTime: Time within the maintenance window to start the
+	// maintenance operations.
+	// Time format should be in
+	// [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)
+	// format "HH:MM”, where HH : [00-23] and MM : [00-59] GMT.
+	StartTime string `json:"startTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Duration") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Duration") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DailyMaintenanceWindow) MarshalJSON() ([]byte, error) {
+	type noMethod DailyMaintenanceWindow
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -1169,6 +1220,68 @@ func (s *ListOperationsResponse) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// MaintenancePolicy: MaintenancePolicy defines the maintenance policy
+// to be used for the cluster.
+type MaintenancePolicy struct {
+	// Window: Specifies the maintenance window in which maintenance may be
+	// performed.
+	Window *MaintenanceWindow `json:"window,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Window") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Window") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MaintenancePolicy) MarshalJSON() ([]byte, error) {
+	type noMethod MaintenancePolicy
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MaintenanceWindow: MaintenanceWindow defines the maintenance window
+// to be used for the cluster.
+type MaintenanceWindow struct {
+	// DailyMaintenanceWindow: DailyMaintenanceWindow specifies a daily
+	// maintenance operation window.
+	DailyMaintenanceWindow *DailyMaintenanceWindow `json:"dailyMaintenanceWindow,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DailyMaintenanceWindow") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DailyMaintenanceWindow")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MaintenanceWindow) MarshalJSON() ([]byte, error) {
+	type noMethod MaintenanceWindow
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // MasterAuth: The authentication information for accessing the master
 // endpoint.
 // Authentication can be done using HTTP basic auth or using
@@ -1314,6 +1427,38 @@ func (s *NetworkPolicy) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// NetworkPolicyConfig: Configuration for NetworkPolicy. This only
+// tracks whether the addon
+// is enabled or not on the Master, it does not track whether network
+// policy
+// is enabled for the nodes.
+type NetworkPolicyConfig struct {
+	// Disabled: Whether NetworkPolicy is enabled for this cluster.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Disabled") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Disabled") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *NetworkPolicyConfig) MarshalJSON() ([]byte, error) {
+	type noMethod NetworkPolicyConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // NodeConfig: Parameters that describe the nodes in a cluster.
 type NodeConfig struct {
 	// Accelerators: A list of hardware accelerators to be attached to each
@@ -1393,6 +1538,20 @@ type NodeConfig struct {
 	//
 	// The total size of all keys and values must be less than 512 KB.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// MinCpuPlatform: Minimum CPU platform to be used by this instance. The
+	// instance may be
+	// scheduled on the specified or newer CPU platform. Applicable values
+	// are the
+	// friendly names of CPU platforms, such as
+	// <code>minCpuPlatform: &quot;Intel Haswell&quot;</code>
+	// or
+	// <code>minCpuPlatform: &quot;Intel Sandy Bridge&quot;</code>. For
+	// more
+	// information, read [how to specify min CPU
+	// platform](https://cloud.google.com/compute/docs/instances/specify-min-
+	// cpu-platform)
+	MinCpuPlatform string `json:"minCpuPlatform,omitempty"`
 
 	// OauthScopes: The set of Google API scopes to be made available on all
 	// of the
@@ -1688,6 +1847,7 @@ type Operation struct {
 	//   "SET_MASTER_AUTH" - Set/generate master auth materials
 	//   "SET_NODE_POOL_SIZE" - Set node pool size.
 	//   "SET_NETWORK_POLICY" - Updates network policy for a cluster.
+	//   "SET_MAINTENANCE_POLICY" - Set the maintenance policy.
 	OperationType string `json:"operationType,omitempty"`
 
 	// SelfLink: Server-defined URL for the resource.
@@ -1984,15 +2144,54 @@ func (s *SetLoggingServiceRequest) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// SetMaintenancePolicyRequest: SetMaintenancePolicyRequest sets the
+// maintenance policy for a cluster.
+type SetMaintenancePolicyRequest struct {
+	// MaintenancePolicy: The maintenance policy to be set for the cluster.
+	// An empty field
+	// clears the existing maintenance policy.
+	MaintenancePolicy *MaintenancePolicy `json:"maintenancePolicy,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "MaintenancePolicy")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "MaintenancePolicy") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SetMaintenancePolicyRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SetMaintenancePolicyRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // SetMasterAuthRequest: SetMasterAuthRequest updates the admin password
 // of a cluster.
 type SetMasterAuthRequest struct {
-	// Action: The exact form of action to be taken on the master auth
+	// Action: The exact form of action to be taken on the master auth.
 	//
 	// Possible values:
-	//   "UNKNOWN" - Operation is unknown and will error out
+	//   "UNKNOWN" - Operation is unknown and will error out.
 	//   "SET_PASSWORD" - Set the password to a user generated value.
 	//   "GENERATE_PASSWORD" - Generate a new password and set it to that.
+	//   "SET_USERNAME" - Set the username.  If an empty username is
+	// provided, basic authentication
+	// is disabled for the cluster.  If a non-empty username is provided,
+	// basic
+	// authentication is enabled, with either a provided password or a
+	// generated
+	// one.
 	Action string `json:"action,omitempty"`
 
 	// Update: A description of the update.
@@ -4271,6 +4470,160 @@ func (c *ProjectsZonesClustersResourceLabelsCall) Do(opts ...googleapi.CallOptio
 	//   "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/resourceLabels",
 	//   "request": {
 	//     "$ref": "SetLabelsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "container.projects.zones.clusters.setMaintenancePolicy":
+
+type ProjectsZonesClustersSetMaintenancePolicyCall struct {
+	s                           *Service
+	projectId                   string
+	zone                        string
+	clusterId                   string
+	setmaintenancepolicyrequest *SetMaintenancePolicyRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+	header_                     http.Header
+}
+
+// SetMaintenancePolicy: Sets the maintenance policy for a cluster.
+func (r *ProjectsZonesClustersService) SetMaintenancePolicy(projectId string, zone string, clusterId string, setmaintenancepolicyrequest *SetMaintenancePolicyRequest) *ProjectsZonesClustersSetMaintenancePolicyCall {
+	c := &ProjectsZonesClustersSetMaintenancePolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.zone = zone
+	c.clusterId = clusterId
+	c.setmaintenancepolicyrequest = setmaintenancepolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsZonesClustersSetMaintenancePolicyCall) Fields(s ...googleapi.Field) *ProjectsZonesClustersSetMaintenancePolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsZonesClustersSetMaintenancePolicyCall) Context(ctx context.Context) *ProjectsZonesClustersSetMaintenancePolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsZonesClustersSetMaintenancePolicyCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsZonesClustersSetMaintenancePolicyCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setmaintenancepolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMaintenancePolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"zone":      c.zone,
+		"clusterId": c.clusterId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "container.projects.zones.clusters.setMaintenancePolicy" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsZonesClustersSetMaintenancePolicyCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the maintenance policy for a cluster.",
+	//   "flatPath": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMaintenancePolicy",
+	//   "httpMethod": "POST",
+	//   "id": "container.projects.zones.clusters.setMaintenancePolicy",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "zone",
+	//     "clusterId"
+	//   ],
+	//   "parameters": {
+	//     "clusterId": {
+	//       "description": "The name of the cluster to update.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The Google Developers Console [project ID or project\nnumber](https://support.google.com/cloud/answer/6158840).",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "zone": {
+	//       "description": "The name of the Google Compute Engine\n[zone](/compute/docs/zones#available) in which the cluster\nresides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}:setMaintenancePolicy",
+	//   "request": {
+	//     "$ref": "SetMaintenancePolicyRequest"
 	//   },
 	//   "response": {
 	//     "$ref": "Operation"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -888,10 +888,10 @@
 			"revisionTime": "2017-09-27T00:04:17Z"
 		},
 		{
-			"checksumSHA1": "9DJNWrpYeGBJXNN4lb9ad3/q6L0=",
+			"checksumSHA1": "acuDPZa9rxUvFhdijdVfG4jy+rw=",
 			"path": "google.golang.org/api/container/v1",
-			"revision": "654f863362977d69086620b5f72f13e911da2410",
-			"revisionTime": "2017-09-14T00:03:44Z"
+			"revision": "7afc123cf726cd2f253faa3e144d2ab65477b18f",
+			"revisionTime": "2017-10-21T00:03:56Z"
 		},
 		{
 			"checksumSHA1": "wv8+a9dOWrdJEIt1mva9qLlTSfo=",

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -162,7 +162,7 @@ which the cluster's instances are launched
 * `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
     The instance may be scheduled on the specified or newer CPU platform. Applicable
     values are the friendly names of CPU platforms, such as `Intel Haswell`. See the
-    [official documentation](https://cloud.google.com/compute/docs/instances/specify-m  in-cpu-platform)
+    [official documentation](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
     for more information.
 
 **Addons Config** supports the following addons:

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -159,6 +159,12 @@ which the cluster's instances are launched
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
+* `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
+    The instance may be scheduled on the specified or newer CPU platform. Applicable
+    values are the friendly names of CPU platforms, such as `Intel Haswell`. See the
+    [official documentation](https://cloud.google.com/compute/docs/instances/specify-m  in-cpu-platform)
+    for more information.
+
 **Addons Config** supports the following addons:
 
 * `http_load_balancing` - (Optional) The status of the HTTP Load Balancing

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -117,7 +117,7 @@ resource "google_container_cluster" "primary" {
 * `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
     The instance may be scheduled on the specified or newer CPU platform. Applicable
     values are the friendly names of CPU platforms, such as `Intel Haswell`. See the
-    [official documentation](https://cloud.google.com/compute/docs/instances/specify-m    in-cpu-platform)
+    [official documentation](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
     for more information.
 
 The `autoscaling` block supports:

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -114,6 +114,12 @@ resource "google_container_cluster" "primary" {
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
+* `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
+    The instance may be scheduled on the specified or newer CPU platform. Applicable
+    values are the friendly names of CPU platforms, such as `Intel Haswell`. See the
+    [official documentation](https://cloud.google.com/compute/docs/instances/specify-m    in-cpu-platform)
+    for more information.
+
 The `autoscaling` block supports:
 
 * `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and


### PR DESCRIPTION
This targets #620:
- Update container/v1 API (handled independently in #624)
- Add support for master_authorized_networks in google_container_cluster

It's probably worth noting that this flag isn't supported in all zones, and the available CPU platforms differ across zones where it is supported.  I followed the same convention used in the compute_instance resource, which doesn't do any validation that I can see, but I can add validation if it makes sense to do so.

```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster -timeout 120m
=== RUN   TestAccContainerCluster_import
=== RUN   TestAccContainerCluster_basic
=== RUN   TestAccContainerCluster_withTimeout
=== RUN   TestAccContainerCluster_withAddons
=== RUN   TestAccContainerCluster_withMasterAuth
=== RUN   TestAccContainerCluster_withAdditionalZones
=== RUN   TestAccContainerCluster_withLegacyAbac
=== RUN   TestAccContainerCluster_withVersion
=== RUN   TestAccContainerCluster_updateVersion
=== RUN   TestAccContainerCluster_withNodeConfig
=== RUN   TestAccContainerCluster_withNodeConfigScopeAlias
=== RUN   TestAccContainerCluster_network
=== RUN   TestAccContainerCluster_backend
=== RUN   TestAccContainerCluster_withLogging
=== RUN   TestAccContainerCluster_withMonitoring
=== RUN   TestAccContainerCluster_withNodePoolBasic
=== RUN   TestAccContainerCluster_withNodePoolResize
=== RUN   TestAccContainerCluster_withNodePoolAutoscaling
=== RUN   TestAccContainerCluster_withNodePoolNamePrefix
=== RUN   TestAccContainerCluster_withNodePoolMultiple
=== RUN   TestAccContainerCluster_withNodePoolConflictingNameFields
=== RUN   TestAccContainerCluster_withNodePoolNodeConfig
--- PASS: TestAccContainerCluster_withNodePoolNamePrefix (371.07s)
--- PASS: TestAccContainerCluster_withNodePoolConflictingNameFields (371.71s)
--- PASS: TestAccContainerCluster_withNodePoolNodeConfig (372.95s)
--- PASS: TestAccContainerCluster_import (373.02s)
--- PASS: TestAccContainerCluster_withNodePoolMultiple (373.48s)
--- PASS: TestAccContainerCluster_backend (378.48s)
--- PASS: TestAccContainerCluster_withNodePoolBasic (382.56s)
--- PASS: TestAccContainerCluster_withMonitoring (622.97s)
--- PASS: TestAccContainerCluster_withVersion (392.99s)
--- PASS: TestAccContainerCluster_withNodeConfigScopeAlias (410.53s)
--- PASS: TestAccContainerCluster_withNodeConfig (420.80s)
--- PASS: TestAccContainerCluster_network (466.25s)
--- PASS: TestAccContainerCluster_updateVersion (669.28s)
--- PASS: TestAccContainerCluster_withLegacyAbac (640.45s)
--- PASS: TestAccContainerCluster_withAddons (538.82s)
--- PASS: TestAccContainerCluster_withNodePoolAutoscaling (791.10s)
--- PASS: TestAccContainerCluster_withMasterAuth (379.33s)
--- PASS: TestAccContainerCluster_withTimeout (370.64s)
--- PASS: TestAccContainerCluster_withAdditionalZones (479.85s)
--- PASS: TestAccContainerCluster_basic (369.87s)
--- PASS: TestAccContainerCluster_withNodePoolResize (801.13s)
--- PASS: TestAccContainerCluster_withLogging (631.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	1643.361s
```

```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerNodePool -timeout 120m
=== RUN   TestAccContainerNodePool_basic
=== RUN   TestAccContainerNodePool_namePrefix
=== RUN   TestAccContainerNodePool_noName
=== RUN   TestAccContainerNodePool_withNodeConfig
=== RUN   TestAccContainerNodePool_withNodeConfigScopeAlias
=== RUN   TestAccContainerNodePool_autoscaling
=== RUN   TestAccContainerNodePool_resize
--- PASS: TestAccContainerNodePool_basic (584.13s)
--- PASS: TestAccContainerNodePool_namePrefix (591.89s)
--- PASS: TestAccContainerNodePool_noName (595.05s)
--- PASS: TestAccContainerNodePool_withNodeConfigScopeAlias (655.04s)
--- PASS: TestAccContainerNodePool_withNodeConfig (659.93s)
--- PASS: TestAccContainerNodePool_resize (969.98s)
--- PASS: TestAccContainerNodePool_autoscaling (1189.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	1189.802s
```