### PR TITLE
Add support for master authorized networks in `google_container_cluster`

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -936,7 +936,6 @@ func flattenMasterAuthorizedNetworksConfig(c *container.MasterAuthorizedNetworks
 				"display_name": v.DisplayName,
 			})
 		}
-		// now does this adhere to the schema?
 		result["cidr_blocks"] = cidrBlocks
 	}
 	return []map[string]interface{}{result}

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -137,8 +137,8 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"8.8.8.8/32"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster("google_container_cluster.with_master_authorized_networks"),
-					resource.TestCheckNoResourceAttr("google_container_cluster.with_master_authorized_networks",
-						"master_authorized_networks_config.0.cidr_blocks"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
+						"master_authorized_networks_config.0.cidr_blocks.#", "1"),
 				),
 			},
 		},
@@ -943,7 +943,7 @@ resource "google_container_cluster" "with_master_authorized_networks" {
 
 	master_authorized_networks_config {
 		%s
-    }
+	}
 }`, clusterName, cidrBlocks)
 }
 

--- a/google/validation_test.go
+++ b/google/validation_test.go
@@ -28,9 +28,42 @@ func TestValidateGCPName(t *testing.T) {
 	}
 }
 
+func TestValidateRFC1918Network(t *testing.T) {
+	x := []RFC1918NetworkTestCase{
+		// No errors
+		{TestName: "valid 10.x", CIDR: "10.0.0.0/8", MinPrefix: 0, MaxPrefix: 32},
+		{TestName: "valid 172.x", CIDR: "172.16.0.0/16", MinPrefix: 0, MaxPrefix: 32},
+		{TestName: "valid 192.x", CIDR: "192.168.0.0/32", MinPrefix: 0, MaxPrefix: 32},
+		{TestName: "valid, bounded 10.x CIDR", CIDR: "10.0.0.0/8", MinPrefix: 8, MaxPrefix: 32},
+		{TestName: "valid, bounded 172.x CIDR", CIDR: "172.16.0.0/16", MinPrefix: 12, MaxPrefix: 32},
+		{TestName: "valid, bounded 192.x CIDR", CIDR: "192.168.0.0/32", MinPrefix: 16, MaxPrefix: 32},
+
+		// With errors
+		{TestName: "empty CIDR", CIDR: "", MinPrefix: 0, MaxPrefix: 32, ExpectError: true},
+		{TestName: "missing mask", CIDR: "10.0.0.0", MinPrefix: 0, MaxPrefix: 32, ExpectError: true},
+		{TestName: "invalid CIDR", CIDR: "10.1.0.0/8", MinPrefix: 0, MaxPrefix: 32, ExpectError: true},
+		{TestName: "valid 10.x CIDR with lower bound violation", CIDR: "10.0.0.0/8", MinPrefix: 16, MaxPrefix: 32, ExpectError: true},
+		{TestName: "valid 10.x CIDR with upper bound violation", CIDR: "10.0.0.0/24", MinPrefix: 8, MaxPrefix: 16, ExpectError: true},
+		{TestName: "valid public CIDR", CIDR: "8.8.8.8/32", MinPrefix: 0, MaxPrefix: 32, ExpectError: true},
+	}
+
+	es := testRFC1918Networks(x)
+	if len(es) > 0 {
+		t.Errorf("Failed to validate RFC1918 Networks: %v", es)
+	}
+}
+
 type GCPNameTestCase struct {
 	TestName    string
 	Value       string
+	ExpectError bool
+}
+
+type RFC1918NetworkTestCase struct {
+	TestName    string
+	CIDR        string
+	MinPrefix   int
+	MaxPrefix   int
 	ExpectError bool
 }
 
@@ -51,6 +84,29 @@ func testGCPName(testCase GCPNameTestCase) []error {
 		} else {
 			return []error{fmt.Errorf("Didn't see expected error in case \"%s\" with string \"%s\"", testCase.TestName, testCase.Value)}
 		}
+	}
+
+	return es
+}
+
+func testRFC1918Networks(cases []RFC1918NetworkTestCase) []error {
+	es := make([]error, 0)
+	for _, c := range cases {
+		es = append(es, testRFC1918Network(c)...)
+	}
+
+	return es
+}
+
+func testRFC1918Network(testCase RFC1918NetworkTestCase) []error {
+	f := validateRFC1918Network(testCase.MinPrefix, testCase.MaxPrefix)
+	_, es := f(testCase.CIDR, testCase.TestName)
+	if testCase.ExpectError {
+		if len(es) > 0 {
+			return nil
+		}
+		return []error{fmt.Errorf("Didn't see expected error in case \"%s\" with CIDR=\"%s\" MinPrefix=%v MaxPrefix=%v",
+			testCase.TestName, testCase.CIDR, testCase.MinPrefix, testCase.MaxPrefix)}
 	}
 
 	return es

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -93,7 +93,8 @@ resource "google_container_cluster" "primary" {
     Kubernetes master. Structure is documented below.
 
 * `master_authorized_networks_config` - (Optional) The desired configuration options
-    for master authorized networks
+    for master authorized networks. Omit the nested `cidr_blocks` attribute to disallow
+    external access (except the cluster node IPs, which GKE automatically whitelists).
 
 * `min_master_version` - (Optional) The minimum version of the master. GKE
     will auto-update the master to new versions, so this does not guarantee the
@@ -163,16 +164,17 @@ The `master_auth` block supports:
 
 The `master_authorized_networks_config` block supports:
 
-* `enabled` - (Required) Whether or not master authorized networks is enabled
-
 * `cidr_blocks` - (Optional) Defines up to 10 external networks that can access
-    Kubernetes master through HTTPS.  To avoid upstream failures, an empty list is
-    passed when this feature is disabled, irrespective of values passed here.
+    Kubernetes master through HTTPS.
+
+The `master_authorized_networks_config.cidr_blocks` block supports:
+
+* `cidr_block` - (Optional) External network that can access Kubernetes master through HTTPS.
+    Must be specified in CIDR notation.
+
+* `display_name` - (Optional) Field for users to identify CIDR blocks.
 
 The `node_config` block supports:
-
-* `machine_type` - (Optional) The name of a Google Compute Engine machine type.
-    Defaults to `n1-standard-1`.
 
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -41,11 +41,11 @@ resource "google_container_cluster" "primary" {
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
-    
+
     labels {
       foo = "bar"
     }
-    
+
     tags = ["foo", "bar"]
   }
 }
@@ -91,6 +91,9 @@ resource "google_container_cluster" "primary" {
 
 * `master_auth` - (Optional) The authentication information for accessing the
     Kubernetes master. Structure is documented below.
+
+* `master_authorized_networks_config` - (Optional) The desired configuration options
+    for master authorized networks
 
 * `min_master_version` - (Optional) The minimum version of the master. GKE
     will auto-update the master to new versions, so this does not guarantee the
@@ -158,7 +161,18 @@ The `master_auth` block supports:
 * `username` - (Required) The username to use for HTTP basic authentication when accessing
     the Kubernetes master endpoint
 
+The `master_authorized_networks_config` block supports:
+
+* `enabled` - (Required) Whether or not master authorized networks is enabled
+
+* `cidr_blocks` - (Optional) Defines up to 10 external networks that can access
+    Kubernetes master through HTTPS.  To avoid upstream failures, an empty list is
+    passed when this feature is disabled, irrespective of values passed here.
+
 The `node_config` block supports:
+
+* `machine_type` - (Optional) The name of a Google Compute Engine machine type.
+    Defaults to `n1-standard-1`.
 
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
@@ -201,7 +215,7 @@ The `node_config` block supports:
 * `service_account` - (Optional) The service account to be used by the Node VMs.
     If not specified, the "default" service account is used.
 
-* `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify 
+* `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #619.
- Update container/v1 API (handled independently in #624)
- Add support for master_authorized_networks in `google_container_cluster`

```
$ make testacc TEST=./google TESTARGS='-run=TestAccContainerCluster_withMasterAuthorizedNetworks'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_withMasterAuthorizedNetworks -timeout 120m
=== RUN   TestAccContainerCluster_withMasterAuthorizedNetworksConfig
--- PASS: TestAccContainerCluster_withMasterAuthorizedNetworksConfig (390.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	390.539s
```