### PR TITLE
Fix link to compute_lb_ip_ranges data source

### DIFF
--- a/website/google.erb
+++ b/website/google.erb
@@ -29,7 +29,7 @@
       <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
-      <a href="/docs/providers/google/d/google_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
+      <a href="/docs/providers/google/d/datasource_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-container-versions") %>>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>


### PR DESCRIPTION
We had a typo in the sidebar link, which was causing the link to be broken. This fixes the link.