### PR TITLE
Update GKE docs to match actual schema; reorder fields in schema

### DIFF
--- a/google/node_config.go
+++ b/google/node_config.go
@@ -14,55 +14,12 @@ var schemaNodeConfig = &schema.Schema{
 	MaxItems: 1,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"machine_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"disk_size_gb": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(10),
-			},
-
-			"local_ssd_count": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-
-			"oauth_scopes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					StateFunc: func(v interface{}) string {
-						return canonicalizeServiceScope(v.(string))
-					},
-				},
-				Set: stringScopeHashcode,
-			},
-
-			"service_account": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"metadata": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     schema.TypeString,
 			},
 
 			"image_type": {
@@ -79,11 +36,46 @@ var schemaNodeConfig = &schema.Schema{
 				Elem:     schema.TypeString,
 			},
 
-			"tags": {
-				Type:     schema.TypeList,
+			"local_ssd_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+
+			"machine_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"metadata": {
+				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
+			},
+
+			"min_cpu_platform": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"oauth_scopes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(v interface{}) string {
+						return canonicalizeServiceScope(v.(string))
+					},
+				},
+				Set: stringScopeHashcode,
 			},
 
 			"preemptible": {
@@ -93,10 +85,18 @@ var schemaNodeConfig = &schema.Schema{
 				Default:  false,
 			},
 
-			"min_cpu_platform": {
+			"service_account": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	},

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -40,42 +40,6 @@ func resourceContainerCluster() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"master_auth": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"client_certificate": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"client_key": {
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
-						},
-						"cluster_ca_certificate": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"password": {
-							Type:      schema.TypeString,
-							Required:  true,
-							ForceNew:  true,
-							Sensitive: true,
-						},
-						"username": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-					},
-				},
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -109,12 +73,6 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"initial_node_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"additional_zones": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -122,71 +80,6 @@ func resourceContainerCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"cluster_ipv4_cidr": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					_, ipnet, err := net.ParseCIDR(value)
-
-					if err != nil || ipnet == nil || value != ipnet.String() {
-						errors = append(errors, fmt.Errorf(
-							"%q must contain a valid CIDR", k))
-					}
-					return
-				},
-			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"enable_legacy_abac": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"instance_group_urls": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
-			"logging_service": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"logging.googleapis.com", "none"}, false),
-			},
-
-			"monitoring_service": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"network": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Default:   "default",
-				ForceNew:  true,
-				StateFunc: StoreResourceName,
-			},
-			"subnetwork": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			"addons_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -240,9 +133,86 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-			"master_version": {
+			"cluster_ipv4_cidr": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					_, ipnet, err := net.ParseCIDR(value)
+
+					if err != nil || ipnet == nil || value != ipnet.String() {
+						errors = append(errors, fmt.Errorf(
+							"%q must contain a valid CIDR", k))
+					}
+					return
+				},
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"enable_legacy_abac": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"initial_node_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"logging_service": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"logging.googleapis.com", "none"}, false),
+			},
+
+			"master_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"password": {
+							Type:      schema.TypeString,
+							Required:  true,
+							ForceNew:  true,
+							Sensitive: true,
+						},
+
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"client_certificate": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"client_key": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
+						},
+
+						"cluster_ca_certificate": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 
 			"min_master_version": {
@@ -250,13 +220,21 @@ func resourceContainerCluster() *schema.Resource {
 				Optional: true,
 			},
 
-			"node_config": schemaNodeConfig,
-
-			"node_version": {
+			"monitoring_service": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
+			"network": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "default",
+				ForceNew:  true,
+				StateFunc: StoreResourceName,
+			},
+
+			"node_config": schemaNodeConfig,
 
 			"node_pool": {
 				Type:     schema.TypeList,
@@ -268,10 +246,38 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"node_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"subnetwork": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"instance_group_urls": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"master_version": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -56,36 +56,6 @@ func resourceContainerNodePool() *schema.Resource {
 }
 
 var schemaNodePool = map[string]*schema.Schema{
-	"name": &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
-	},
-
-	"name_prefix": &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		ForceNew: true,
-	},
-
-	"initial_node_count": &schema.Schema{
-		Type:       schema.TypeInt,
-		Optional:   true,
-		ForceNew:   true,
-		Computed:   true,
-		Deprecated: "Use node_count instead",
-	},
-
-	"node_count": {
-		Type:         schema.TypeInt,
-		Optional:     true,
-		Computed:     true,
-		ValidateFunc: validation.IntAtLeast(1),
-	},
-
-	"node_config": schemaNodeConfig,
-
 	"autoscaling": &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -105,6 +75,36 @@ var schemaNodePool = map[string]*schema.Schema{
 				},
 			},
 		},
+	},
+
+	"initial_node_count": &schema.Schema{
+		Type:       schema.TypeInt,
+		Optional:   true,
+		ForceNew:   true,
+		Computed:   true,
+		Deprecated: "Use node_count instead",
+	},
+
+	"name": &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+	},
+
+	"name_prefix": &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+	},
+
+	"node_config": schemaNodeConfig,
+
+	"node_count": {
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.IntAtLeast(1),
 	},
 }
 

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -79,7 +79,7 @@ resource "google_container_cluster" "primary" {
     will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
 
 * `initial_node_count` - (Optional) The number of nodes to create in this
-    cluster (not including the Kubernetes master).
+    cluster (not including the Kubernetes master). Must be set if `node_pool` is not set.
 
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com` and

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -78,7 +78,7 @@ resource "google_container_cluster" "primary" {
     When enabled, identities in the system, including service accounts, nodes, and controllers,
     will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
 
-* `initial_node_count` - (Required) The number of nodes to create in this
+* `initial_node_count` - (Optional) The number of nodes to create in this
     cluster (not including the Kubernetes master).
 
 * `logging_service` - (Optional) The logging service that the cluster should

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -55,12 +55,13 @@ resource "google_container_cluster" "primary" {
 
 * `cluster` - (Required) The cluster to create the node pool for.
 
-* `initial_node_count` - (Required) The initial node count for the pool.
-
 - - -
 
-* `project` - (Optional) The project in which to create the node pool. If blank,
-    the provider-configured project will be used.
+* `autoscaling` - (Optional) Configuration required by cluster autoscaler to adjust
+    the size of the node pool to the current cluster usage. Structure is documented below.
+
+* `initial_node_count` - (Deprecated, Optional) The initial node count for the pool.
+    Use `node_count` instead.
 
 * `name` - (Optional) The name of the node pool. If left blank, Terraform will
     auto-generate a unique name.
@@ -68,57 +69,13 @@ resource "google_container_cluster" "primary" {
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
 
-* `node_config` - (Optional) The machine type and image to use for all nodes in
-    this pool
+* `node_config` - (Optional) The node configuration of the pool. See
+    [google_container_cluster](container_cluster.html for schema.
 
-* `autoscaling` - (Optional) Configuration required by cluster autoscaler to adjust
-    the size of the node pool to the current cluster usage. Structure is documented below.
+* `node_count` - (Optional) The number of nodes per instance group.
 
-**Node Config** supports the following arguments:
-
-* `machine_type` - (Optional) The name of a Google Compute Engine machine type.
-    Defaults to `n1-standard-1`.
-
-* `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
-    in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
-
-* `local_ssd_count` - (Optional) The amount of local SSD disks that will be
-    attached to each node pool. Defaults to 0.
-
-* `oauth_scopes` - (Optional) The set of Google API scopes to be made available
-    on all of the node VMs under the "default" service account. These can be
-    either FQDNs, or scope aliases. The following scopes are necessary to ensure
-    the correct functioning of the node pool:
-
-  * `compute-rw` (`https://www.googleapis.com/auth/compute`)
-  * `storage-ro` (`https://www.googleapis.com/auth/devstorage.read_only`)
-  * `logging-write` (`https://www.googleapis.com/auth/logging.write`),
-    if `logging_service` points to Google
-  * `monitoring` (`https://www.googleapis.com/auth/monitoring`),
-    if `monitoring_service` points to Google
-
-* `service_account` - (Optional) The service account to be used by the Node VMs.
-    If not specified, the "default" service account is used.
-
-* `metadata` - (Optional) The metadata key/value pairs assigned to instances in
-    the node pool.
-
-* `image_type` - (Optional) The image type to use for this node.
-
-* `labels` - (Optional) The Kubernetes labels (key/value pairs) to be applied to each node.
-
-* `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
-    valid sources or targets for network firewalls.
-
-* `preemptible` - (Optional) A boolean that represents whether or not the underlying node VMs
-    are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
-    for more information. Defaults to false.
-
-* `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
-    The instance may be scheduled on the specified or newer CPU platform. Applicable
-    values are the friendly names of CPU platforms, such as `Intel Haswell`. See the
-    [official documentation](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
-    for more information.
+* `project` - (Optional) The project in which to create the node pool. If blank,
+    the provider-configured project will be used.
 
 The `autoscaling` block supports:
 


### PR DESCRIPTION
Reordered to be alphabetical within a category (Required -> Optional -> Computed).
Also consolidated docs a bit by providing references from cluster <--> node pool.

Fixes #559.