### PR TITLE
Add example in docs for creating a subscription with a topic in another project

### DIFF
--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -16,9 +16,13 @@ Creates a subscription in Google's pubsub queueing system. For more information 
 ## Example Usage
 
 ```hcl
+resource "google_pubsub_topic" "default-topic" {
+  name = "default-topic"
+}
+
 resource "google_pubsub_subscription" "default" {
   name  = "default-subscription"
-  topic = "default-topic"
+  topic = "${google_pubsub_topic.default-topic.name}"
 
   ack_deadline_seconds = 20
 
@@ -32,6 +36,20 @@ resource "google_pubsub_subscription" "default" {
 }
 ```
 
+If the subscription has a topic in a different project:
+
+```hcl
+resource "google_pubsub_topic" "topic-different-project" {
+  project = "another-project"
+  name = "topic-different-project"
+}
+
+resource "google_pubsub_subscription" "default" {
+  name  = "default-subscription"
+  topic = "${google_pubsub_topic.topic-different-project.id}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -39,7 +57,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by pubsub.
     Changing this forces a new resource to be created.
 
-* `topic` - (Required) A topic to bind this subscription to, required by pubsub.
+* `topic` - (Required) The topic name or id to bind this subscription to, required by pubsub.
     Changing this forces a new resource to be created.
 
 - - -


### PR DESCRIPTION
Fixes #649 

Add documentation for the improvement added in #640.

cc/ @sebasrobert