### PR TITLE
Add import support to global forwarding rule

### DIFF
--- a/google/import_compute_global_forwarding_rule_test.go
+++ b/google/import_compute_global_forwarding_rule_test.go
@@ -1,0 +1,34 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeGlobalForwardingRule_import(t *testing.T) {
+	t.Parallel()
+
+	fr := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	proxy1 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	proxy2 := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	backend := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	urlmap := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeGlobalForwardingRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeGlobalForwardingRule_basic1(fr, proxy1, proxy2, backend, hc, urlmap),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_global_forwarding_rule.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		}})
+}

--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -73,15 +73,10 @@ func resourceComputeForwardingRule() *schema.Resource {
 			},
 
 			"port_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == new+"-"+new {
-						return true
-					}
-					return false
-				},
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: portRangeDiffSuppress,
 			},
 
 			"ports": &schema.Schema{

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -23,6 +23,10 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 		Update: resourceComputeGlobalForwardingRuleUpdate,
 		Delete: resourceComputeGlobalForwardingRuleDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -69,9 +73,10 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			},
 
 			"port_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: portRangeDiffSuppress,
 			},
 
 			"ip_version": &schema.Schema{
@@ -273,6 +278,10 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 		}
 	}
 
+	d.Set("name", frule.Name)
+	d.Set("description", frule.Description)
+	d.Set("target", frule.Target)
+	d.Set("port_range", frule.PortRange)
 	d.Set("ip_address", frule.IPAddress)
 	d.Set("ip_protocol", frule.IPProtocol)
 	d.Set("ip_version", frule.IpVersion)

--- a/google/utils.go
+++ b/google/utils.go
@@ -283,6 +283,16 @@ func ipCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+// Port range '80' and '80-80' is equivalent.
+// `old` is read from the server and always has the full range format (e.g. '80-80', '1024-2048').
+// `new` can be either a single port or a port range.
+func portRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if old == new+"-"+new {
+		return true
+	}
+	return false
+}
+
 // expandLabels pulls the value of "labels" out of a schema.ResourceData as a map[string]string.
 func expandLabels(d *schema.ResourceData) map[string]string {
 	return expandStringMap(d, "labels")

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -17,7 +17,7 @@ documentation](https://cloud.google.com/compute/docs/load-balancing/http/global-
 
 ```hcl
 resource "google_compute_global_forwarding_rule" "default" {
-  name       = "test"
+  name       = "default-rule"
   target     = "${google_compute_target_http_proxy.default.self_link}"
   port_range = "80"
 }
@@ -110,3 +110,11 @@ exported:
 * `self_link` - The URI of the created resource.
 
 * `label_fingerprint` - ([Beta](/docs/providers/google/index.html#beta-features)) The current label fingerprint.
+
+## Import
+
+Global forwarding rules can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_forwarding_rule.default default-rule
+```

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -116,5 +116,5 @@ exported:
 Global forwarding rules can be imported using the `name`, e.g.
 
 ```
-$ terraform import google_compute_forwarding_rule.default default-rule
+$ terraform import google_compute_global_forwarding_rule.default default-rule
 ```


### PR DESCRIPTION
Fixes #643

```sh
TF_ACC=1 go test ./google -v -run TestAccComputeGlobalForwardingRule_ -timeout 120m
=== RUN   TestAccComputeGlobalForwardingRule_import
=== RUN   TestAccComputeGlobalForwardingRule_basic
=== RUN   TestAccComputeGlobalForwardingRule_update
=== RUN   TestAccComputeGlobalForwardingRule_ipv6
=== RUN   TestAccComputeGlobalForwardingRule_labels
--- PASS: TestAccComputeGlobalForwardingRule_ipv6 (111.14s)
--- PASS: TestAccComputeGlobalForwardingRule_basic (111.16s)
--- PASS: TestAccComputeGlobalForwardingRule_import (111.83s)
--- PASS: TestAccComputeGlobalForwardingRule_update (124.67s)
--- PASS: TestAccComputeGlobalForwardingRule_labels (135.41s)
PASS
```

cc/ @siulcode