### PR TITLE
add support for ip aliasing in `google_container_cluster`

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -617,8 +617,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	d.Set("node_pool", nps)
 
-	if err := d.Set("ip_allocation_policy", flattenIPAllocationPolicy(cluster.IpAllocationPolicy)); err != nil {
-		return err
+	if cluster.IpAllocationPolicy != nil {
+		if err := d.Set("ip_allocation_policy", flattenIPAllocationPolicy(cluster.IpAllocationPolicy)); err != nil {
+			return err
+		}
 	}
 
 	if igUrls, err := getInstanceGroupUrlsFromManagerUrls(config, cluster.InstanceGroupUrls); err != nil {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -610,7 +610,6 @@ func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
 						"services": "10.2.0.0/20",
 					},
 					map[string]string{
-						"use_ip_aliases":                "true",
 						"cluster_secondary_range_name":  "pods",
 						"services_secondary_range_name": "services",
 					},
@@ -626,9 +625,7 @@ func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
 						"pods":     "10.1.0.0/16",
 						"services": "10.2.0.0/20",
 					},
-					map[string]string{
-						"use_ip_aliases": "true",
-					},
+					map[string]string{},
 				),
 				ExpectError: regexp.MustCompile("clusters using IP aliases must specify secondary ranges"),
 			},
@@ -638,7 +635,6 @@ func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
 						"pods": "10.1.0.0/16",
 					},
 					map[string]string{
-						"use_ip_aliases":                "true",
 						"cluster_secondary_range_name":  "pods",
 						"services_secondary_range_name": "services",
 					},

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -595,6 +595,60 @@ func TestAccContainerCluster_withMaintenanceWindow(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withIPAllocationPolicy(
+					map[string]string{
+						"pods":     "10.1.0.0/16",
+						"services": "10.2.0.0/20",
+					},
+					map[string]string{
+						"use_ip_aliases":                "true",
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerCluster(
+						"google_container_cluster.with_ip_allocation_policy"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_withIPAllocationPolicy(
+					map[string]string{
+						"pods":     "10.1.0.0/16",
+						"services": "10.2.0.0/20",
+					},
+					map[string]string{
+						"use_ip_aliases": "true",
+					},
+				),
+				ExpectError: regexp.MustCompile("clusters using IP aliases must specify secondary ranges"),
+			},
+			{
+				Config: testAccContainerCluster_withIPAllocationPolicy(
+					map[string]string{
+						"pods": "10.1.0.0/16",
+					},
+					map[string]string{
+						"use_ip_aliases":                "true",
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				),
+				ExpectError: regexp.MustCompile("secondary ranges are missing on the cluster's subnetwork"),
+			},
+		},
+	})
+}
+
 func testAccCheckContainerClusterDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -1472,11 +1526,57 @@ resource "google_container_cluster" "with_maintenance_window" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
 	initial_node_count = 1
-	
+
 	maintenance_policy {
 		daily_maintenance_window {
 			start_time = "%s"
 		}
 	}
 }`, acctest.RandString(10), startTime)
+}
+
+func testAccContainerCluster_withIPAllocationPolicy(ranges, policy map[string]string) string {
+
+	var secondaryRanges bytes.Buffer
+	for rangeName, cidr := range ranges {
+		secondaryRanges.WriteString(fmt.Sprintf(`
+	secondary_ip_range {
+	    range_name    = "%s"
+	    ip_cidr_range = "%s"
+	}`, rangeName, cidr))
+	}
+
+	var ipAllocationPolicy bytes.Buffer
+	for key, value := range policy {
+		ipAllocationPolicy.WriteString(fmt.Sprintf(`
+		%s = "%s"`, key, value))
+	}
+
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+	name = "container-net-%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+	name          = "${google_compute_network.container_network.name}"
+	network       = "${google_compute_network.container_network.name}"
+	ip_cidr_range = "10.0.0.0/24"
+	region        = "us-central1"
+
+	%s
+}
+
+resource "google_container_cluster" "with_ip_allocation_policy" {
+	name = "with-ip-allocation-policy"
+	zone = "us-central1-a"
+
+	network = "${google_compute_network.container_network.name}"
+	subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
+
+	initial_node_count = 1
+	ip_allocation_policy {
+	    %s
+	}
+}`, acctest.RandString(10), secondaryRanges.String(), ipAllocationPolicy.String())
 }

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -98,12 +98,14 @@ output "cluster_ca_certificate" {
 * `initial_node_count` - (Optional) The number of nodes to create in this
     cluster (not including the Kubernetes master). Must be set if `node_pool` is not set.
 
+* `ip_allocation_policy` - (Optional) Configuration for cluster IP allocation. As of now, only pre-allocated subnetworks (custom type with secondary ranges) are supported.
+
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com` and
     `none`. Defaults to `logging.googleapis.com`
 
-* `maintenance_policy` - (Optional) The maintenance policy to use for the cluster. Structure is 
-    documented below. 
+* `maintenance_policy` - (Optional) The maintenance policy to use for the cluster. Structure is
+    documented below.
 
 * `master_auth` - (Optional) The authentication information for accessing the
     Kubernetes master. Structure is documented below.
@@ -173,7 +175,7 @@ addons_config {
 The `maintenance_policy` block supports:
 
 * `daily_maintenance_window` - (Required) Time window specified for daily maintenance operations.
-    Specify `start_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format "HH:MM”, 
+    Specify `start_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format "HH:MM”,
     where HH : \[00-23\] and MM : \[00-59\] GMT. For example:
 
 ```
@@ -183,6 +185,18 @@ maintenance_policy {
   }
 }
 ```
+
+The `ip_allocation_policy` block supports:
+
+* `cluster_secondary_range_name` - (Optional) The name of the secondary range to be
+    used as for the cluster CIDR block. The secondary range will be used for pod IP
+    addresses. This must be an existing secondary range associated with the cluster
+    subnetwork. This field is only applicable with `use_ip_aliases`.
+
+* `services_secondary_range_name` - (Optional) The name of the secondary range to be
+    used as for the services CIDR block.  The secondary range will be used for service
+    ClusterIPs. This must be an existing secondary range associated with the cluster
+    subnetwork. This field is only applicable with `use_ip_aliases`.
 
 The `master_auth` block supports:
 
@@ -261,7 +275,7 @@ exported:
     to the cluster.
 
 * `maintenance_policy.0.daily_maintenance_window.0.duration` - Duration of the time window, automatically chosen to be
-    smallest possible in the given scenario.  
+    smallest possible in the given scenario.
     Duration will be in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format "PTnHnMnS".
 
 * `master_auth.0.client_certificate` - Base64 encoded public certificate

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -191,12 +191,12 @@ The `ip_allocation_policy` block supports:
 * `cluster_secondary_range_name` - (Optional) The name of the secondary range to be
     used as for the cluster CIDR block. The secondary range will be used for pod IP
     addresses. This must be an existing secondary range associated with the cluster
-    subnetwork. This field is only applicable with `use_ip_aliases`.
+    subnetwork.
 
 * `services_secondary_range_name` - (Optional) The name of the secondary range to be
     used as for the services CIDR block.  The secondary range will be used for service
     ClusterIPs. This must be an existing secondary range associated with the cluster
-    subnetwork. This field is only applicable with `use_ip_aliases`.
+    subnetwork.
 
 The `master_auth` block supports:
 


### PR DESCRIPTION
Fixes #618.

Note that there are two mutually exclusive paths for GKE clusters with IP aliasing enabled:
1) pre-allocated subnets
2) dynamically created subnets, which are a bit more magical and strictly tied to cluster lifecycle

I chose to implement only (1), for now, because:
- It seemed like the most flexible path
- There are several tiers of conflicting and dependent attributes.  `ConflictsWith` halfway solves the problem, but AFAIK there's no good abstraction on the other side for dependencies/requirements, making it difficult to implement both strategies and detect failures at plan-time.  There are cases where I wasn't able to do so even with the single strategy.