### PR TITLE
two-tier example is idempotent

### DIFF
--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -17,7 +17,7 @@ resource "google_compute_http_health_check" "default" {
 
 resource "google_compute_target_pool" "default" {
   name          = "tf-www-target-pool"
-  instances     = ["${google_compute_instance.www.*.self_link}"]
+  instances     = ["${formatlist("%s/%s", var.region_zone, google_compute_instance.www.*.name)}"]
   health_checks = ["${google_compute_http_health_check.default.name}"]
 }
 


### PR DESCRIPTION
Moving this from old repo (https://github.com/hashicorp/terraform/pull/12258)

This PR makes the two-tier example apply more cleanly and idempotently.

* `google_compute_forwarding_rule.default.port_range = "80"` would save okay, but then would save to state file as "80-80", so it would always think a change was needed
* `google_compute_target_pool.default.instances` items would resolve to full URLs, but saved in state as just `{zone}/{instance.name}`.
  * This PR uses a [workaround](#9121 (comment)) mentioned in #9121