### PR TITLE
Check for sets in node pool tests

### DIFF
--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -197,6 +197,10 @@ func testAccCheckContainerNodePoolDestroy(s *terraform.State) error {
 	return nil
 }
 
+var nodepoolSetFields map[string]struct{} = map[string]struct{}{
+	"node_config.0.oauth_scopes": struct{}{},
+}
+
 func testAccCheckContainerNodePoolMatches(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
@@ -414,6 +418,9 @@ resource "google_container_node_pool" "np" {
 
 func nodepoolCheckMatch(attributes map[string]string, attr string, gcp interface{}) string {
 	if gcpList, ok := gcp.([]string); ok {
+		if _, ok := nodepoolSetFields[attr]; ok {
+			return nodepoolCheckSetMatch(attributes, attr, gcpList)
+		}
 		return nodepoolCheckListMatch(attributes, attr, gcpList)
 	}
 	if gcpMap, ok := gcp.(map[string]string); ok {


### PR DESCRIPTION
Fixes our failing node pool tests.

Before:
```
=== RUN   TestAccContainerNodePool_basic
--- FAIL: TestAccContainerNodePool_basic (580.78s)
    testing.go:434: Step 0 error: Check failed: Check 1/1 error: NodePool has mismatched node_config.0.oauth_scopes[0].
        TF State: 
        GCP State: https://www.googleapis.com/auth/logging.write
FAIL
```

After:
```
=== RUN   TestAccContainerNodePool_basic
--- PASS: TestAccContainerNodePool_basic (502.16s)
PASS
```