### PR TITLE
Increase timeout for deleting networks

### DIFF
--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -136,7 +136,7 @@ func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Deleting Network")
+	err = computeOperationWaitTime(config.clientCompute, op, project, "Deleting Network", 10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Our tests have been timing out a lot on network deletion lately. I'm not quite sure why it takes more than 4 minutes to delete a network but let's give it 10 minutes just in case.

Checked by running firewall tests, which are currently failing in CI:
```
=== RUN   TestAccComputeFirewall_importBasic
=== RUN   TestAccComputeFirewall_basic
=== RUN   TestAccComputeFirewall_update
=== RUN   TestAccComputeFirewall_priority
=== RUN   TestAccComputeFirewall_noSource
=== RUN   TestAccComputeFirewall_denied
=== RUN   TestAccComputeFirewall_egress
--- PASS: TestAccComputeFirewall_noSource (296.32s)
--- PASS: TestAccComputeFirewall_basic (306.30s)
--- PASS: TestAccComputeFirewall_importBasic (316.45s)
--- PASS: TestAccComputeFirewall_egress (295.70s)
--- PASS: TestAccComputeFirewall_denied (295.37s)
--- PASS: TestAccComputeFirewall_priority (305.40s)
--- PASS: TestAccComputeFirewall_update (307.44s)
PASS
```