### PR TITLE
Fix bug with empty `initialize_params` block

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -40,7 +40,7 @@ func resourceComputeInstance() *schema.Resource {
 		Update: resourceComputeInstanceUpdate,
 		Delete: resourceComputeInstanceDelete,
 
-		SchemaVersion: 5,
+		SchemaVersion: 6,
 		MigrateState:  resourceComputeInstanceMigrateState,
 
 		Schema: map[string]*schema.Schema{

--- a/google/resource_compute_instance_migrate.go
+++ b/google/resource_compute_instance_migrate.go
@@ -505,6 +505,9 @@ func migrateStateV5toV6(is *terraform.InstanceState) (*terraform.InstanceState, 
 			is.Attributes["boot_disk.0.initialize_params.0.type"] == "" &&
 			is.Attributes["boot_disk.0.initialize_params.0.image"] == "" {
 			is.Attributes["boot_disk.0.initialize_params.#"] = "0"
+			delete(is.Attributes, "boot_disk.0.initialize_params.0.size")
+			delete(is.Attributes, "boot_disk.0.initialize_params.0.type")
+			delete(is.Attributes, "boot_disk.0.initialize_params.0.image")
 		}
 	}
 	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -65,6 +65,16 @@ func TestComputeInstanceMigrateState(t *testing.T) {
 				"create_timeout": "4",
 			},
 		},
+		"remove empty initialize_params": {
+			StateVersion: 5,
+			Attributes: map[string]string{
+				"boot_disk.0.initialize_params.#":      "1",
+				"boot_disk.0.initialize_params.0.size": "0",
+			},
+			Expected: map[string]string{
+				"boot_disk.0.initialize_params.#": "0",
+			},
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
In old versions of Terraform, `disk.size` was being set to "0" in state for disks that did not specify a size parameter. Check for this case when checking that the field is empty, and fix states that accidentally added an `initialize_params` block to the `boot_disk` during the migration in the above scenario.

Part of #658.