### PR TITLE
Make `google_container_cluster.node_pool` mutable (ForceNew=false)

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -295,10 +295,10 @@ func resourceContainerCluster() *schema.Resource {
 			"node_config": schemaNodeConfig,
 
 			"node_pool": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				ForceNew: false,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: schemaNodePool,
 				},

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -298,7 +298,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				ForceNew: true, // TODO(danawillow): Add ability to add/remove nodePools
+				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: schemaNodePool,
 				},


### PR DESCRIPTION
I'm guessing this is too naive, but I thought it made sense to pose the question before tackling some of the larger problems around node pool mutation / lifecycle – is this all that's required (beyond additional tests) to be able to add/remove node pools from the cluster resource?

/cc @danawillow (as there's a `TODO` here with your name on it)