### PR TITLE
Update `google_compute_target_pool` to no longer have a plan/apply loop with instance URLs

### DIFF
--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -79,12 +79,28 @@ resource "google_compute_http_health_check" "foobar" {
 	host = "example.com"
 }
 
+resource "google_compute_instance" "foobar" {
+	name         = "inst-tp-test-%s"
+	machine_type = "n1-standard-1"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
 resource "google_compute_target_pool" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
-	instances = ["us-central1-a/foo", "us-central1-b/bar"]
+	instances = ["${google_compute_instance.foobar.self_link}", "us-central1-b/bar"]
 	name = "tpool-test-%s"
 	session_affinity = "CLIENT_IP_PROTO"
 	health_checks = [
 		"${google_compute_http_health_check.foobar.name}"
 	]
-}`, acctest.RandString(10), acctest.RandString(10))
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))


### PR DESCRIPTION
Fixes #46 

```
$ make testacc TEST=./google TESTARGS='-run=TestAccComputeTargetPool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeTargetPool_basic -timeout 120m
=== RUN   TestAccComputeTargetPool_basic
--- PASS: TestAccComputeTargetPool_basic (85.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	85.689s
```