### PR TITLE
Add new `google_project_service` resource for fine-grained service control.

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -129,6 +129,7 @@ func Provider() terraform.ResourceProvider {
 			"google_project_iam_policy":                    resourceGoogleProjectIamPolicy(),
 			"google_project_iam_binding":                   resourceGoogleProjectIamBinding(),
 			"google_project_iam_member":                    resourceGoogleProjectIamMember(),
+			"google_project_service":                       resourceGoogleProjectService(),
 			"google_project_services":                      resourceGoogleProjectServices(),
 			"google_pubsub_topic":                          resourcePubsubTopic(),
 			"google_pubsub_subscription":                   resourcePubsubSubscription(),

--- a/google/resource_google_project_service.go
+++ b/google/resource_google_project_service.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -41,7 +42,7 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error enabling service: %s", err)
 	}
 
-	d.SetId(srv)
+	d.SetId(projectServiceId{project, srv}.terraformId())
 	return resourceGoogleProjectServiceRead(d, meta)
 }
 
@@ -53,13 +54,18 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	id, err := parseProjectServiceId(d.Id())
+	if err != nil {
+		return err
+	}
+
 	services, err := getApiServices(project, config, map[string]struct{}{})
 	if err != nil {
 		return err
 	}
 
 	for _, s := range services {
-		if s == d.Id() {
+		if s == id.service {
 			d.Set("service", s)
 			return nil
 		}
@@ -78,10 +84,35 @@ func resourceGoogleProjectServiceDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	if err = disableService(d.Id(), project, config); err != nil {
+	id, err := parseProjectServiceId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if err = disableService(id.service, project, config); err != nil {
 		return fmt.Errorf("Error disabling service: %s", err)
 	}
 
 	d.SetId("")
 	return nil
+}
+
+// Parts that make up the id of a `google_project_service` resource.
+// Project is included in order to allow multiple projects to enable the same service within the same Terraform state
+type projectServiceId struct {
+	project string
+	service string
+}
+
+func (id projectServiceId) terraformId() string {
+	return fmt.Sprintf("%s/%s", id.project, id.service)
+}
+
+func parseProjectServiceId(id string) (*projectServiceId, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid google_project_service id format, expecting `{project}/{service}`, found %s", id)
+	}
+
+	return &projectServiceId{parts[0], parts[1]}, nil
 }

--- a/google/resource_google_project_service.go
+++ b/google/resource_google_project_service.go
@@ -1,0 +1,87 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGoogleProjectService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectServiceCreate,
+		Read:   resourceGoogleProjectServiceRead,
+		Delete: resourceGoogleProjectServiceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"service": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	srv := d.Get("service").(string)
+
+	if err = enableService(srv, project, config); err != nil {
+		return fmt.Errorf("Error enabling service: %s", err)
+	}
+
+	d.SetId(srv)
+	return resourceGoogleProjectServiceRead(d, meta)
+}
+
+func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	services, err := getApiServices(project, config, map[string]struct{}{})
+	if err != nil {
+		return err
+	}
+
+	for _, s := range services {
+		if s == d.Id() {
+			d.Set("service", s)
+			return nil
+		}
+	}
+
+	// The service is not enabled server-side, so remove it from state
+	d.SetId("")
+	return nil
+}
+
+func resourceGoogleProjectServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	if err = disableService(d.Id(), project, config); err != nil {
+		return fmt.Errorf("Error disabling service: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/google/resource_google_project_service_test.go
+++ b/google/resource_google_project_service_test.go
@@ -1,0 +1,85 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Test that services can be enabled and disabled on a project
+func TestAccGoogleProjectService_basic(t *testing.T) {
+	t.Parallel()
+
+	pid := "terraform-" + acctest.RandString(10)
+	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleProjectService_basic(services, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectService(services, pid, true),
+				),
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectService(services, pid, false),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckProjectService(services []string, pid string, expectEnabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		apiServices, err := getApiServices(pid, config, map[string]struct{}{})
+		if err != nil {
+			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
+		}
+
+		for _, expected := range services {
+			exists := false
+			for _, actual := range apiServices {
+				if expected == actual {
+					exists = true
+				}
+			}
+			if expectEnabled && !exists {
+				return fmt.Errorf("Expected service %s is not enabled server-side (found %v)", expected, apiServices)
+			}
+			if !expectEnabled && exists {
+				return fmt.Errorf("Expected disabled service %s is enabled server-side", expected)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccGoogleProjectService_basic(services []string, pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+}
+
+resource "google_project_service" "test" {
+  project = "${google_project.acceptance.project_id}"
+  service = "%s"
+}
+
+resource "google_project_service" "test2" {
+  project = "${google_project.acceptance.project_id}"
+  service = "%s"
+}
+`, pid, name, org, services[0], services[1])
+}

--- a/google/resource_google_project_services.go
+++ b/google/resource_google_project_services.go
@@ -36,7 +36,7 @@ func resourceGoogleProjectServices() *schema.Resource {
 
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.
-var ignore = map[string]struct{}{
+var ignoreProjectServices = map[string]struct{}{
 	"containeranalysis.googleapis.com": struct{}{},
 	"dataproc-control.googleapis.com":  struct{}{},
 	"source.googleapis.com":            struct{}{},
@@ -50,7 +50,7 @@ func resourceGoogleProjectServicesCreate(d *schema.ResourceData, meta interface{
 	cfgServices := getConfigServices(d)
 
 	// Get services from API
-	apiServices, err := getApiServices(pid, config)
+	apiServices, err := getApiServices(pid, config, ignoreProjectServices)
 	if err != nil {
 		return fmt.Errorf("Error creating services: %v", err)
 	}
@@ -69,7 +69,7 @@ func resourceGoogleProjectServicesCreate(d *schema.ResourceData, meta interface{
 func resourceGoogleProjectServicesRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	services, err := getApiServices(d.Id(), config)
+	services, err := getApiServices(d.Id(), config, ignoreProjectServices)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func resourceGoogleProjectServicesUpdate(d *schema.ResourceData, meta interface{
 	cfgServices := getConfigServices(d)
 
 	// Get services from API
-	apiServices, err := getApiServices(pid, config)
+	apiServices, err := getApiServices(pid, config, ignoreProjectServices)
 	if err != nil {
 		return fmt.Errorf("Error updating services: %v", err)
 	}
@@ -164,7 +164,7 @@ func getConfigServices(d *schema.ResourceData) (services []string) {
 }
 
 // Retrieve a project's services from the API
-func getApiServices(pid string, config *Config) ([]string, error) {
+func getApiServices(pid string, config *Config, ignore map[string]struct{}) ([]string, error) {
 	apiServices := make([]string, 0)
 	// Get services from the API
 	token := ""
@@ -186,27 +186,39 @@ func getApiServices(pid string, config *Config) ([]string, error) {
 
 func enableService(s, pid string, config *Config) error {
 	esr := newEnableServiceRequest(pid)
-	sop, err := config.clientServiceMan.Services.Enable(s, esr).Do()
+	err := retry(func() error {
+		sop, err := config.clientServiceMan.Services.Enable(s, esr).Do()
+		if err != nil {
+			return err
+		}
+		waitErr := serviceManagementOperationWait(config, sop, "api to enable")
+		if waitErr != nil {
+			return waitErr
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error enabling service %q for project %q: %v", s, pid, err)
 	}
-	// Wait for the operation to complete
-	waitErr := serviceManagementOperationWait(config, sop, "api to enable")
-	if waitErr != nil {
-		return waitErr
-	}
 	return nil
 }
+
 func disableService(s, pid string, config *Config) error {
 	dsr := newDisableServiceRequest(pid)
-	sop, err := config.clientServiceMan.Services.Disable(s, dsr).Do()
+	err := retry(func() error {
+		sop, err := config.clientServiceMan.Services.Disable(s, dsr).Do()
+		if err != nil {
+			return err
+		}
+		// Wait for the operation to complete
+		waitErr := serviceManagementOperationWait(config, sop, "api to disable")
+		if waitErr != nil {
+			return waitErr
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error disabling service %q for project %q: %v", s, pid, err)
-	}
-	// Wait for the operation to complete
-	waitErr := serviceManagementOperationWait(config, sop, "api to disable")
-	if waitErr != nil {
-		return waitErr
 	}
 	return nil
 }

--- a/google/resource_google_project_services_test.go
+++ b/google/resource_google_project_services_test.go
@@ -264,7 +264,7 @@ func testProjectServicesMatch(services []string, pid string) resource.TestCheckF
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
-		apiServices, err := getApiServices(pid, config)
+		apiServices, err := getApiServices(pid, config, ignoreProjectServices)
 		if err != nil {
 			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
 		}

--- a/website/docs/r/google_project_service.html.markdown
+++ b/website/docs/r/google_project_service.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "google"
+page_title: "Google: google_project_service"
+sidebar_current: "docs-google-project-service"
+description: |-
+ Allows management of a single API service for a Google Cloud Platform project.
+---
+
+# google\_project\_service
+
+Allows management of a single API service for an existing Google Cloud Platform project. 
+
+For a list of services available, visit the
+[API library page](https://console.cloud.google.com/apis/library) or run `gcloud service-management list`.
+
+~> **Note:** This resource _must not_ be used in conjunction with
+   `google_project_services` or they will fight over which services should be enabled.
+
+## Example Usage
+
+```hcl
+resource "google_project_service" "project" {
+  project = "your-project-id"
+  service = "iam.googleapis.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service` - (Required) The service to enable.
+
+* `project` - (Optional) The project ID. If not provided, the provider project is used.

--- a/website/docs/r/google_project_services.html.markdown
+++ b/website/docs/r/google_project_services.html.markdown
@@ -15,6 +15,10 @@ in the config will be removed.
 For a list of services available, visit the
 [API library page](https://console.cloud.google.com/apis/library) or run `gcloud service-management list`.
 
+~> **Note:** This resource attempts to be the authoritative source on which APIs are enabled, which can
+	lead to conflicts when certain APIs or actions enable other APIs. To just ensure that a specific
+	API is enabled, use the [google_project_service](google_project_service.html) resource.
+
 ## Example Usage
 
 ```hcl

--- a/website/google.erb
+++ b/website/google.erb
@@ -95,6 +95,9 @@
       <li<%= sidebar_current("docs-google-project-iam-policy") %>>
         <a href="/docs/providers/google/r/google_project_iam_policy.html">google_project_iam_policy</a>
       </li>
+      <li<%= sidebar_current("docs-google-project-service") %>>
+        <a href="/docs/providers/google/r/google_project_service.html">google_project_service</a>
+      </li>
       <li<%= sidebar_current("docs-google-project-services") %>>
         <a href="/docs/providers/google/r/google_project_services.html">google_project_services</a>
       </li>


### PR DESCRIPTION
Fixes #482.
Potential fix for #5 and #596.

Also adds retry logic for enabling/disabling because the tests were being too flaky without it.