### PR TITLE
Add import support for ssl certificate, http/s proxy and url map

### DIFF
--- a/google/import_compute_ssl_certificate_test.go
+++ b/google/import_compute_ssl_certificate_test.go
@@ -1,0 +1,27 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeSslCertificate_import(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeSslCertificate_import,
+			},
+			resource.TestStep{
+				ResourceName:            "google_compute_ssl_certificate.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_key"},
+			},
+		},
+	})
+}

--- a/google/import_compute_target_http_proxy_test.go
+++ b/google/import_compute_target_http_proxy_test.go
@@ -1,0 +1,34 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeTargetHttpProxy_import(t *testing.T) {
+	t.Parallel()
+
+	target := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
+	backend := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
+	hc := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
+	urlmap1 := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
+	urlmap2 := fmt.Sprintf("thttp-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetHttpProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetHttpProxy_basic1(target, backend, hc, urlmap1, urlmap2),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_target_http_proxy.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/import_compute_target_https_proxy_test.go
+++ b/google/import_compute_target_https_proxy_test.go
@@ -1,0 +1,30 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeTargetHttpsProxy_import(t *testing.T) {
+	t.Parallel()
+
+	id := fmt.Sprintf("thttps-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeTargetHttpsProxyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeTargetHttpsProxy_basic1(id),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_target_https_proxy.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/google/import_compute_url_map_test.go
+++ b/google/import_compute_url_map_test.go
@@ -1,0 +1,32 @@
+package google
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccComputeUrlMap_import(t *testing.T) {
+	t.Parallel()
+
+	bsName := fmt.Sprintf("bs-test-%s", acctest.RandString(10))
+	hcName := fmt.Sprintf("hc-test-%s", acctest.RandString(10))
+	umName := fmt.Sprintf("um-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeUrlMapDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeUrlMap_basic1(bsName, hcName, umName),
+			},
+			resource.TestStep{
+				ResourceName:            "google_compute_url_map.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"host_rule", "path_matcher", "test"},
+			},
+		}})
+}

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -15,6 +15,10 @@ func resourceComputeSslCertificate() *schema.Resource {
 		Read:   resourceComputeSslCertificateRead,
 		Delete: resourceComputeSslCertificateDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"certificate": &schema.Schema{
 				Type:      schema.TypeString,
@@ -141,6 +145,9 @@ func resourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("self_link", cert.SelfLink)
 	d.Set("certificate_id", strconv.FormatUint(cert.Id, 10))
+	d.Set("description", cert.Description)
+	d.Set("name", cert.Name)
+	d.Set("certificate", cert.Certificate)
 
 	return nil
 }

--- a/google/resource_compute_ssl_certificate_test.go
+++ b/google/resource_compute_ssl_certificate_test.go
@@ -136,3 +136,12 @@ resource "google_compute_ssl_certificate" "foobar" {
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 `, acctest.RandString(10))
+
+var testAccComputeSslCertificate_import = fmt.Sprintf(`
+resource "google_compute_ssl_certificate" "foobar" {
+	name = "sslcert-test-%s"
+	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+`, acctest.RandString(10))

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -16,6 +16,10 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 		Delete: resourceComputeTargetHttpProxyDelete,
 		Update: resourceComputeTargetHttpProxyUpdate,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -135,6 +139,9 @@ func resourceComputeTargetHttpProxyRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("self_link", proxy.SelfLink)
 	d.Set("proxy_id", strconv.FormatUint(proxy.Id, 10))
+	d.Set("description", proxy.Description)
+	d.Set("url_map", proxy.UrlMap)
+	d.Set("name", proxy.Name)
 
 	return nil
 }

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -23,6 +23,10 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 		Delete: resourceComputeTargetHttpsProxyDelete,
 		Update: resourceComputeTargetHttpsProxyUpdate,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -180,6 +184,9 @@ func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{
 	d.Set("ssl_certificates", proxy.SslCertificates)
 	d.Set("proxy_id", strconv.FormatUint(proxy.Id, 10))
 	d.Set("self_link", proxy.SelfLink)
+	d.Set("description", proxy.Description)
+	d.Set("url_map", proxy.UrlMap)
+	d.Set("name", proxy.Name)
 
 	return nil
 }

--- a/google/resource_compute_url_map.go
+++ b/google/resource_compute_url_map.go
@@ -15,6 +15,10 @@ func resourceComputeUrlMap() *schema.Resource {
 		Update: resourceComputeUrlMapUpdate,
 		Delete: resourceComputeUrlMapDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceComputeUrlMapImportState,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"default_service": &schema.Schema{
 				Type:     schema.TypeString,
@@ -317,6 +321,7 @@ func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("self_link", urlMap.SelfLink)
 	d.Set("map_id", strconv.FormatUint(urlMap.Id, 10))
 	d.Set("fingerprint", urlMap.Fingerprint)
+	d.Set("default_service", urlMap.DefaultService)
 
 	hostRuleMap := make(map[string]*compute.HostRule)
 	for _, v := range urlMap.HostRules {
@@ -674,6 +679,11 @@ func resourceComputeUrlMapDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+func resourceComputeUrlMapImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("name", d.Id())
+	return []*schema.ResourceData{d}, nil
 }
 
 func validateHostRules(v interface{}, k string) (ws []string, es []error) {

--- a/website/docs/r/compute_ssl_certificate.html.markdown
+++ b/website/docs/r/compute_ssl_certificate.html.markdown
@@ -90,3 +90,11 @@ exported:
 
 [1]: /docs/providers/google/r/compute_target_https_proxy.html
 [2]: /docs/configuration/resources.html#lifecycle
+
+## Import
+
+SSL certificate can be imported using the `name`, e.g.
+
+```
+$ terraform import compute_ssl_certificate.html.foobar foobar
+```

--- a/website/docs/r/compute_target_http_proxy.html.markdown
+++ b/website/docs/r/compute_target_http_proxy.html.markdown
@@ -89,3 +89,11 @@ exported:
 * `proxy_id` - A unique ID assigned by GCE.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Target HTTP Proxy can be imported using the `name`, e.g.
+
+```
+$ terraform import compute_target_http_proxy.foobar foobar
+```

--- a/website/docs/r/compute_target_https_proxy.html.markdown
+++ b/website/docs/r/compute_target_https_proxy.html.markdown
@@ -99,3 +99,11 @@ exported:
 * `proxy_id` - A unique ID assigned by GCE.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+Target HTTPS Proxy can be imported using the `name`, e.g.
+
+```
+$ terraform import compute_target_https_proxy.foobar foobar
+```

--- a/website/docs/r/compute_url_map.html.markdown
+++ b/website/docs/r/compute_url_map.html.markdown
@@ -160,3 +160,14 @@ exported:
 * `map_id` - The GCE assigned ID of the resource.
 
 * `self_link` - The URI of the created resource.
+
+## Import
+
+URL Map can be imported using the `name`, e.g.
+
+```
+$ terraform import google_compute_url_map.html.foobar foobar
+```
+
+
+Currently `host_rule`, `path_matcher` and `test` importing is not yet supported.


### PR DESCRIPTION
```
$ TF_ACC=1 go test ./google -v -run TestAccComputeUrlMap -timeout 120m
=== RUN   TestAccComputeUrlMap_import
=== RUN   TestAccComputeUrlMap_basic
=== RUN   TestAccComputeUrlMap_update_path_matcher
=== RUN   TestAccComputeUrlMap_advanced
=== RUN   TestAccComputeUrlMap_noPathRulesWithUpdate
--- PASS: TestAccComputeUrlMap_basic (69.27s)
--- PASS: TestAccComputeUrlMap_import (72.18s)
--- PASS: TestAccComputeUrlMap_noPathRulesWithUpdate (83.70s)
--- PASS: TestAccComputeUrlMap_update_path_matcher (85.37s)
--- PASS: TestAccComputeUrlMap_advanced (143.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	143.133s

$ TF_ACC=1 go test ./google -v -run TestAccComputeTargetHttp
=== RUN   TestAccComputeTargetHttpProxy_import
=== RUN   TestAccComputeTargetHttpsProxy_import
=== RUN   TestAccComputeTargetHttpProxy_basic
=== RUN   TestAccComputeTargetHttpProxy_update
=== RUN   TestAccComputeTargetHttpsProxy_basic
=== RUN   TestAccComputeTargetHttpsProxy_update
=== RUN   TestAccComputeTargetHttpsProxy_invalidCertificate
--- PASS: TestAccComputeTargetHttpsProxy_invalidCertificate (0.04s)
--- PASS: TestAccComputeTargetHttpProxy_basic (93.05s)
--- PASS: TestAccComputeTargetHttpsProxy_basic (93.94s)
--- PASS: TestAccComputeTargetHttpsProxy_import (95.11s)
--- PASS: TestAccComputeTargetHttpProxy_import (104.19s)
--- PASS: TestAccComputeTargetHttpProxy_update (113.31s)
--- PASS: TestAccComputeTargetHttpsProxy_update (120.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	120.100s

$ TF_ACC=1 go test ./google -v -run TestAccComputeSslCertificate
=== RUN   TestAccComputeSslCertificate_import
=== RUN   TestAccComputeSslCertificate_basic
=== RUN   TestAccComputeSslCertificate_no_name
=== RUN   TestAccComputeSslCertificate_name_prefix
--- PASS: TestAccComputeSslCertificate_name_prefix (23.85s)
--- PASS: TestAccComputeSslCertificate_import (23.89s)
--- PASS: TestAccComputeSslCertificate_basic (25.72s)
--- PASS: TestAccComputeSslCertificate_no_name (30.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	30.912s
```