### PR TITLE
Add secondary range support to google_compute_subnetwork data source

### DIFF
--- a/google/data_source_google_compute_subnetwork.go
+++ b/google/data_source_google_compute_subnetwork.go
@@ -33,6 +33,22 @@ func dataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"secondary_ip_range": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"range_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_cidr_range": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"network": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -43,11 +59,13 @@ func dataSourceGoogleComputeSubnetwork() *schema.Resource {
 			},
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 		},
@@ -84,6 +102,10 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	d.Set("description", subnetwork.Description)
 	d.Set("gateway_address", subnetwork.GatewayAddress)
 	d.Set("network", subnetwork.Network)
+	d.Set("project", project)
+	d.Set("region", region)
+	// Flattening code defined in resource_compute_subnetwork.go
+	d.Set("secondary_ip_range", flattenSecondaryRanges(subnetwork.SecondaryIpRanges))
 
 	//Subnet id creation is defined in resource_compute_subnetwork.go
 	subnetwork.Region = region

--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -48,6 +48,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"ip_cidr_range",
 			"network",
 			"private_ip_google_access",
+			"secondary_ip_range",
 		}
 
 		for _, attr_to_check := range subnetwork_attrs_to_test {
@@ -77,6 +78,10 @@ resource "google_compute_subnetwork" "foobar" {
 	ip_cidr_range = "10.0.0.0/24"
 	network  = "${google_compute_network.foobar.self_link}"
 	private_ip_google_access = true
+	secondary_ip_range {
+		range_name = "tf-test-secondary-range"
+		ip_cidr_range = "192.168.1.0/24"
+	}
 }
 
 data "google_compute_subnetwork" "my_subnetwork" {

--- a/website/docs/d/datasource_compute_subnetwork.html.markdown
+++ b/website/docs/d/datasource_compute_subnetwork.html.markdown
@@ -51,4 +51,15 @@ In addition to the arguments listed above, the following attributes are exported
     can access Google services without assigned external IP
     addresses.
 
+* `secondary_ip_range` - An array of configurations for secondary IP ranges for
+    VM instances contained in this subnetwork. Structure is documented below.
+
 * `self_link` - The URI of the created resource.
+
+The `secondary_ip_range` block supports:
+
+* `range_name` - The name associated with this subnetwork secondary range, used
+    when adding an alias IP range to a VM instance.
+
+* `ip_cidr_range` - The range of IP addresses belonging to this subnetwork
+    secondary range.


### PR DESCRIPTION
..and throw in project and region while we're at it, which should fix https://github.com/terraform-providers/terraform-provider-google/issues/159.

```
$ GOOGLE_XPN_HOST_PROJECT=REDACTED \
  GOOGLE_PROJECT=REDACTED \
  GOOGLE_REGION=us-central1 \
  GOOGLE_USE_DEFAULT_CREDENTIALS=1 \
  TF_ACC=1 \
  go test -v . -run "^TestAccDataSourceGoogleSubnetwork$"                                                                
=== RUN   TestAccDataSourceGoogleSubnetwork                                                                          
--- PASS: TestAccDataSourceGoogleSubnetwork (313.85s)                               
PASS                                                                   
ok      github.com/terraform-providers/terraform-provider-google/google 313.872s
```