### PR TITLE
Support highly available postgresql instances

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -56,6 +56,13 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"availability_type": &schema.Schema{
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressFirstGen,
+							// Set computed instead of default because this property is for second-gen only.
+							Computed: true,
+						},
 						"backup_configuration": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
@@ -386,6 +393,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 			settings.AuthorizedGaeApplications = append(settings.AuthorizedGaeApplications,
 				app.(string))
 		}
+	}
+
+	if v, ok := _settings["availability_type"]; ok {
+		settings.AvailabilityType = v.(string)
 	}
 
 	if v, ok := _settings["backup_configuration"]; ok {
@@ -734,6 +745,10 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+		if v, ok := _settings["availability_type"]; ok {
+			settings.AvailabilityType = v.(string)
+		}
+
 		if v, ok := _settings["backup_configuration"]; ok {
 			_backupConfigurationList := v.([]interface{})
 
@@ -981,6 +996,7 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 		"tier":                        settings.Tier,
 		"activation_policy":           settings.ActivationPolicy,
 		"authorized_gae_applications": settings.AuthorizedGaeApplications,
+		"availability_type":           settings.AvailabilityType,
 		"crash_safe_replication":      settings.CrashSafeReplicationEnabled,
 		"disk_autoresize":             settings.StorageAutoResize,
 		"disk_type":                   settings.DataDiskType,

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -413,7 +413,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		settings.CrashSafeReplicationEnabled = v.(bool)
 	}
 
-	settings.StorageAutoResize = _settings["disk_autoresize"].(bool)
+	settings.StorageAutoResize = _settings["disk_autoresize"].(*bool)
 
 	if v, ok := _settings["disk_size"]; ok && v.(int) > 0 {
 		settings.DataDiskSizeGb = int64(v.(int))
@@ -718,7 +718,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		settings := &sqladmin.Settings{
 			Tier:              _settings["tier"].(string),
 			SettingsVersion:   instance.Settings.SettingsVersion,
-			StorageAutoResize: _settings["disk_autoresize"].(bool),
+			StorageAutoResize: _settings["disk_autoresize"].(*bool),
 			ForceSendFields:   []string{"StorageAutoResize"},
 		}
 

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -549,7 +549,7 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 			return fmt.Errorf("Error settings.crash_safe_replication mismatch, (%s, %s)", server, local)
 		}
 
-		server = strconv.FormatBool(instance.Settings.StorageAutoResize)
+		server = strconv.FormatBool(*instance.Settings.StorageAutoResize)
 		local = attributes["settings.0.disk_autoresize"]
 		if server != local && len(server) > 0 && len(local) > 0 {
 			return fmt.Errorf("Error settings.disk_autoresize mismatch, (%s, %s)", server, local)

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -523,6 +523,12 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 			return fmt.Errorf("Error settings.activation_policy mismatch, (%s, %s)", server, local)
 		}
 
+		server = instance.Settings.AvailabilityType
+		local = attributes["settings.0.availability_type"]
+		if server != local && len(server) > 0 && len(local) > 0 {
+			return fmt.Errorf("Error settings.availability_type mismatch, (%s, %s)", server, local)
+		}
+
 		if instance.Settings.BackupConfiguration != nil {
 			server = strconv.FormatBool(instance.Settings.BackupConfiguration.BinaryLogEnabled)
 			local = attributes["settings.0.backup_configuration.0.binary_log_enabled"]

--- a/vendor/google.golang.org/api/sqladmin/v1beta4/sqladmin-api.json
+++ b/vendor/google.golang.org/api/sqladmin/v1beta4/sqladmin-api.json
@@ -1,12 +1,12 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"tbys6C40o18GZwyMen5GMkdK-3s/0q1bgr0rR6WxzzPOS6Rfltu7D84\"",
+ "etag": "\"YWOzh2SDasdU84ArJnpYek-OMdg/qGR3q9t_cRz9md0zXxOmhlJ1eX0\"",
  "discoveryVersion": "v1",
  "id": "sqladmin:v1beta4",
  "name": "sqladmin",
  "canonicalName": "SQL Admin",
  "version": "v1beta4",
- "revision": "20161115",
+ "revision": "20171011",
  "title": "Cloud SQL Administration API",
  "description": "Creates and configures Cloud SQL instances, which provide fully-managed MySQL databases.",
  "ownerDomain": "google.com",
@@ -21,7 +21,7 @@
  "basePath": "/sql/v1beta4/",
  "rootUrl": "https://www.googleapis.com/",
  "servicePath": "sql/v1beta4/",
- "batchPath": "batch",
+ "batchPath": "batch/sqladmin/v1beta4",
  "parameters": {
   "alt": {
    "type": "string",
@@ -344,7 +344,7 @@
     },
     "databaseVersion": {
      "type": "string",
-     "description": "The database engine type and version. The databaseVersion can not be changed after instance creation. Can be MYSQL_5_5, MYSQL_5_6 or MYSQL_5_7. Defaults to MYSQL_5_6. MYSQL_5_7 is applicable only to Second Generation instances."
+     "description": "The database engine type and version. The databaseVersion field can not be changed after instance creation. MySQL Second Generation instances: MYSQL_5_7 (default) or MYSQL_5_6. PostgreSQL instances: POSTGRES_9_6 MySQL First Generation instances: MYSQL_5_6 (default) or MYSQL_5_5"
     },
     "etag": {
      "type": "string",
@@ -363,6 +363,10 @@
        "description": "The name of the failover replica. If specified at instance creation, a failover replica is created for the instance. The name doesn't include the project ID. This property is applicable only to Second Generation instances."
       }
      }
+    },
+    "gceZone": {
+     "type": "string",
+     "description": "The GCE zone that the instance is serving from. In case when the instance is failed over to standby zone, this value may be different with what user specified in the settings."
     },
     "instanceType": {
      "type": "string",
@@ -476,6 +480,74 @@
      "type": "string",
      "description": "This is always sql#databasesList.",
      "default": "sql#databasesList"
+    }
+   }
+  },
+  "DemoteMasterConfiguration": {
+   "id": "DemoteMasterConfiguration",
+   "type": "object",
+   "description": "Read-replica configuration for connecting to the on-premises master.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "This is always sql#demoteMasterConfiguration.",
+     "default": "sql#demoteMasterConfiguration"
+    },
+    "mysqlReplicaConfiguration": {
+     "$ref": "DemoteMasterMySqlReplicaConfiguration",
+     "description": "MySQL specific configuration when replicating from a MySQL on-premises master. Replication configuration information such as the username, password, certificates, and keys are not stored in the instance metadata. The configuration information is used only to set up the replication connection and is stored by MySQL in a file named master.info in the data directory."
+    }
+   }
+  },
+  "DemoteMasterContext": {
+   "id": "DemoteMasterContext",
+   "type": "object",
+   "description": "Database instance demote master context.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "This is always sql#demoteMasterContext.",
+     "default": "sql#demoteMasterContext"
+    },
+    "masterInstanceName": {
+     "type": "string",
+     "description": "The name of the instance which will act as on-premises master in the replication setup."
+    },
+    "replicaConfiguration": {
+     "$ref": "DemoteMasterConfiguration",
+     "description": "Configuration specific to read-replicas replicating from the on-premises master."
+    }
+   }
+  },
+  "DemoteMasterMySqlReplicaConfiguration": {
+   "id": "DemoteMasterMySqlReplicaConfiguration",
+   "type": "object",
+   "description": "Read-replica configuration specific to MySQL databases.",
+   "properties": {
+    "caCertificate": {
+     "type": "string",
+     "description": "PEM representation of the trusted CA's x509 certificate."
+    },
+    "clientCertificate": {
+     "type": "string",
+     "description": "PEM representation of the slave's x509 certificate."
+    },
+    "clientKey": {
+     "type": "string",
+     "description": "PEM representation of the slave's private key. The corresponsing public key is encoded in the client's certificate. The format of the slave's private key can be either PKCS #1 or PKCS #8."
+    },
+    "kind": {
+     "type": "string",
+     "description": "This is always sql#demoteMasterMysqlReplicaConfiguration.",
+     "default": "sql#demoteMasterMysqlReplicaConfiguration"
+    },
+    "password": {
+     "type": "string",
+     "description": "The password for the replication connection."
+    },
+    "username": {
+     "type": "string",
+     "description": "The username for the replication connection."
     }
    }
   },
@@ -647,6 +719,10 @@
      "type": "string",
      "description": "The file type for the specified uri.\nSQL: The file contains SQL statements.\nCSV: The file contains CSV data."
     },
+    "importUser": {
+     "type": "string",
+     "description": "The PostgreSQL user for this import operation. Defaults to cloudsqlsuperuser. Used only for PostgreSQL instances."
+    },
     "kind": {
      "type": "string",
      "description": "This is always sql#importContext.",
@@ -666,6 +742,17 @@
     "cloneContext": {
      "$ref": "CloneContext",
      "description": "Contains details about the clone operation."
+    }
+   }
+  },
+  "InstancesDemoteMasterRequest": {
+   "id": "InstancesDemoteMasterRequest",
+   "type": "object",
+   "description": "Database demote master request.",
+   "properties": {
+    "demoteMasterContext": {
+     "$ref": "DemoteMasterContext",
+     "description": "Contains details about the demoteMaster operation."
     }
    }
   },
@@ -736,6 +823,17 @@
     }
    }
   },
+  "InstancesTruncateLogRequest": {
+   "id": "InstancesTruncateLogRequest",
+   "type": "object",
+   "description": "Instance truncate log request.",
+   "properties": {
+    "truncateLogContext": {
+     "$ref": "TruncateLogContext",
+     "description": "Contains details about the truncate log operation."
+    }
+   }
+  },
   "IpConfiguration": {
    "id": "IpConfiguration",
    "type": "object",
@@ -754,7 +852,7 @@
     },
     "requireSsl": {
      "type": "boolean",
-     "description": "Whether the mysqld should default to 'REQUIRE X509' for users connecting over IP."
+     "description": "Whether SSL connections over IP should be enforced or not."
     }
    }
   },
@@ -951,8 +1049,7 @@
      "description": "Name of the database instance related to this operation."
     },
     "targetLink": {
-     "type": "string",
-     "description": "The URI of the instance related to the operation."
+     "type": "string"
     },
     "targetProject": {
      "type": "string",
@@ -1088,6 +1185,10 @@
       "type": "string"
      }
     },
+    "availabilityType": {
+     "type": "string",
+     "description": "Reserved for future use."
+    },
     "backupConfiguration": {
      "$ref": "BackupConfiguration",
      "description": "The daily backup configuration for the instance."
@@ -1153,7 +1254,12 @@
     },
     "storageAutoResize": {
      "type": "boolean",
-     "description": "Configuration to increase storage size automatically. The default value is false. Applies only to Second Generation instances."
+     "description": "Configuration to increase storage size automatically. The default value is true. Applies only to Second Generation instances."
+    },
+    "storageAutoResizeLimit": {
+     "type": "string",
+     "description": "The maximum size to which storage capacity can be automatically increased. The default value is 0, which specifies that there is no limit. Applies only to Second Generation instances.",
+     "format": "int64"
     },
     "tier": {
      "type": "string",
@@ -1163,6 +1269,14 @@
        "sql.instances.insert",
        "sql.instances.update"
       ]
+     }
+    },
+    "userLabels": {
+     "type": "object",
+     "description": "User-provided labels, represented as a dictionary where each label is a single key value pair.",
+     "additionalProperties": {
+      "type": "string",
+      "description": "An individual label entry, composed of a key and a value."
      }
     }
    }
@@ -1342,6 +1456,22 @@
      "type": "string",
      "description": "This is always sql#tiersList.",
      "default": "sql#tiersList"
+    }
+   }
+  },
+  "TruncateLogContext": {
+   "id": "TruncateLogContext",
+   "type": "object",
+   "description": "Database Instance truncate log context.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "This is always sql#truncateLogContext.",
+     "default": "sql#truncateLogContext"
+    },
+    "logType": {
+     "type": "string",
+     "description": "The type of log to truncate. Valid values are MYSQL_GENERAL_TABLE and MYSQL_SLOW_TABLE."
     }
    }
   },
@@ -1798,6 +1928,13 @@
      "path": "flags",
      "httpMethod": "GET",
      "description": "List all available database flags for Google Cloud SQL instances.",
+     "parameters": {
+      "databaseVersion": {
+       "type": "string",
+       "description": "Database version for flag retrieval. Flags are specific to the database version.",
+       "location": "query"
+      }
+     },
      "response": {
       "$ref": "FlagsListResponse"
      },
@@ -1867,6 +2004,40 @@
       "project",
       "instance"
      ],
+     "response": {
+      "$ref": "Operation"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/sqlservice.admin"
+     ]
+    },
+    "demoteMaster": {
+     "id": "sql.instances.demoteMaster",
+     "path": "projects/{project}/instances/{instance}/demoteMaster",
+     "httpMethod": "POST",
+     "description": "Demotes the standalone instance to be a read replica Cloud SQL instance of an on-premises master.",
+     "parameters": {
+      "instance": {
+       "type": "string",
+       "description": "Cloud SQL instance name.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "ID of the project that contains the instance.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "instance"
+     ],
+     "request": {
+      "$ref": "InstancesDemoteMasterRequest"
+     },
      "response": {
       "$ref": "Operation"
      },
@@ -2039,6 +2210,11 @@
      "httpMethod": "GET",
      "description": "Lists instances under a given project in the alphabetical order of the instance name.",
      "parameters": {
+      "filter": {
+       "type": "string",
+       "description": "An expression for filtering the results of the request, such as by name or label.",
+       "location": "query"
+      },
       "maxResults": {
        "type": "integer",
        "description": "The maximum number of results to return per response.",
@@ -2283,6 +2459,40 @@
       "project",
       "instance"
      ],
+     "response": {
+      "$ref": "Operation"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/sqlservice.admin"
+     ]
+    },
+    "truncateLog": {
+     "id": "sql.instances.truncateLog",
+     "path": "projects/{project}/instances/{instance}/truncateLog",
+     "httpMethod": "POST",
+     "description": "Truncate MySQL general and slow query log tables",
+     "parameters": {
+      "instance": {
+       "type": "string",
+       "description": "Cloud SQL instance ID. This does not include the project ID.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Project ID of the Cloud SQL project.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "instance"
+     ],
+     "request": {
+      "$ref": "InstancesTruncateLogRequest"
+     },
      "response": {
       "$ref": "Operation"
      },

--- a/vendor/google.golang.org/api/sqladmin/v1beta4/sqladmin-gen.go
+++ b/vendor/google.golang.org/api/sqladmin/v1beta4/sqladmin-gen.go
@@ -554,9 +554,10 @@ type DatabaseInstance struct {
 	CurrentDiskSize int64 `json:"currentDiskSize,omitempty,string"`
 
 	// DatabaseVersion: The database engine type and version. The
-	// databaseVersion can not be changed after instance creation. Can be
-	// MYSQL_5_5, MYSQL_5_6 or MYSQL_5_7. Defaults to MYSQL_5_6. MYSQL_5_7
-	// is applicable only to Second Generation instances.
+	// databaseVersion field can not be changed after instance creation.
+	// MySQL Second Generation instances: MYSQL_5_7 (default) or MYSQL_5_6.
+	// PostgreSQL instances: POSTGRES_9_6 MySQL First Generation instances:
+	// MYSQL_5_6 (default) or MYSQL_5_5
 	DatabaseVersion string `json:"databaseVersion,omitempty"`
 
 	// Etag: HTTP 1.1 Entity tag for the resource.
@@ -565,6 +566,11 @@ type DatabaseInstance struct {
 	// FailoverReplica: The name and status of the failover replica. This
 	// property is applicable only to Second Generation instances.
 	FailoverReplica *DatabaseInstanceFailoverReplica `json:"failoverReplica,omitempty"`
+
+	// GceZone: The GCE zone that the instance is serving from. In case when
+	// the instance is failed over to standby zone, this value may be
+	// different with what user specified in the settings.
+	GceZone string `json:"gceZone,omitempty"`
 
 	// InstanceType: The instance type. This can be one of the
 	// following.
@@ -745,6 +751,128 @@ type DatabasesListResponse struct {
 
 func (s *DatabasesListResponse) MarshalJSON() ([]byte, error) {
 	type noMethod DatabasesListResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DemoteMasterConfiguration: Read-replica configuration for connecting
+// to the on-premises master.
+type DemoteMasterConfiguration struct {
+	// Kind: This is always sql#demoteMasterConfiguration.
+	Kind string `json:"kind,omitempty"`
+
+	// MysqlReplicaConfiguration: MySQL specific configuration when
+	// replicating from a MySQL on-premises master. Replication
+	// configuration information such as the username, password,
+	// certificates, and keys are not stored in the instance metadata. The
+	// configuration information is used only to set up the replication
+	// connection and is stored by MySQL in a file named master.info in the
+	// data directory.
+	MysqlReplicaConfiguration *DemoteMasterMySqlReplicaConfiguration `json:"mysqlReplicaConfiguration,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DemoteMasterConfiguration) MarshalJSON() ([]byte, error) {
+	type noMethod DemoteMasterConfiguration
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DemoteMasterContext: Database instance demote master context.
+type DemoteMasterContext struct {
+	// Kind: This is always sql#demoteMasterContext.
+	Kind string `json:"kind,omitempty"`
+
+	// MasterInstanceName: The name of the instance which will act as
+	// on-premises master in the replication setup.
+	MasterInstanceName string `json:"masterInstanceName,omitempty"`
+
+	// ReplicaConfiguration: Configuration specific to read-replicas
+	// replicating from the on-premises master.
+	ReplicaConfiguration *DemoteMasterConfiguration `json:"replicaConfiguration,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DemoteMasterContext) MarshalJSON() ([]byte, error) {
+	type noMethod DemoteMasterContext
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DemoteMasterMySqlReplicaConfiguration: Read-replica configuration
+// specific to MySQL databases.
+type DemoteMasterMySqlReplicaConfiguration struct {
+	// CaCertificate: PEM representation of the trusted CA's x509
+	// certificate.
+	CaCertificate string `json:"caCertificate,omitempty"`
+
+	// ClientCertificate: PEM representation of the slave's x509
+	// certificate.
+	ClientCertificate string `json:"clientCertificate,omitempty"`
+
+	// ClientKey: PEM representation of the slave's private key. The
+	// corresponsing public key is encoded in the client's certificate. The
+	// format of the slave's private key can be either PKCS #1 or PKCS #8.
+	ClientKey string `json:"clientKey,omitempty"`
+
+	// Kind: This is always sql#demoteMasterMysqlReplicaConfiguration.
+	Kind string `json:"kind,omitempty"`
+
+	// Password: The password for the replication connection.
+	Password string `json:"password,omitempty"`
+
+	// Username: The username for the replication connection.
+	Username string `json:"username,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CaCertificate") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CaCertificate") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DemoteMasterMySqlReplicaConfiguration) MarshalJSON() ([]byte, error) {
+	type noMethod DemoteMasterMySqlReplicaConfiguration
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -1005,6 +1133,10 @@ type ImportContext struct {
 	// CSV: The file contains CSV data.
 	FileType string `json:"fileType,omitempty"`
 
+	// ImportUser: The PostgreSQL user for this import operation. Defaults
+	// to cloudsqlsuperuser. Used only for PostgreSQL instances.
+	ImportUser string `json:"importUser,omitempty"`
+
 	// Kind: This is always sql#importContext.
 	Kind string `json:"kind,omitempty"`
 
@@ -1093,6 +1225,36 @@ type InstancesCloneRequest struct {
 
 func (s *InstancesCloneRequest) MarshalJSON() ([]byte, error) {
 	type noMethod InstancesCloneRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// InstancesDemoteMasterRequest: Database demote master request.
+type InstancesDemoteMasterRequest struct {
+	// DemoteMasterContext: Contains details about the demoteMaster
+	// operation.
+	DemoteMasterContext *DemoteMasterContext `json:"demoteMasterContext,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DemoteMasterContext")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DemoteMasterContext") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstancesDemoteMasterRequest) MarshalJSON() ([]byte, error) {
+	type noMethod InstancesDemoteMasterRequest
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -1254,6 +1416,36 @@ func (s *InstancesRestoreBackupRequest) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// InstancesTruncateLogRequest: Instance truncate log request.
+type InstancesTruncateLogRequest struct {
+	// TruncateLogContext: Contains details about the truncate log
+	// operation.
+	TruncateLogContext *TruncateLogContext `json:"truncateLogContext,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "TruncateLogContext")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "TruncateLogContext") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstancesTruncateLogRequest) MarshalJSON() ([]byte, error) {
+	type noMethod InstancesTruncateLogRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // IpConfiguration: IP Management configuration.
 type IpConfiguration struct {
 	// AuthorizedNetworks: The list of external networks that are allowed to
@@ -1265,8 +1457,8 @@ type IpConfiguration struct {
 	// not.
 	Ipv4Enabled bool `json:"ipv4Enabled,omitempty"`
 
-	// RequireSsl: Whether the mysqld should default to 'REQUIRE X509' for
-	// users connecting over IP.
+	// RequireSsl: Whether SSL connections over IP should be enforced or
+	// not.
 	RequireSsl bool `json:"requireSsl,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "AuthorizedNetworks")
@@ -1566,7 +1758,6 @@ type Operation struct {
 	// TargetId: Name of the database instance related to this operation.
 	TargetId string `json:"targetId,omitempty"`
 
-	// TargetLink: The URI of the instance related to the operation.
 	TargetLink string `json:"targetLink,omitempty"`
 
 	// TargetProject: The project ID of the target instance related to this
@@ -1811,6 +2002,9 @@ type Settings struct {
 	// instances.
 	AuthorizedGaeApplications []string `json:"authorizedGaeApplications,omitempty"`
 
+	// AvailabilityType: Reserved for future use.
+	AvailabilityType string `json:"availabilityType,omitempty"`
+
 	// BackupConfiguration: The daily backup configuration for the instance.
 	BackupConfiguration *BackupConfiguration `json:"backupConfiguration,omitempty"`
 
@@ -1873,13 +2067,23 @@ type Settings struct {
 	SettingsVersion int64 `json:"settingsVersion,omitempty,string"`
 
 	// StorageAutoResize: Configuration to increase storage size
-	// automatically. The default value is false. Applies only to Second
+	// automatically. The default value is true. Applies only to Second
 	// Generation instances.
-	StorageAutoResize bool `json:"storageAutoResize,omitempty"`
+	StorageAutoResize *bool `json:"storageAutoResize,omitempty"`
+
+	// StorageAutoResizeLimit: The maximum size to which storage capacity
+	// can be automatically increased. The default value is 0, which
+	// specifies that there is no limit. Applies only to Second Generation
+	// instances.
+	StorageAutoResizeLimit int64 `json:"storageAutoResizeLimit,omitempty,string"`
 
 	// Tier: The tier of service for this instance, for example D1, D2. For
 	// more information, see pricing.
 	Tier string `json:"tier,omitempty"`
+
+	// UserLabels: User-provided labels, represented as a dictionary where
+	// each label is a single key value pair.
+	UserLabels map[string]string `json:"userLabels,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "ActivationPolicy") to
 	// unconditionally include in API requests. By default, fields with
@@ -2207,6 +2411,38 @@ type TiersListResponse struct {
 
 func (s *TiersListResponse) MarshalJSON() ([]byte, error) {
 	type noMethod TiersListResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TruncateLogContext: Database Instance truncate log context.
+type TruncateLogContext struct {
+	// Kind: This is always sql#truncateLogContext.
+	Kind string `json:"kind,omitempty"`
+
+	// LogType: The type of log to truncate. Valid values are
+	// MYSQL_GENERAL_TABLE and MYSQL_SLOW_TABLE.
+	LogType string `json:"logType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TruncateLogContext) MarshalJSON() ([]byte, error) {
+	type noMethod TruncateLogContext
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -3874,6 +4110,14 @@ func (r *FlagsService) List() *FlagsListCall {
 	return c
 }
 
+// DatabaseVersion sets the optional parameter "databaseVersion":
+// Database version for flag retrieval. Flags are specific to the
+// database version.
+func (c *FlagsListCall) DatabaseVersion(databaseVersion string) *FlagsListCall {
+	c.urlParams_.Set("databaseVersion", databaseVersion)
+	return c
+}
+
 // Fields allows partial responses to be retrieved. See
 // https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
 // for more information.
@@ -3968,6 +4212,13 @@ func (c *FlagsListCall) Do(opts ...googleapi.CallOption) (*FlagsListResponse, er
 	//   "description": "List all available database flags for Google Cloud SQL instances.",
 	//   "httpMethod": "GET",
 	//   "id": "sql.flags.list",
+	//   "parameters": {
+	//     "databaseVersion": {
+	//       "description": "Database version for flag retrieval. Flags are specific to the database version.",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
 	//   "path": "flags",
 	//   "response": {
 	//     "$ref": "FlagsListResponse"
@@ -4248,6 +4499,151 @@ func (c *InstancesDeleteCall) Do(opts ...googleapi.CallOption) (*Operation, erro
 	//     }
 	//   },
 	//   "path": "projects/{project}/instances/{instance}",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/sqlservice.admin"
+	//   ]
+	// }
+
+}
+
+// method id "sql.instances.demoteMaster":
+
+type InstancesDemoteMasterCall struct {
+	s                            *Service
+	project                      string
+	instance                     string
+	instancesdemotemasterrequest *InstancesDemoteMasterRequest
+	urlParams_                   gensupport.URLParams
+	ctx_                         context.Context
+	header_                      http.Header
+}
+
+// DemoteMaster: Demotes the standalone instance to be a read replica
+// Cloud SQL instance of an on-premises master.
+func (r *InstancesService) DemoteMaster(project string, instance string, instancesdemotemasterrequest *InstancesDemoteMasterRequest) *InstancesDemoteMasterCall {
+	c := &InstancesDemoteMasterCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.instance = instance
+	c.instancesdemotemasterrequest = instancesdemotemasterrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *InstancesDemoteMasterCall) Fields(s ...googleapi.Field) *InstancesDemoteMasterCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *InstancesDemoteMasterCall) Context(ctx context.Context) *InstancesDemoteMasterCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *InstancesDemoteMasterCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *InstancesDemoteMasterCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.instancesdemotemasterrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "projects/{project}/instances/{instance}/demoteMaster")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"project":  c.project,
+		"instance": c.instance,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "sql.instances.demoteMaster" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *InstancesDemoteMasterCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Demotes the standalone instance to be a read replica Cloud SQL instance of an on-premises master.",
+	//   "httpMethod": "POST",
+	//   "id": "sql.instances.demoteMaster",
+	//   "parameterOrder": [
+	//     "project",
+	//     "instance"
+	//   ],
+	//   "parameters": {
+	//     "instance": {
+	//       "description": "Cloud SQL instance name.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "ID of the project that contains the instance.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "projects/{project}/instances/{instance}/demoteMaster",
+	//   "request": {
+	//     "$ref": "InstancesDemoteMasterRequest"
+	//   },
 	//   "response": {
 	//     "$ref": "Operation"
 	//   },
@@ -4993,6 +5389,13 @@ func (r *InstancesService) List(project string) *InstancesListCall {
 	return c
 }
 
+// Filter sets the optional parameter "filter": An expression for
+// filtering the results of the request, such as by name or label.
+func (c *InstancesListCall) Filter(filter string) *InstancesListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
 // MaxResults sets the optional parameter "maxResults": The maximum
 // number of results to return per response.
 func (c *InstancesListCall) MaxResults(maxResults int64) *InstancesListCall {
@@ -5109,6 +5512,11 @@ func (c *InstancesListCall) Do(opts ...googleapi.CallOption) (*InstancesListResp
 	//     "project"
 	//   ],
 	//   "parameters": {
+	//     "filter": {
+	//       "description": "An expression for filtering the results of the request, such as by name or label.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
 	//     "maxResults": {
 	//       "description": "The maximum number of results to return per response.",
 	//       "format": "uint32",
@@ -6115,6 +6523,150 @@ func (c *InstancesStopReplicaCall) Do(opts ...googleapi.CallOption) (*Operation,
 	//     }
 	//   },
 	//   "path": "projects/{project}/instances/{instance}/stopReplica",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/sqlservice.admin"
+	//   ]
+	// }
+
+}
+
+// method id "sql.instances.truncateLog":
+
+type InstancesTruncateLogCall struct {
+	s                           *Service
+	project                     string
+	instance                    string
+	instancestruncatelogrequest *InstancesTruncateLogRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+	header_                     http.Header
+}
+
+// TruncateLog: Truncate MySQL general and slow query log tables
+func (r *InstancesService) TruncateLog(project string, instance string, instancestruncatelogrequest *InstancesTruncateLogRequest) *InstancesTruncateLogCall {
+	c := &InstancesTruncateLogCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.project = project
+	c.instance = instance
+	c.instancestruncatelogrequest = instancestruncatelogrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *InstancesTruncateLogCall) Fields(s ...googleapi.Field) *InstancesTruncateLogCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *InstancesTruncateLogCall) Context(ctx context.Context) *InstancesTruncateLogCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *InstancesTruncateLogCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *InstancesTruncateLogCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.instancestruncatelogrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "projects/{project}/instances/{instance}/truncateLog")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"project":  c.project,
+		"instance": c.instance,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "sql.instances.truncateLog" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *InstancesTruncateLogCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Truncate MySQL general and slow query log tables",
+	//   "httpMethod": "POST",
+	//   "id": "sql.instances.truncateLog",
+	//   "parameterOrder": [
+	//     "project",
+	//     "instance"
+	//   ],
+	//   "parameters": {
+	//     "instance": {
+	//       "description": "Cloud SQL instance ID. This does not include the project ID.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "Project ID of the Cloud SQL project.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "projects/{project}/instances/{instance}/truncateLog",
+	//   "request": {
+	//     "$ref": "InstancesTruncateLogRequest"
+	//   },
 	//   "response": {
 	//     "$ref": "Operation"
 	//   },

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1113,10 +1113,10 @@
 			"revisionTime": "2017-07-05T20:32:08Z"
 		},
 		{
-			"checksumSHA1": "moKPpECJZQR/mANGD26E7Pbxn4I=",
+			"checksumSHA1": "7VocuDGA5eFIOX/CEy/1i5WrLVw=",
 			"path": "google.golang.org/api/sqladmin/v1beta4",
-			"revision": "3cc2e591b550923a2c5f0ab5a803feda924d5823",
-			"revisionTime": "2016-11-27T23:54:21Z"
+			"revision": "76b09a3314405551b1f19de9944347fcda3f80ae",
+			"revisionTime": "2017-11-08T00:03:15Z"
 		},
 		{
 			"checksumSHA1": "Zd7ojgrWPn3j7fLx9HB6/Oub8lE=",

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -82,6 +82,9 @@ The required `settings` block supports:
 * `authorized_gae_applications` - (Optional) A list of Google App Engine (GAE)
     project names that are allowed to access this instance.
 
+* `availability_type` - (Optional) This specifies whether a PostgreSQL instance
+    should be set up for high availability (`REGIONAL`) or single zone (`ZONAL`).
+
 * `crash_safe_replication` - (Optional) Specific to read instances, indicates
     when crash-safe replication flags are enabled.
 


### PR DESCRIPTION
Cloud SQL now supports high availability configurations (https://cloudplatform.googleblog.com/2017/11/Cloud-SQL-for-PostgreSQL-adds-high-availability-and-replication.html).  This adds support for specifying the new availability_type setting.

This fixes #682 