### PR TITLE
Add docs about upgrading to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,15 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-google
 $ make build
 ```
 
-Upgrading the provider
-----------------------
-
-To upgrade to the latest stable version of the Google provider run `terraform init -upgrade`.
-
-
 Using the provider
 ----------------------
 
 See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the Google provider.
+
+Upgrading the provider
+----------------------
+
+To upgrade to the latest stable version of the Google provider run `terraform init -upgrade`. See the [Terraform website](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for more information.
 
 Developing the Provider
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-google
 $ make build
 ```
 
+Upgrading the provider
+----------------------
+
+To upgrade to the latest stable version of the Google provider run `terraform init -upgrade`.
+
+
 Using the provider
 ----------------------
 


### PR DESCRIPTION
@nodesocket opened #338 to document upgrading to the README. This just moves that around a bit to put it below the section on using the provider, and points to the Terraform website as the source of truth.