### PR TITLE
Add support to google_compute_target_pool for health checks self_link

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -25,6 +25,10 @@ func ParseSslCertificateFieldValue(sslCertificate string, d TerraformResourceDat
 	return parseGlobalFieldValue("sslCertificates", sslCertificate, "project", d, config, false)
 }
 
+func ParseHttpHealthCheckFieldValue(healthCheck string, d TerraformResourceData, config *Config) (*GlobalFieldValue, error) {
+	return parseGlobalFieldValue("httpHealthChecks", healthCheck, "project", d, config, false)
+}
+
 func ParseDiskFieldValue(disk string, d TerraformResourceData, config *Config) (*ZonalFieldValue, error) {
 	return parseZonalFieldValue("disks", disk, "project", "zone", d, config, false)
 }

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -91,7 +91,7 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 
 		hcLink := healthCheckRes.Primary.Attributes["self_link"]
 		if targetPoolRes.Primary.Attributes["health_checks.0"] != hcLink {
-			return fmt.Errorf("Health check not set up. Expected '%s'", hcLink)
+			return fmt.Errorf("Health check not set up. Expected %q", hcLink)
 		}
 
 		return nil

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -21,7 +21,11 @@ func TestAccComputeTargetPool_basic(t *testing.T) {
 				Config: testAccComputeTargetPool_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetPoolExists(
-						"google_compute_target_pool.foobar"),
+						"google_compute_target_pool.foo"),
+					testAccCheckComputeTargetPoolHealthCheck("google_compute_target_pool.foo", "google_compute_http_health_check.foobar"),
+					testAccCheckComputeTargetPoolExists(
+						"google_compute_target_pool.bar"),
+					testAccCheckComputeTargetPoolHealthCheck("google_compute_target_pool.bar", "google_compute_http_health_check.foobar"),
 				),
 			},
 		},
@@ -73,6 +77,27 @@ func testAccCheckComputeTargetPoolExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		targetPoolRes, ok := s.RootModule().Resources[targetPool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", targetPool)
+		}
+
+		healthCheckRes, ok := s.RootModule().Resources[healthCheck]
+		if !ok {
+			return fmt.Errorf("Not found: %s", healthCheck)
+		}
+
+		hcLink := healthCheckRes.Primary.Attributes["self_link"]
+		if targetPoolRes.Primary.Attributes["health_checks.0"] != hcLink {
+			return fmt.Errorf("Health check not set up. Expected '%s'", hcLink)
+		}
+
+		return nil
+	}
+}
+
 var testAccComputeTargetPool_basic = fmt.Sprintf(`
 resource "google_compute_http_health_check" "foobar" {
 	name = "healthcheck-test-%s"
@@ -95,7 +120,7 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 
-resource "google_compute_target_pool" "foobar" {
+resource "google_compute_target_pool" "foo" {
 	description = "Resource created for Terraform acceptance testing"
 	instances = ["${google_compute_instance.foobar.self_link}", "us-central1-b/bar"]
 	name = "tpool-test-%s"
@@ -103,4 +128,12 @@ resource "google_compute_target_pool" "foobar" {
 	health_checks = [
 		"${google_compute_http_health_check.foobar.name}"
 	]
-}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
+
+resource "google_compute_target_pool" "bar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "tpool-test-%s"
+	health_checks = [
+		"${google_compute_http_health_check.foobar.self_link}"
+	]
+}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/website/docs/r/compute_target_pool.html.markdown
+++ b/website/docs/r/compute_target_pool.html.markdown
@@ -30,6 +30,13 @@ resource "google_compute_target_pool" "default" {
     "${google_compute_http_health_check.default.name}",
   ]
 }
+
+resource "google_compute_http_health_check" "default" {
+  name               = "default"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
 ```
 
 ## Argument Reference
@@ -49,7 +56,8 @@ The following arguments are supported:
 * `failover_ratio` - (Optional) Ratio (0 to 1) of failed nodes before using the
     backup pool (which must also be set).
 
-* `health_checks` - (Optional) List of zero or one healthcheck names.
+* `health_checks` - (Optional) List of zero or one health check name or self_link. Only
+    legacy `google_compute_http_health_check` is supported.
 
 * `instances` - (Optional) List of instances in the pool. They can be given as
     URLs, or in the form of "zone/name". Note that the instances need not exist


### PR DESCRIPTION
Instead of requiring the health check name. It now accepts the self_link or the name.

I added:
- Accepts self_link in addition of health check name
- Removes the need for an API call to generate the self link
- Improves the documentation to mention that only the legacy `google_compute_http_health_check` is supported. This will prevent our user from being stuck like mentioned here: #300.
- Adds a `MaxItems:1` in the schema. You can't have more than one. The API will fail. The official docs also says so.
- Adds a check to the acceptance test to ensure the health checks are properly setup.