### PR TITLE
Fix the description of the compute instance group

### DIFF
--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -8,9 +8,8 @@ description: |-
 
 # google\_compute\_instance\_group
 
-The Google Compute Engine Instance Group API creates and manages pools
-of homogeneous Compute Engine virtual machine instances from a common instance
-template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
+Creates a group of dissimilar Compute Engine virtual machine instances.
+For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
 and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroups)
 
 ## Example Usage


### PR DESCRIPTION
Since this resource is targeting unmanaged instances i've changed the description to better fit its purpose 😄 