### PR TITLE
Add configurable timeouts for disks

### DIFF
--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -31,6 +32,21 @@ func TestAccComputeDisk_basic(t *testing.T) {
 					testAccCheckComputeDiskHasLabel(&disk, "my-label", "my-label-value"),
 					testAccCheckComputeDiskHasLabelFingerprint(&disk, "google_compute_disk.foobar"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccComputeDisk_timeout(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccComputeDisk_timeout,
+				ExpectError: regexp.MustCompile("timeout"),
 			},
 		},
 	})
@@ -297,6 +313,18 @@ resource "google_compute_disk" "foobar" {
 	}
 }`, diskName)
 }
+
+var testAccComputeDisk_timeout = fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+	name  = "%s"
+	image = "debian-8-jessie-v20160803"
+	type  = "pd-ssd"
+	zone  = "us-central1-a"
+
+	timeouts {
+		Create = "1s"
+	}
+}`, acctest.RandString(10))
 
 func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`

--- a/website/docs/r/compute_disk.html.markdown
+++ b/website/docs/r/compute_disk.html.markdown
@@ -78,6 +78,15 @@ exported:
 
 * `label_fingerprint` - The fingerprint of the assigned labels.
 
+## Timeouts
+
+`google_compute_disk` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `5 minutes`) Used for creating disks.
+- `update` - (Default `5 minutes`) Used for resizing a disk and setting labels on disks.
+- `delete` - (Default `5 minutes`) Used for destroying disks (not including time to detach the disk from instances).
+
 ## Import
 
 Disks can be imported using the `name`, e.g.


### PR DESCRIPTION
Fixes #703 by way of allowing the user to control the timeout for disks. Also changes the default from 4 to 5 in case that helps too.