### PR TITLE
Improve documentation for resource service_account_key

### DIFF
--- a/__test-project/creds.json
+++ b/__test-project/creds.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "keymaster-00100",
+  "private_key_id": "6c12d5eabb10bd4b06290b045deaa99853c29d1a",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDLC6/08GmLgHqA\ny87KCVzPtWb12gN6jK00LDGQiyZgpap7geCmOGHItRFSI/Oex2IMviqA6wc6fpFv\nyCvqpSF6+JzgAzgbxPif4Vl+zdSOXOgRBqaiPBfuc2crlAtfQtd9xbPWVbbQ+SnC\nmf02ts7wlVf7TE+ksl29tGVVqFrzJ/Rl6vIX928BHwunzBisUnkiW29WTG28g+Gi\n89GneYLNoic5gHBcrectfT8NUV6h/PCoD3xkAZZvFYtgu8xlisTC9UZH0A6x1hxJ\ncakFv0o6P05cURaXT5sXUB+e6qabRjJXQy9f8st2HxVITT8mbNvdt9OPdOSfr5Z6\nRLyAbh1BAgMBAAECggEABFB3GoI622PBUpwWBJppozkVfyIE7LdJUT5ixpmC0RcX\nD+sT53NDbmPcyoMMnLwrwuWd5oWr7n34zBRHvNt5sky+3FaMLEChh+fmXnKsHnLm\nXFGA5BnI2ERx6dnaSqG7bYLwT/Sr+u1u6gFqsT1V2QRC2XpS90biFZc8F5uBVHkc\nQ0/xc17tHS3OStZwd33jxwCfsZxVwgs8S8A8aad9k6WC9uGntp9naY1zx3YKMt/r\n6+W0MIJCWJ5f7/oJ6p/3CADEcgnramp5+3LExmoJBfDmqVxjb3bzCKnU0BXhvRjE\nR64DZHVqutvp/7aGjfwRxvgOqBCUD9NYqplyzi/UoQKBgQDrtVZVm53QLzvEQwBW\nSOzHtWUCdGzXSWSKwNswvsRSvFwT9T2Z81IP91VZMG1KjEn751T42zogWMN9AeNV\nkkMQUvY1uDJMpl/0FY+3y14Q+SBOVIH18g5YtnU2MCn0pNOrHOHvDcm1RLMMMi2Z\ni/rTdh90Gi4rALTV51w4MLGkYQKBgQDchoM/aWuQiqdkqqEEvNlo5f9wATH6GcFj\nMPrSjc5k75YgtNtn0nyY/BOUjbIhn8Gko3mtggVjvMMp4DVoeR4vrBXNFoJVlPmR\nckomGAIcTGx/ZjTWvDirv5i9hax3Ec874a/46SwjFe3UA6wRK2hT1B5j/0W5pPia\n6JcPR48k4QKBgQDlV6jsXSEdiofVu/ec/RHec4IX9F5ez1uTonjjogp2Ei5pgOpy\nXA1R2a9iu7rrmTr3bqwAA5c4GAYGIQsonMrCHGbR+CqA6DVe0ofnJmqdizlC3fkh\n7GbHLKk5k32PO710tgKjzj+gL3sjd8Nkro3cqQeLuVmIoARUSOwzBDYkoQKBgQC7\nElTGdzxrWmPUDrcXWMippuqA7lKiEjUuWv97nBYpI+FcD3BMa4+NC9HkZCtnQKm5\na4AuAy1lRVzd6jgETzKfSEEaQG0CAqWPj798/0LTFLW5gU9zlioQ8DC3HW2HeJEv\nAC4SXmM1xEWDZDYUPpl6+2dodsWETYEjkAmNSawRoQKBgQC9jaw+IQfcGA513nfF\nSg6Z5qwDpXJKOFWTwlWXbDGLtJX5utXkCyR63zhw5VdXX+uuUG335VH1UCK6jpgm\nv+X05aiBAEEiztT3AT/19nPnQFCmRlIswhg45MDo0KsqPe2A2cIf5AT2lGDyWLYh\nVpBTk+ryu0ONML0Utp3LQ9W6WA==\n-----END PRIVATE KEY-----\n",
+  "client_email": "myserviceaccount@keymaster-00100.iam.gserviceaccount.com",
+  "client_id": "117160445203861227860",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/myserviceaccount%40keymaster-00100.iam.gserviceaccount.com"
+}

--- a/__test-project/creds2.json
+++ b/__test-project/creds2.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "terraform-test-123",
+  "private_key_id": "61ad2bc91ace67e3d17791d07a666504fdf09fba",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCkGHdozqbycNoZ\nCU5YsU6ys6GlEYFPWjGdYpJJlh27EWw0afntbbL3CT5EtpmTWPLflm0nOfHEI6Iv\nfOxTWaR0WJ/2YZxbMFHnLgVEyunlmo/M6rdZmN2BBBm26t8zZ/j8QTlDdLx4yqj0\nUUR1BniLk7dn4cd9Z9xLAuZbrMsQm0q14SgqgX34VGgUAwl7x/mAcrluWCDUYdqh\nW3C+QyiCGcjKfr/332ex1+CgkqkrbygEgYatq+q0CbPPqToBAe2YtLRI1oReKwOC\nD4nxoWtBWRhpIoPh8h5MHsycrFwmVUpp3yQZus/cwdSAgd0Ixqi/2qzPpPNxLT5a\nf5vZtq+JAgMBAAECggEAFiPH7p/dJf5EatbW14AatGEomM8fEYADjC7Junxyx/PO\nk9bNlfN0T0DTwi0Z1OfOIw0WbpGylSpSnlIeR5OjbOAtOu6KDEKddlG++7xd6PDc\n4IK1mLTXg+nz9zpCwZqQXSaGrZuBN1HukEIruJdWKczVFMLBaeHattMuFeXfIv79\nV7S0kfXDbrKdMZUnydHoTxwF+F2t24eBRRPjEvAHGp8bAsRqStyp+lzf+UiCDtaU\nCkWRrTYSztve920wxzYYDMZu179Zh06HhWVqS1f6ex/IjMFvBPUXlGXoV/otxY4N\neuSffBoW7jtyaL6ZEt9L7yHCjJMTXqSXPAFquVyLJQKBgQDcFwrkKlgJp9xoBIfV\nTVaKFWJ7XsoN/PKK/vbhwgOPth8aMkr0w0CvY84snenCrBc+DTDyw8H1/LrZCh9E\nYHysUPvjAQySIgfjll4+VpJSyiBfMlWRamRPQ8Ps7idh55zfIDc4LwQhE8OfAfML\ncyY1BlvD7ogaEq7ZL7ZH5kMfPQKBgQC+3pZymAxne4awcbvi2Vct6f5TfQZpuF28\nYBTG9FdzuDTMk/LS71bfiK1Qq/xLMHtRgnnmoOH4zNuHmxzRwFA8iwdEOo87I3YV\niU0lKh/IwDsKtmnwKUd7xGmWu8WC59zNqvmMOWrOXMKFQFcMUHUJevui8Y3DXdfs\n3oIdM70WPQKBgER6auoY/rFqaBp5JmZInN9zzeOC161IgZKbx+bwPbluOfklosrL\nIYowrIqXS49FiinFYvB11hiaXOyAyL+2obPfsq+ruOSS8A9wzrvopbhaqX3VJGiN\nSM6c0A4c/2Xn8Zg+5s91WXyNMLV9nsh2OHIRG2Y4BmLOY1ayEK4IR+QlAoGAOXSn\ntTcwBLaahOK3vEHQjHGzrU4lcA2fqeUCXCGRcbQxsKOYpQaHECMEiRQ8jiW5+X9d\nUp97ZnnEW73Fnx5VCOSQ+2jlVNgH49PA9T8I8lVrcH4YxcKnUgp9/nHnstA5F3Aw\nTpW6IQSrSZFkosBVetUaiqJMGlNVfGg+oqvAb8ECgYARYEcTidfyy4t+1psFjTWa\nTfQenI9ZTmra34iwSxcOMgX+HPh9LX2CD0BhtHfywp5iJ1GsGVuCBbZFc8RCvdCY\nyO4d8/WCktZIkHlTTAbO/rl4Plf5u+zLCXqRUhbwRI+Z50mPRu2EcDc5RG180TwN\nthtk4livzVt6A9Fz4uHxUQ==\n-----END PRIVATE KEY-----\n",
+  "client_email": "svc-368@terraform-test-123.iam.gserviceaccount.com",
+  "client_id": "112106731584611812017",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/svc-368%40terraform-test-123.iam.gserviceaccount.com"
+}

--- a/__test-project/creds3.json
+++ b/__test-project/creds3.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "god-00100",
+  "private_key_id": "ee4b508c96b3aff060a9ec4c06e666a0d2dccd96",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC8OIxn/K86+4To\nia/l04xylbEkwPrXifudQDWeuCxVoM+ezHiAhaYIBYAevfjuN5XssKWwMib2yz7W\nMPwQZzkzofAPWDORuRVuV8GSvisCmP3tcqQMgSijPWOWU5gI5sE//Z+JgIvMAGD3\n0SGKRtmYtnr1M7YwrGEHIKVzRFWWmeO9NSM5sQMzIIpUzjIWbVjz5zXtC0k4jMWn\nE4vIfsyqcNlCy7OlV9v5sd13Ss/nT1vDGaw8KJpCTIuk7S7mSkQtA9HiK1WhuhHM\n3pKCQVIhpayDDTqr/cF8qZbEvNW1m5w6aHpzYIPvEme9WkT9bdJEkwrvILPHFU4m\nsIEB7F4hAgMBAAECgf8OQ/PSGHvL6tmWKdlZR0EhX+jX1Z3YFKfWP7XQqqvqbfP5\nH9RlzNfMLoIZJ7eA5Mr0mtJlxLyoKZvO7lIsbBgtVTGZFJK3kZo8cPFiBrmKA4dX\n0LFsiE9Inj5/zV1DMwEylNgw10nBKOKiV3rvvHYPvP3Ggn26ucevDUbSQFgRo6i3\nbvXN/32rCGMr6jzpTxCFa8/kgnbWD8fncWj1Ln0oGgD099IcGWZ75tFLEQVfZQoa\nziGO+b7xoTGJISNGC2CZN2wy/lFOX2x/8bj4By9zqXhqrdTrjYHXq6HNN7Kf7+v5\n4kZcQekSs18+KwpRCs/33QT8C6bAMpq04UJSEaECgYEA5ZeCLrYTO+J2CXX6ZUvJ\nxO2krNpBMNHVnYlw3KpH7bwd0p1tTm1gMpNbomvgcSnW24ZHLHrjESTEg2Px4aZV\nVpoFqhTxR8+bSjTEI7Ud04ViRbD9uPKc6zz+rBRzRRchHNxSE+P6U9GF1BOpfZRg\nqQ0B9etYyxrx+1J+KHlm81ECgYEA0d7YBbaPzNHpW+g3CHCYiOPQjhifo1LERbRt\nnNHfnXIrhuHYztfmq2rIQ9XJi7Te/2vEk4MGg2XocRcnjwho8wSnBBSzsYq08Tl0\naEBlFDl9a0eRc5aec5OidQtUwFQhjp8jw+jy1RPWPBTpVRTEW9bf29Ttg6QNC+RY\n6lH76dECgYEAtKiYbosk7V1QRjeIdYbCWOwqRT1kSLcEoPbSUUDIYqBA00a/CRR1\nurZLR64dKM6kW474mF6GKCpHW6AcZ9PLmN6PkHr0NO5+olCM+g/9TUDKyE3yCEMY\nCN6xAtUAsx/1FVGkYDRm+OeIqA1ktAU6Xit3HHw5HXCxcnJCBTUqNlECgYEAqjTf\n3+pKv6Mybg5rq5Wdr8+LUeLYfV3fvmRxTXDMuWVhtbeu3TouYrFsj89v8LUU8fPV\n7oiiHKjmlelgdNkuPIF2bpHXllLXIpglN3OaRofFlt7pMORjx3phlClHZ+ATgxa/\nq+BeKL84zWtsPUtlYNJopWIP6uZ+ijl8fzVUaDECgYAdajIfOfFmV5GDBLdKb7mo\n4vMnb9xckiY59zI+PMxILcG0nXU/oRidHOB8uhG1ov66iXbEmgm1aU0e399mojr/\nMOd4A4LncFIUVHnAcVQkZ6c6NHu/R9rTTgIT3AyKA+bJXQ/0oBb9JhUG/3lhfRQ8\n4a0W2f+k1AEFLtt+Dkv4cA==\n-----END PRIVATE KEY-----\n",
+  "client_email": "god-380@god-00100.iam.gserviceaccount.com",
+  "client_id": "116277606202406548605",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/god-380%40god-00100.iam.gserviceaccount.com"
+}

--- a/__test-project/main.tf
+++ b/__test-project/main.tf
@@ -1,0 +1,75 @@
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "acceptance" {
+  project = "${google_project.acceptance.project_id}"
+
+  services = [
+    "cloudkms.googleapis.com",
+  ]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = "${google_project_services.acceptance.project}"
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = "${google_kms_key_ring.key_ring.id}"
+}
+
+# rotation
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "acceptance" {
+  project = "${google_project.acceptance.project_id}"
+
+  services = [
+    "cloudkms.googleapis.com",
+  ]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = "${google_project.acceptance.project_id}"
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name            = "%s"
+  key_ring        = "${google_kms_key_ring.key_ring.id}"
+  rotation_period = "%s"
+}
+
+# remove
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "acceptance" {
+  project = "${google_project.acceptance.project_id}"
+
+  services = [
+    "cloudkms.googleapis.com",
+  ]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = "${google_project.acceptance.project_id}"
+  name     = "%s"
+  location = "us-central1"
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+    <h1>Hello, world!</h1>
+</body>
+</html>

--- a/patch
+++ b/patch
@@ -1,0 +1,12 @@
+diff --git a/google/provider.go b/google/provider.go
+index 2448388..d3ec987 100644
+--- a/google/provider.go
++++ b/google/provider.go
+@@ -118,6 +118,7 @@ func Provider() terraform.ResourceProvider {
+ 			"google_logging_folder_sink":                   resourceLoggingFolderSink(),
+ 			"google_logging_project_sink":                  resourceLoggingProjectSink(),
+ 			"google_kms_key_ring":                          resourceKmsKeyRing(),
++			"google_kms_crypto_key":                        resourceKmsCryptoKey(),
+ 			"google_sourcerepo_repository":                 resourceSourceRepoRepository(),
+ 			"google_spanner_instance":                      resourceSpannerInstance(),
+ 			"google_spanner_database":                      resourceSpannerDatabase(),

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -53,7 +53,9 @@ The following arguments are supported:
 * `private_key_type` (Optional) The output format of the private key. GOOGLE_CREDENTIALS_FILE is the default output format.
 
 * `pgp_key` – (Optional) An optional PGP key to encrypt the resulting private
-key material. Only used when creating or importing a new key pair
+key material. Only used when creating or importing a new key pair. May either be
+a base64-encoded public key or a `keybase:keybaseusername` string for looking up
+in Vault.
 
 ~> **NOTE:** a PGP key is not required, however it is strongly encouraged.
 Without a PGP key, the private key material will be stored in state unencrypted.

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -46,7 +46,10 @@ The following arguments are supported:
 
 * `service_account_id` - (Required) The Service account id of the Key Pair.
 
-* `key_algorithm` - (Optional) The output format of the private key. GOOGLE_CREDENTIALS_FILE is the default output format. Valid values are listed at [ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountPrivateKeyType) (only used on create)
+* `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
+Valid values are listed at
+[ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKeyAlgorithm)
+(only used on create)
 
 * `public_key_type` (Optional) The output format of the public key requested. X509_PEM is the default output format.
 


### PR DESCRIPTION
Great to have this resource available; playing around with it, I came across a couple of issues with the documentation.

- `key_algorithm` description was erroneous, and actually had information about `private_key_type`
- The `pgp_key` argument also accepts literal key bytes, so I thought that was worth mentioning for people who aren't using vault.