### PR TITLE
Correction and clarification of service_account_key docs

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -53,7 +53,9 @@ The following arguments are supported:
 * `private_key_type` (Optional) The output format of the private key. GOOGLE_CREDENTIALS_FILE is the default output format.
 
 * `pgp_key` – (Optional) An optional PGP key to encrypt the resulting private
-key material. Only used when creating or importing a new key pair
+key material. Only used when creating or importing a new key pair. May either be
+a base64-encoded public key or a `keybase:keybaseusername` string for looking up
+in Vault.
 
 ~> **NOTE:** a PGP key is not required, however it is strongly encouraged.
 Without a PGP key, the private key material will be stored in state unencrypted.

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -46,7 +46,10 @@ The following arguments are supported:
 
 * `service_account_id` - (Required) The Service account id of the Key Pair.
 
-* `key_algorithm` - (Optional) The output format of the private key. GOOGLE_CREDENTIALS_FILE is the default output format. Valid values are listed at [ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountPrivateKeyType) (only used on create)
+* `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
+Valid values are listed at
+[ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKeyAlgorithm)
+(only used on create)
 
 * `public_key_type` (Optional) The output format of the public key requested. X509_PEM is the default output format.
 


### PR DESCRIPTION
Great to have this resource available; playing around with it, I came across a couple of issues with the documentation.

- `key_algorithm` description was erroneous, and actually had information about `private_key_type`
- The `pgp_key` argument also accepts literal key bytes, so I thought that was worth mentioning for people who aren't using vault.