### PR TITLE
Include maintainers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Terraform Provider for Google Cloud Platform
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 
+Maintainers
+-----------
+
+This provider plugin is maintained by:
+
+* The [Google Cloud Graphite Team](https://cloudplatform.googleblog.com/2017/03/partnering-on-open-source-Google-and-HashiCorp-engineers-on-managing-GCP-infrastructure.html) at Google
+* The Terraform team at [HashiCorp](https://www.hashicorp.com/)
+
 Requirements
 ------------
 


### PR DESCRIPTION
I'm planning to make changes like this across all of the provider repositories, to highlight the different maintainers across each of them.

I'm not sure if the "Partnering on Open Source" blog post is the best link for "Google Cloud Graphite Team" here; happy to change it if there's a better page for this!
