### PR TITLE
Set UseLegacySql to true for compatibility with the BigQuery API

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -112,7 +112,7 @@ func resourceBigQueryTable() *schema.Resource {
 						"use_legacy_sql": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default: true,
+							Default:  true,
 						},
 					},
 				},

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -112,6 +112,7 @@ func resourceBigQueryTable() *schema.Resource {
 						"use_legacy_sql": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default: true,
 						},
 					},
 				},


### PR DESCRIPTION
This is required for compatibility with the default value of this field in BigQuery. Without this set, Terraform will always detect that there has been a change to resources that do not explicitly set this field.