### PR TITLE
Relax diff on maintenance_policy.daily_maintenance_window.start_time

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -187,10 +187,11 @@ func resourceContainerCluster() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"start_time": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validateRFC3339Time,
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
+										ValidateFunc:     validateRFC3339Time,
+										DiffSuppressFunc: rfc3339TimeDiffSuppress,
 									},
 									"duration": {
 										Type:     schema.TypeString,

--- a/google/utils.go
+++ b/google/utils.go
@@ -293,6 +293,15 @@ func portRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+// Single-digit hour is equivalent to hour with leading zero e.g. suppress diff 1:00 => 01:00
+// Assume `new` will have already been validated to ensure leading zero
+func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if len(old) == 4 && "0"+old == new {
+		return true
+	}
+	return false
+}
+
 // expandLabels pulls the value of "labels" out of a schema.ResourceData as a map[string]string.
 func expandLabels(d *schema.ResourceData) map[string]string {
 	return expandStringMap(d, "labels")

--- a/google/utils.go
+++ b/google/utils.go
@@ -293,10 +293,10 @@ func portRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-// Single-digit hour is equivalent to hour with leading zero e.g. suppress diff 1:00 => 01:00
-// Assume `new` will have already been validated to ensure leading zero
+// Single-digit hour is equivalent to hour with leading zero e.g. suppress diff 1:00 => 01:00.
+// Assume either value could be in either format.
 func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if len(old) == 4 && "0"+old == new {
+	if (len(old) == 4 && "0"+old == new) || (len(new) == 4 && "0"+new == old) {
 		return true
 	}
 	return false

--- a/google/utils_test.go
+++ b/google/utils_test.go
@@ -93,3 +93,11 @@ func TestIpCidrRangeDiffSuppress(t *testing.T) {
 		}
 	}
 }
+
+func TestRfc3339TimeDiffSuppress(t *testing.T) {
+	old := "2:00"
+	new := "02:00"
+	if rfc3339TimeDiffSuppress("time", old, new, nil) == false {
+		t.Fatalf("Expected diff of '%s' => '%s' to be suppressed", old, new)
+	}
+}

--- a/google/utils_test.go
+++ b/google/utils_test.go
@@ -95,9 +95,44 @@ func TestIpCidrRangeDiffSuppress(t *testing.T) {
 }
 
 func TestRfc3339TimeDiffSuppress(t *testing.T) {
-	old := "2:00"
-	new := "02:00"
-	if rfc3339TimeDiffSuppress("time", old, new, nil) == false {
-		t.Fatalf("Expected diff of '%s' => '%s' to be suppressed", old, new)
+	cases := map[string]struct {
+		Old, New          string
+		ExpectDiffSupress bool
+	}{
+		"same time, format changed to have leading zero": {
+			Old:               "2:00",
+			New:               "02:00",
+			ExpectDiffSupress: true,
+		},
+		"same time, format changed not to have leading zero": {
+			Old:               "02:00",
+			New:               "2:00",
+			ExpectDiffSupress: true,
+		},
+		"different time, both without leading zero": {
+			Old:               "2:00",
+			New:               "3:00",
+			ExpectDiffSupress: false,
+		},
+		"different time, old with leading zero, new without": {
+			Old:               "02:00",
+			New:               "3:00",
+			ExpectDiffSupress: false,
+		},
+		"different time, new with leading zero, oldwithout": {
+			Old:               "2:00",
+			New:               "03:00",
+			ExpectDiffSupress: false,
+		},
+		"different time, both with leading zero": {
+			Old:               "02:00",
+			New:               "03:00",
+			ExpectDiffSupress: false,
+		},
+	}
+	for tn, tc := range cases {
+		if rfc3339TimeDiffSuppress("time", tc.Old, tc.New, nil) != tc.ExpectDiffSupress {
+			t.Errorf("bad: %s, '%s' => '%s' expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSupress)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #719.
Add a DiffSuppressFunc to start_time.

I can't see if there's a useful way to test this in the unit test and I can't see how I'd trigger this condition through an acceptance test case. Ideas & advice welcome!