### PR TITLE
Fix timeout issue with project services

### DIFF
--- a/google/resource_google_project_services.go
+++ b/google/resource_google_project_services.go
@@ -205,7 +205,7 @@ func enableService(s, pid string, config *Config) error {
 
 func disableService(s, pid string, config *Config) error {
 	dsr := newDisableServiceRequest(pid)
-	err := retry(func() error {
+	err := retryTime(func() error {
 		sop, err := config.clientServiceMan.Services.Disable(s, dsr).Do()
 		if err != nil {
 			return err

--- a/google/resource_google_project_services.go
+++ b/google/resource_google_project_services.go
@@ -186,7 +186,7 @@ func getApiServices(pid string, config *Config, ignore map[string]struct{}) ([]s
 
 func enableService(s, pid string, config *Config) error {
 	esr := newEnableServiceRequest(pid)
-	err := retry(func() error {
+	err := retryTime(func() error {
 		sop, err := config.clientServiceMan.Services.Enable(s, esr).Do()
 		if err != nil {
 			return err
@@ -196,7 +196,7 @@ func enableService(s, pid string, config *Config) error {
 			return waitErr
 		}
 		return nil
-	})
+	}, 10)
 	if err != nil {
 		return fmt.Errorf("Error enabling service %q for project %q: %v", s, pid, err)
 	}
@@ -216,7 +216,7 @@ func disableService(s, pid string, config *Config) error {
 			return waitErr
 		}
 		return nil
-	})
+	}, 10)
 	if err != nil {
 		return fmt.Errorf("Error disabling service %q for project %q: %v", s, pid, err)
 	}

--- a/google/utils.go
+++ b/google/utils.go
@@ -376,7 +376,11 @@ func mergeSchemas(a, b map[string]*schema.Schema) map[string]*schema.Schema {
 }
 
 func retry(retryFunc func() error) error {
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return retryTime(retryFunc, 1)
+}
+
+func retryTime(retryFunc func() error, minutes int) error {
+	return resource.Retry(time.Duration(minutes)*time.Minute, func() *resource.RetryError {
 		err := retryFunc()
 		if err == nil {
 			return nil


### PR DESCRIPTION
Apparently the retry function (which was set to retry for one minute) was conflicting with our operation wait (which was set to retry for ten minutes) and winning. I looked through the code and it really seems like that the first iteration through the retry it should wait for the function to return, which would take the full ten minutes (or whenever the api is done getting enabled) but this at least fixes it.

I definitely agree that we should have configurable timeouts, but it's a bit complicated with project_services because it makes as many API calls as there are APIs to enable or disable in a given run, and we usually do a timeout per create/read/update/delete function and I don't want it to be misleading. We could pretty easily add it to the fine-grained project_service resource, but it's not as urgent now that the timeout is actually getting set to the value we had set it to originally.

I'll go ahead and say this fixes #722.