### PR TITLE
Make the link to the documentation more discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Terraform Provider for Google Cloud Platform
 ==================
 
 - Website: https://www.terraform.io
+- Documentation: https://www.terraform.io/docs/providers/google/index.html
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">


### PR DESCRIPTION
Right now, the link is under the "Using the provider" section, I think it doesn't hurt to also add it at the top of the README file.