### PR TITLE
Adds google_kms_secret data source

### DIFF
--- a/google/data_source_google_kms_secret.go
+++ b/google/data_source_google_kms_secret.go
@@ -1,0 +1,123 @@
+package google
+
+import (
+	"google.golang.org/api/cloudkms/v1"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"regexp"
+	"strings"
+	"encoding/base64"
+	"time"
+)
+
+func dataSourceGoogleKmsSecret() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleKmsSecretRead,
+		Schema: map[string]*schema.Schema{
+			"crypto_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ciphertext": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"plaintext": &schema.Schema{
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+type kmsCryptoKeyId struct {
+	KeyRingId kmsKeyRingId
+	Name      string
+}
+
+// TODO: Add the info about rotation frequency and start time.
+
+func (s *kmsCryptoKeyId) cryptoKeyId() string {
+	return fmt.Sprintf("%s/cryptoKeys/%s", s.KeyRingId.keyRingId(), s.Name)
+}
+
+func (s *kmsCryptoKeyId) parentId() string {
+	return s.KeyRingId.keyRingId()
+}
+
+func (s *kmsCryptoKeyId) terraformId() string {
+	return fmt.Sprintf("%s/%s", s.KeyRingId.terraformId(), s.Name)
+}
+
+func parseKmsCryptoKeyId(id string, config *Config) (*kmsCryptoKeyId, error) {
+	parts := strings.Split(id, "/")
+
+	cryptoKeyIdRegex := regexp.MustCompile("^([a-z0-9-]+)/([a-z0-9-])+/([a-zA-Z0-9_-]{1,63})+/([a-zA-Z0-9_-]{1,63})$")
+	cryptoKeyIdWithoutProjectRegex := regexp.MustCompile("^([a-z0-9-])+/([a-zA-Z0-9_-]{1,63})+/([a-zA-Z0-9_-]{1,63})$")
+
+	if cryptoKeyIdRegex.MatchString(id) {
+		return &kmsCryptoKeyId{
+			KeyRingId: kmsKeyRingId{
+				Project:  parts[0],
+				Location: parts[1],
+				Name:     parts[2],
+			},
+			Name: parts[3],
+		}, nil
+	}
+
+	if cryptoKeyIdWithoutProjectRegex.MatchString(id) {
+		if config.Project == "" {
+			return nil, fmt.Errorf("The default project for the provider must be set when using the `{location}/{keyRingName}/{cryptoKeyName}` id format.")
+		}
+
+		return &kmsCryptoKeyId{
+			KeyRingId: kmsKeyRingId{
+				Project:  config.Project,
+				Location: parts[0],
+				Name:     parts[1],
+			},
+			Name: parts[2],
+		}, nil
+	}
+
+	return nil, fmt.Errorf("Invalid CryptoKey id format, expecting `{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}` or `{locationId}/{keyRingName}/{cryptoKeyName}.`")
+}
+
+func dataSourceGoogleKmsSecretRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	cryptoKeyId, err := parseKmsCryptoKeyId(d.Get("crypto_key").(string), config)
+
+	if err != nil {
+		return err
+	}
+
+	ciphertext := d.Get("ciphertext").(string)
+
+	kmsDecryptRequest := &cloudkms.DecryptRequest{
+		Ciphertext: ciphertext,
+	}
+
+	decryptResponse, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Decrypt(cryptoKeyId.cryptoKeyId(), kmsDecryptRequest).Do()
+
+	if err != nil {
+		return fmt.Errorf("Error decrypting ciphertext: %s", err)
+	}
+
+	plaintext, err := base64.StdEncoding.DecodeString(decryptResponse.Plaintext)
+
+	if err != nil {
+		return fmt.Errorf("Error decoding base64 response: %s", err)
+	}
+
+	log.Printf("[INFO] Successfully decrypted ciphertext: %s", ciphertext)
+
+	d.Set("plaintext", fmt.Sprintf("%s", plaintext))
+	d.SetId(time.Now().UTC().String())
+
+	return nil
+}

--- a/google/data_source_google_kms_secret.go
+++ b/google/data_source_google_kms_secret.go
@@ -60,7 +60,7 @@ func dataSourceGoogleKmsSecretRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Successfully decrypted ciphertext: %s", ciphertext)
 
-	d.Set("plaintext", fmt.Sprintf("%s", plaintext))
+	d.Set("plaintext", string(plaintext[:]))
 	d.SetId(time.Now().UTC().String())
 
 	return nil

--- a/google/data_source_google_kms_secret.go
+++ b/google/data_source_google_kms_secret.go
@@ -3,12 +3,10 @@ package google
 import (
 	"google.golang.org/api/cloudkms/v1"
 
+	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
-	"regexp"
-	"strings"
-	"encoding/base64"
 	"time"
 )
 
@@ -31,60 +29,6 @@ func dataSourceGoogleKmsSecret() *schema.Resource {
 			},
 		},
 	}
-}
-
-type kmsCryptoKeyId struct {
-	KeyRingId kmsKeyRingId
-	Name      string
-}
-
-// TODO: Add the info about rotation frequency and start time.
-
-func (s *kmsCryptoKeyId) cryptoKeyId() string {
-	return fmt.Sprintf("%s/cryptoKeys/%s", s.KeyRingId.keyRingId(), s.Name)
-}
-
-func (s *kmsCryptoKeyId) parentId() string {
-	return s.KeyRingId.keyRingId()
-}
-
-func (s *kmsCryptoKeyId) terraformId() string {
-	return fmt.Sprintf("%s/%s", s.KeyRingId.terraformId(), s.Name)
-}
-
-func parseKmsCryptoKeyId(id string, config *Config) (*kmsCryptoKeyId, error) {
-	parts := strings.Split(id, "/")
-
-	cryptoKeyIdRegex := regexp.MustCompile("^([a-z0-9-]+)/([a-z0-9-])+/([a-zA-Z0-9_-]{1,63})+/([a-zA-Z0-9_-]{1,63})$")
-	cryptoKeyIdWithoutProjectRegex := regexp.MustCompile("^([a-z0-9-])+/([a-zA-Z0-9_-]{1,63})+/([a-zA-Z0-9_-]{1,63})$")
-
-	if cryptoKeyIdRegex.MatchString(id) {
-		return &kmsCryptoKeyId{
-			KeyRingId: kmsKeyRingId{
-				Project:  parts[0],
-				Location: parts[1],
-				Name:     parts[2],
-			},
-			Name: parts[3],
-		}, nil
-	}
-
-	if cryptoKeyIdWithoutProjectRegex.MatchString(id) {
-		if config.Project == "" {
-			return nil, fmt.Errorf("The default project for the provider must be set when using the `{location}/{keyRingName}/{cryptoKeyName}` id format.")
-		}
-
-		return &kmsCryptoKeyId{
-			KeyRingId: kmsKeyRingId{
-				Project:  config.Project,
-				Location: parts[0],
-				Name:     parts[1],
-			},
-			Name: parts[2],
-		}, nil
-	}
-
-	return nil, fmt.Errorf("Invalid CryptoKey id format, expecting `{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}` or `{locationId}/{keyRingName}/{cryptoKeyName}.`")
 }
 
 func dataSourceGoogleKmsSecretRead(d *schema.ResourceData, meta interface{}) error {

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -10,21 +10,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudkms/v1"
 	"log"
-	"os"
 )
 
 func TestAccGoogleKmsSecret_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	projectOrg := os.Getenv("GOOGLE_ORG")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 
 	projectId := "terraform-" + acctest.RandString(10)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -65,12 +65,12 @@ func TestAccGoogleKmsSecret_basic(t *testing.T) {
 	})
 }
 
-func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, resourceName, plaintext string) (string, *kmsCryptoKeyId, error) {
+func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, cryptoKeyResourceName, plaintext string) (string, *kmsCryptoKeyId, error) {
 	config := testAccProvider.Meta().(*Config)
 
-	rs, ok := s.RootModule().Resources[resourceName]
+	rs, ok := s.RootModule().Resources[cryptoKeyResourceName]
 	if !ok {
-		return "", nil, fmt.Errorf("Resource not found: %s", resourceName)
+		return "", nil, fmt.Errorf("Resource not found: %s", cryptoKeyResourceName)
 	}
 
 	cryptoKeyId, err := parseKmsCryptoKeyId(rs.Primary.Attributes["id"], config)

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -1,0 +1,104 @@
+package google
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/cloudkms/v1"
+	"log"
+	"os"
+)
+
+func TestAccGoogleKmsSecret_basic(t *testing.T) {
+	t.Parallel()
+
+	skipIfEnvNotSet(t,
+		[]string{
+			"GOOGLE_ORG",
+			"GOOGLE_BILLING_ACCOUNT",
+		}...,
+	)
+
+	projectOrg := os.Getenv("GOOGLE_ORG")
+	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+
+	projectId := "terraform-" + acctest.RandString(10)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	plaintext := fmt.Sprintf("secret-%s", acctest.RandString(10))
+
+	// The first test creates resources needed to encrypt plaintext and produce ciphertext
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: func(s *terraform.State) error {
+					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext)
+
+					if err != nil {
+						return err
+					}
+
+					// The second test asserts that the data source has the correct plaintext, given the created ciphertext
+					resource.Test(t, resource.TestCase{
+						PreCheck:  func() { testAccPreCheck(t) },
+						Providers: testAccProviders,
+						Steps: []resource.TestStep{
+							resource.TestStep{
+								Config: testGoogleKmsSecret_datasource(cryptoKeyId.terraformId(), ciphertext),
+								Check:  resource.TestCheckResourceAttr("data.google_kms_secret.acceptance", "plaintext", plaintext),
+							},
+						},
+					})
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, resourceName, plaintext string) (string, *kmsCryptoKeyId, error) {
+	config := testAccProvider.Meta().(*Config)
+
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return "", nil, fmt.Errorf("Resource not found: %s", resourceName)
+	}
+
+	cryptoKeyId, err := parseKmsCryptoKeyId(rs.Primary.Attributes["id"], config)
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	kmsEncryptRequest := &cloudkms.EncryptRequest{
+		Plaintext: base64.StdEncoding.EncodeToString([]byte(plaintext)),
+	}
+
+	encryptResponse, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Encrypt(cryptoKeyId.cryptoKeyId(), kmsEncryptRequest).Do()
+
+	if err != nil {
+		return "", nil, fmt.Errorf("Error encrypting plaintext: %s", err)
+	}
+
+	log.Printf("[INFO] Successfully encrypted plaintext and got ciphertext: %s", encryptResponse.Ciphertext)
+
+	return encryptResponse.Ciphertext, cryptoKeyId, nil
+}
+
+func testGoogleKmsSecret_datasource(cryptoKeyTerraformId, ciphertext string) string {
+	return fmt.Sprintf(`
+data "google_kms_secret" "acceptance" {
+    crypto_key = "%s"
+    ciphertext = "%s"
+}
+	`, cryptoKeyTerraformId, ciphertext)
+}

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -97,8 +97,8 @@ func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, resourceName, pla
 func testGoogleKmsSecret_datasource(cryptoKeyTerraformId, ciphertext string) string {
 	return fmt.Sprintf(`
 data "google_kms_secret" "acceptance" {
-    crypto_key = "%s"
-    ciphertext = "%s"
+	crypto_key = "%s"
+	ciphertext = "%s"
 }
 	`, cryptoKeyTerraformId, ciphertext)
 }

--- a/google/provider.go
+++ b/google/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"google_container_engine_versions":     dataSourceGoogleContainerEngineVersions(),
 			"google_active_folder":                 dataSourceGoogleActiveFolder(),
 			"google_iam_policy":                    dataSourceGoogleIamPolicy(),
+			"google_kms_secret":                    dataSourceGoogleKmsSecret(),
 			"google_storage_object_signed_url":     dataSourceGoogleSignedUrl(),
 		},
 

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -1,0 +1,93 @@
+---
+layout: "google"
+page_title: "Google: google_kms_secret"
+sidebar_current: "docs-google_kms_secret"
+description: |-
+  Provides access to secret data encrypted with Google Cloud KMS
+---
+
+# google\_kms\_secret
+
+This data source allows you to use data encrypted with Google Cloud KMS
+within your resource definitions.
+
+For more information see
+[the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
+
+~> **NOTE**: Using this data provider will allow you to conceal secret data within your
+resource definitions, but it does not take care of protecting that data in the
+logging output, plan output or state output.  Please take care to secure your secret
+data outside of resource definitions.
+
+## Example Usage
+
+First, create a KMS KeyRing and CryptoKey using the resource definitions:
+
+```hcl
+resource "google_kms_key_ring" "my_key_ring" {
+  project  = "my-project"
+  name     = "my-key-ring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "my_crypto_key" {
+  name     = "my-crypto-key"
+  key_ring = "${google_kms_key_ring.my_key_ring.id}"
+}
+```
+
+Next, use the [Cloud SDK](https://cloud.google.com/sdk/) to encrypt some
+sensitive information:
+
+```bash
+$ echo -n my-secret-password | gcloud kms encrypt \
+> --project my-project \
+> --location us-central1 \
+> --keyring my-key-ring \
+> --key my-crypto-key \
+> --plaintext-file - \
+> --ciphertext-file - \
+> | base64
+CiQAqD+xX4SXOSziF4a8JYvq4spfAuWhhYSNul33H85HnVtNQW4SOgDu2UZ46dQCRFl5MF6ekabviN8xq+F+2035ZJ85B+xTYXqNf4mZs0RJitnWWuXlYQh6axnnJYu3kDU=
+```
+
+Finally, reference the encrypted ciphertext in your resource definitions:
+
+```hcl
+data "google_kms_secret" "sql_user_password" {
+  crypto_key = "${google_kms_crypto_key.my_crypto_key.id}"
+  ciphertext = "CiQAqD+xX4SXOSziF4a8JYvq4spfAuWhhYSNul33H85HnVtNQW4SOgDu2UZ46dQCRFl5MF6ekabviN8xq+F+2035ZJ85B+xTYXqNf4mZs0RJitnWWuXlYQh6axnnJYu3kDU="
+}
+
+resource "google_sql_database_instance" "master" {
+  name = "master-instance"
+
+  settings {
+    tier = "D0"
+  }
+}
+
+resource "google_sql_user" "users" {
+  name     = "me"
+  instance = "${google_sql_database_instance.master.name}"
+  host     = "me.com"
+  password = "${data.google_kms_secret.sql_user_password.plaintext}"
+}
+```
+
+This will result in a Cloud SQL user being created with password `my-secret-password`.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ciphertext` (Required) - The ciphertext to be decrypted, encoded in base64
+* `crypto_key` (Required) - The id of the CryptoKey that will be used to
+  decrypt the provided ciphertext. This is represented by the format
+  `{projectId}/{location}/{keyRingName}/{cryptoKeyName}`.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `plaintext` - Contains the result of decrypting the provided ciphertext.

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_kms_secret"
-sidebar_current: "docs-google_kms_secret"
+sidebar_current: "docs-google-kms-secret"
 description: |-
   Provides access to secret data encrypted with Google Cloud KMS
 ---

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -16,7 +16,7 @@ For more information see
 
 ~> **NOTE**: Using this data provider will allow you to conceal secret data within your
 resource definitions, but it does not take care of protecting that data in the
-logging output, plan output or state output.  Please take care to secure your secret
+logging output, plan output, or state output.  Please take care to secure your secret
 data outside of resource definitions.
 
 ## Example Usage

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -36,7 +36,7 @@ resource "google_kms_crypto_key" "my_crypto_key" {
 }
 ```
 
-Next, use the [Cloud SDK](https://cloud.google.com/sdk/) to encrypt some
+Next, use the [Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/kms/encrypt) to encrypt some
 sensitive information:
 
 ```bash

--- a/website/google.erb
+++ b/website/google.erb
@@ -55,6 +55,9 @@
       <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
+      <li<%= sidebar_current("docs-google-kms-secret") %>>
+      <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-signed_url") %>>
         <a href="/docs/providers/google/d/signed_url.html">google_storage_object_signed_url</a>
       </li>


### PR DESCRIPTION
Discussion in #495 

cc @rochdev and @tragiclifestories who asked for this.

Example:

```hcl
resource "google_kms_key_ring" "key_ring" {
  name     = "kms-secret-keyring"
  location = "us-central1"
}

resource "google_kms_crypto_key" "crypto_key" {
  name     = "kms-secret-key"
  key_ring = "${google_kms_key_ring.key_ring.id}"
}

# After running `gcloud kms encrypt`
data "google_kms_secret" "secret" {
  crypto_key = "${google_kms_crypto_key.crypto_key.id}"
  ciphertext = "CiQAWm5esXYu3WnKrDRi5zY63pw4cZl13InzSGcx4Z7t/6NHneYSOAD3jiTonMNNnUb+iRsD79ir2L91Kfe2VTgD988ixe/VawV/nLHXKD1UOPyXoeJzQWCb96DEluMs"
}

resource "google_sql_database_instance" "master" {
  name = "master-instance"

  settings {
    tier = "D0"
  }
}

resource "google_sql_user" "users" {
  name     = "me"
  instance = "${google_sql_database_instance.master.name}"
  host     = "me.com"
  password = "${data.google_kms_secret.secret.plaintext}"
}
```

Acceptance test:
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccGoogleKmsSecret_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccGoogleKmsSecret_basic
--- PASS: TestAccGoogleKmsSecret_basic (55.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	55.995s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-google/scripts	0.026s [no tests to run]
```

