### PR TITLE
Add the "google_compute_address" datasource

### DIFF
--- a/google/data_source_google_compute_address.go
+++ b/google/data_source_google_compute_address.go
@@ -1,0 +1,83 @@
+package google
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/googleapi"
+)
+
+func dataSourceGoogleComputeAddress() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeAddressRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeAddressRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	address, err := config.clientCompute.Addresses.Get(
+		project, region, d.Get("name").(string)).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			// The resource doesn't exist anymore
+
+			return fmt.Errorf("Address Not Found")
+		}
+
+		return fmt.Errorf("Error reading Address: %s", err)
+	}
+
+	d.Set("address", address.Address)
+	d.Set("status", address.Status)
+	d.Set("self_link", address.SelfLink)
+	d.Set("project", project)
+	d.Set("region", region)
+
+	d.SetId(strconv.FormatUint(uint64(address.Id), 10))
+	return nil
+}

--- a/google/data_source_google_compute_address_test.go
+++ b/google/data_source_google_compute_address_test.go
@@ -1,0 +1,105 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceComputeAddress(t *testing.T) {
+	t.Parallel()
+
+	rsName := "foobar"
+	rsFullName := fmt.Sprintf("google_compute_address.%s", rsName)
+	dsName := "my_address"
+	dsFullName := fmt.Sprintf("data.google_compute_address.%s", dsName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataSourceComputeAddressDestroy(rsFullName),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceComputeAddressConfig(rsName, dsName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceComputeAddressCheck(dsFullName, rsFullName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeAddressCheck(data_source_name string, resource_name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[data_source_name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", data_source_name)
+		}
+
+		rs, ok := s.RootModule().Resources[resource_name]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resource_name)
+		}
+
+		ds_attr := ds.Primary.Attributes
+		rs_attr := rs.Primary.Attributes
+
+		address_attrs_to_test := []string{
+			"self_link",
+			"name",
+			"address",
+		}
+
+		for _, attr_to_check := range address_attrs_to_test {
+			if ds_attr[attr_to_check] != rs_attr[attr_to_check] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attr_to_check,
+					ds_attr[attr_to_check],
+					rs_attr[attr_to_check],
+				)
+			}
+		}
+
+		if ds_attr["status"] != "RESERVED" {
+			return fmt.Errorf("status is %s; want RESERVED", ds_attr["status"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataSourceComputeAddressDestroy(resource_name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		rs, ok := s.RootModule().Resources[resource_name]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resource_name)
+		}
+
+		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+
+		_, err = config.clientCompute.Addresses.Get(
+			config.Project, addressId.Region, addressId.Name).Do()
+		if err == nil {
+			return fmt.Errorf("Address still exists")
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceComputeAddressConfig(rsName, dsName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_address" "%s" {
+	name = "address-test"
+}
+
+data "google_compute_address" "%s" {
+	name = "${google_compute_address.%s.name}"
+}
+`, rsName, dsName, rsName)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -51,6 +51,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"google_dns_managed_zone":          dataSourceDnsManagedZone(),
 			"google_client_config":             dataSourceGoogleClientConfig(),
+			"google_compute_address":           dataSourceGoogleComputeAddress(),
 			"google_compute_lb_ip_ranges":      dataSourceGoogleComputeLbIpRanges(),
 			"google_compute_network":           dataSourceGoogleComputeNetwork(),
 			"google_compute_subnetwork":        dataSourceGoogleComputeSubnetwork(),

--- a/website/docs/d/datasource_compute_address.html.markdown
+++ b/website/docs/d/datasource_compute_address.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "google"
+page_title: "Google: google_compute_address"
+sidebar_current: "docs-google-datasource-compute-address"
+description: |-
+  Get the IP address from a static address.
+---
+
+# google\_compute\_address
+
+Get the IP address from a static address. For more information see
+the official [API](https://cloud.google.com/compute/docs/reference/latest/addresses/get) documentation.
+
+## Example Usage
+
+```hcl
+data "google_compute_address" "my_address" {
+  name = "foobar"
+}
+
+resource "google_dns_record_set" "frontend" {
+  name = "frontend.${google_dns_managed_zone.prod.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+
+  rrdatas = ["${data.google_compute_address.my_address.address}"]
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by GCE.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The Region in which the created address reside.
+    If it is not provided, the provider region is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `self_link` - The URI of the created resource.
+* `address` - The IP of the created resource.
+* `status` - Indicates if the address is used. Possible values are: RESERVED or IN_USE.

--- a/website/google.erb
+++ b/website/google.erb
@@ -16,6 +16,9 @@
       <li<%= sidebar_current("docs-google-datasource-client-config") %>>
         <a href="/docs/providers/google/d/datasource_client_config.html">google_client_config</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-address") %>>
+        <a href="/docs/providers/google/d/datasource_compute_address.html">google_compute_address</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>


### PR DESCRIPTION
As said in #712, it could be useful to have that kind of datasource to better handle IP creation/updates, e.g. for use in other providers such as cloudfare.