### PR TITLE
Allow node pools with size 0

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -104,7 +104,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Computed:     true,
-		ValidateFunc: validation.IntAtLeast(1),
+		ValidateFunc: validation.IntAtLeast(0),
 	},
 }
 
@@ -280,9 +280,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 			return nil, fmt.Errorf("Cannot set both initial_node_count and node_count on node pool %s", name)
 		}
 		nodeCount = nc.(int)
-	}
-	if nodeCount == 0 {
-		return nil, fmt.Errorf("Node pool %s cannot be set with 0 node count", name)
 	}
 
 	np := &container.NodePool{


### PR DESCRIPTION
So far the provider forbids empty node pools, however from a google API point of view it appears to be possible to have node pools with size 0 (works for me as of today). This makes it possible to ramp down a node pool without destroying it. I am very happy for feedback if somebody can foresee if this might cause any problems.