### PR TITLE
Fix `TestAccComputeRoute_hopInstance` now that we store the self link

### DIFF
--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -57,6 +58,7 @@ func TestAccComputeRoute_hopInstance(t *testing.T) {
 
 	instanceName := "tf" + acctest.RandString(10)
 	zone := "us-central1-b"
+	instanceNameRegexp := regexp.MustCompile(fmt.Sprintf("projects/(.+)/zones/%s/instances/%s$", zone, instanceName))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,8 +70,8 @@ func TestAccComputeRoute_hopInstance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRouteExists(
 						"google_compute_route.foobar", &route),
-					resource.TestCheckResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceName),
-					resource.TestCheckResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceName),
+					resource.TestMatchResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceNameRegexp),
+					resource.TestMatchResourceAttr("google_compute_route.foobar", "next_hop_instance", instanceNameRegexp),
 				),
 			},
 		},


### PR DESCRIPTION
```
$ make testacc TEST=./google TESTARGS='-run=TestAccComputeRoute_hopInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeRoute_hopInstance -timeout 120m
=== RUN   TestAccComputeRoute_hopInstance
--- PASS: TestAccComputeRoute_hopInstance (71.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	71.755s
```

If you want I can add the actual project value here, to me it didn't seem like it would really make a difference.