### PR TITLE
Fix target pool import test

### DIFF
--- a/google/import_compute_target_pool_test.go
+++ b/google/import_compute_target_pool_test.go
@@ -9,7 +9,7 @@ import (
 func TestAccComputeTargetPool_importBasic(t *testing.T) {
 	t.Parallel()
 
-	resourceName := "google_compute_target_pool.foobar"
+	resourceName := "google_compute_target_pool.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
the resource name for the non-import test changed, so it needs to be changed here too.