### PR TITLE
Remove check for 0 nodes in a pool

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -281,9 +281,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 		}
 		nodeCount = nc.(int)
 	}
-	if nodeCount == 0 {
-		return nil, fmt.Errorf("Node pool %s cannot be set with 0 node count", name)
-	}
 
 	np := &container.NodePool{
 		Name:             name,


### PR DESCRIPTION
I'm not sure whether the API changed or what happened, but it turns out that you can create a node pool with 0 nodes in it. I'm not sure why anybody would _want_ to, but it does mean we can remove the check (#742 proposed removing it in the case just when autoscaling is enabled)

I checked this both for the case where we create a node pool at cluster creation time (using the cluster api) and on its own afterwards (using the node pool api).

Fixes #742.