### PR TITLE
the GOOGLE_XPN_HOST_PROJECT variable is no longer mandatory

### DIFF
--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -70,10 +70,6 @@ func testAccPreCheck(t *testing.T) {
 	if v := multiEnvSearch(regionEnvVars); v != "us-central1" {
 		t.Fatalf("One of %s must be set to us-central1 for acceptance tests", strings.Join(regionEnvVars, ", "))
 	}
-
-	if v := os.Getenv("GOOGLE_XPN_HOST_PROJECT"); v == "" {
-		t.Fatal("GOOGLE_XPN_HOST_PROJECT must be set for acceptance tests")
-	}
 }
 
 func TestProvider_getRegionFromZone(t *testing.T) {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -90,6 +90,8 @@ func TestAccComputeDisk_update(t *testing.T) {
 func TestAccComputeDisk_fromSnapshot(t *testing.T) {
 	t.Parallel()
 
+	skipIfEnvNotSet(t, "GOOGLE_XPN_HOST_PROJECT")
+
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	firstDiskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -178,6 +178,8 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 	t.Parallel()
 
+	skipIfEnvNotSet(t, "GOOGLE_XPN_HOST_PROJECT")
+
 	var instanceTemplate compute.InstanceTemplate
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
 

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -587,6 +587,8 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 	t.Parallel()
 
+	skipIfEnvNotSet(t, "GOOGLE_XPN_HOST_PROJECT")
+
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")


### PR DESCRIPTION
Since this variable is only used for 3 tests, it doesn't make sense to declare it as mandatory in the test config. Therefore, concerned tests are now skipped if the variable is absent (the same behavior is used for `GOOGLE_ORG`).

This PR partially closes #715 as we still need to create a project and declare its ID in this variable (_at least, we won't need to include this var for each tests!_).