### PR TITLE
Get test org and billing account in a consistent way

### DIFF
--- a/google/data_source_google_active_folder_test.go
+++ b/google/data_source_google_active_folder_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourceGoogleActiveFolder(t *testing.T) {
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 
 	parent := fmt.Sprintf("organizations/%s", org)
 	displayName := "terraform-test-" + acctest.RandString(10)

--- a/google/import_google_folder_test.go
+++ b/google/import_google_folder_test.go
@@ -3,17 +3,14 @@ package google
 import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 	"testing"
 )
 
 func TestAccGoogleFolder_import(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_google_organization_iam_custom_role_test.go
+++ b/google/import_google_organization_iam_custom_role_test.go
@@ -9,7 +9,7 @@ import (
 func TestAccGoogleOrganizationIamCustomRole_import(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	roleId := "tfIamRole" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{

--- a/google/import_google_organization_policy_test.go
+++ b/google/import_google_organization_policy_test.go
@@ -2,16 +2,13 @@ package google
 
 import (
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 	"testing"
 )
 
 func TestAccGoogleOrganizationPolicy_import(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/import_google_project_services_test.go
+++ b/google/import_google_project_services_test.go
@@ -10,6 +10,7 @@ import (
 func TestAccGoogleProjectServices_importBasic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	resourceName := "google_project_services.acceptance"
 	projectId := "terraform-" + acctest.RandString(10)
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com", "servicemanagement.googleapis.com"}

--- a/google/import_google_project_test.go
+++ b/google/import_google_project_test.go
@@ -11,6 +11,7 @@ import (
 func TestAccGoogleProject_importBasic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	resourceName := "google_project.acceptance"
 	projectId := "terraform-" + acctest.RandString(10)
 	conf := testAccGoogleProject_import(projectId, org, pname)

--- a/google/import_kms_crypto_key_test.go
+++ b/google/import_kms_crypto_key_test.go
@@ -6,24 +6,16 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 )
 
 func TestAccGoogleKmsCryptoKey_importBasic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
 	resourceName := "google_kms_crypto_key.crypto_key"
 
 	projectId := "terraform-" + acctest.RandString(10)
-	projectOrg := os.Getenv("GOOGLE_ORG")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/google/import_kms_key_ring_test.go
+++ b/google/import_kms_key_ring_test.go
@@ -6,22 +6,14 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 )
 
 func TestAccGoogleKmsKeyRing_importBasic(t *testing.T) {
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
 	resourceName := "google_kms_key_ring.key_ring"
 
 	projectId := "terraform-" + acctest.RandString(10)
-	projectOrg := os.Getenv("GOOGLE_ORG")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -33,6 +33,14 @@ var regionEnvVars = []string{
 	"CLOUDSDK_COMPUTE_REGION",
 }
 
+var orgEnvVars = []string{
+	"GOOGLE_ORG",
+}
+
+var billingAccountEnvVars = []string{
+	"GOOGLE_BILLING_ACCOUNT",
+}
+
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
@@ -109,6 +117,16 @@ func getTestProject(is *terraform.InstanceState, config *Config) (string, error)
 // getTestProjectFromEnv returns the current configured project from environment variables.
 func getTestProjectFromEnv() string {
 	return multiEnvSearch(projectEnvVars)
+}
+
+func getTestOrgFromEnv(t *testing.T) string {
+	skipIfEnvNotSet(t, orgEnvVars...)
+	return multiEnvSearch(orgEnvVars)
+}
+
+func getTestBillingAccountFromEnv(t *testing.T) string {
+	skipIfEnvNotSet(t, billingAccountEnvVars...)
+	return multiEnvSearch(billingAccountEnvVars)
 }
 
 func multiEnvSearch(ks []string) string {

--- a/google/resource_compute_project_metadata_test.go
+++ b/google/resource_compute_project_metadata_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -15,14 +14,8 @@ import (
 func TestAccComputeProjectMetadata_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	var project compute.Project
 	projectID := "terrafom-test-" + acctest.RandString(10)
 
@@ -49,14 +42,8 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	var project compute.Project
 	projectID := "terrafom-test-" + acctest.RandString(10)
 
@@ -96,14 +83,8 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	var project compute.Project
 	projectID := "terraform-test-" + acctest.RandString(10)
 

--- a/google/resource_compute_shared_vpc_test.go
+++ b/google/resource_compute_shared_vpc_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"os"
 )
 
 func TestAccComputeSharedVpc_basic(t *testing.T) {
-	skipIfEnvNotSet(t, "GOOGLE_ORG", "GOOGLE_BILLING_ACCOUNT")
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 
 	hostProject := "xpn-host-" + acctest.RandString(10)
 	serviceProject := "xpn-service-" + acctest.RandString(10)

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -15,10 +14,8 @@ import (
 func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
 
 	policy := &resourceManagerV2Beta1.Policy{
@@ -48,10 +45,8 @@ func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
 func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
 
 	policy1 := &resourceManagerV2Beta1.Policy{

--- a/google/resource_google_folder_test.go
+++ b/google/resource_google_folder_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"os"
 	"testing"
 
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
@@ -14,11 +13,9 @@ import (
 func TestAccGoogleFolder_rename(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
 	newFolderDisplayName := "tf-test-renamed-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
 	folder := resourceManagerV2Beta1.Folder{}
 
@@ -49,11 +46,9 @@ func TestAccGoogleFolder_rename(t *testing.T) {
 func TestAccGoogleFolder_moveParent(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
 	folder1DisplayName := "tf-test-" + acctest.RandString(10)
 	folder2DisplayName := "tf-test-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	parent := "organizations/" + org
 	folder1 := resourceManagerV2Beta1.Folder{}
 	folder2 := resourceManagerV2Beta1.Folder{}

--- a/google/resource_google_organization_iam_custom_role_test.go
+++ b/google/resource_google_organization_iam_custom_role_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccGoogleOrganizationIamCustomRole_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	roleId := "tfIamCustomRole" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -46,6 +46,7 @@ func TestAccGoogleOrganizationIamCustomRole_basic(t *testing.T) {
 func TestAccGoogleOrganizationIamCustomRole_undelete(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	roleId := "tfIamCustomRole" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_google_organization_policy_test.go
+++ b/google/resource_google_organization_policy_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -18,9 +17,7 @@ var DENIED_ORG_POLICIES = []string{
 func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -58,9 +55,7 @@ func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
 func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -77,10 +72,8 @@ func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
 func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
+	org := getTestOrgFromEnv(t)
 	project := getTestProjectFromEnv()
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -97,9 +90,7 @@ func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
 func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -116,9 +107,7 @@ func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
 func TestAccGoogleOrganizationPolicy_list_update(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-	org := os.Getenv("GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -45,6 +46,7 @@ func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -89,6 +91,7 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -123,6 +126,7 @@ func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -173,6 +177,7 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -43,6 +44,7 @@ func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -83,6 +85,7 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_iam_policy_test.go
+++ b/google/resource_google_project_iam_policy_test.go
@@ -224,6 +224,7 @@ func TestSubtractIamPolicy(t *testing.T) {
 func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -287,6 +288,7 @@ func TestAccGoogleProjectIamPolicy_defaultProject(t *testing.T) {
 func TestAccGoogleProjectIamPolicy_expanded(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_google_project_service_test.go
+++ b/google/resource_google_project_service_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccGoogleProjectService_basic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	resource.Test(t, resource.TestCase{

--- a/google/resource_google_project_services_test.go
+++ b/google/resource_google_project_services_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -19,6 +18,7 @@ import (
 func TestAccGoogleProjectServices_basic(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services1 := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services2 := []string{"cloudresourcemanager.googleapis.com"}
@@ -61,6 +61,7 @@ func TestAccGoogleProjectServices_basic(t *testing.T) {
 func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{"cloudresourcemanager.googleapis.com"}
 	oobService := "iam.googleapis.com"
@@ -97,6 +98,7 @@ func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	oobServices := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services := []string{"iam.googleapis.com"}
@@ -136,14 +138,8 @@ func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{
 		"dataproc.googleapis.com",
@@ -177,14 +173,8 @@ func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
 func TestAccGoogleProjectServices_manyServices(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{
 		"bigquery-json.googleapis.com",

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -16,10 +16,6 @@ import (
 )
 
 var (
-	org = multiEnvSearch([]string{
-		"GOOGLE_ORG",
-	})
-
 	pname          = "Terraform Acceptance Tests"
 	originalPolicy *cloudresourcemanager.Policy
 )
@@ -54,12 +50,7 @@ func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
 func TestAccGoogleProject_create(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-		}...,
-	)
-
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -81,14 +72,8 @@ func TestAccGoogleProject_create(t *testing.T) {
 func TestAccGoogleProject_createBilling(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -109,6 +94,7 @@ func TestAccGoogleProject_createBilling(t *testing.T) {
 func TestAccGoogleProject_createLabels(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -129,15 +115,10 @@ func TestAccGoogleProject_createLabels(t *testing.T) {
 func TestAccGoogleProject_updateBilling(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-			"GOOGLE_BILLING_ACCOUNT_2",
-		}...,
-	)
+	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT_2")
 
-	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	org := getTestOrgFromEnv(t)
+	billingId := getTestBillingAccountFromEnv(t)
 	billingId2 := os.Getenv("GOOGLE_BILLING_ACCOUNT_2")
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -181,6 +162,7 @@ func TestAccGoogleProject_updateBilling(t *testing.T) {
 func TestAccGoogleProject_merge(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -210,6 +192,7 @@ func TestAccGoogleProject_merge(t *testing.T) {
 func TestAccGoogleProject_updateLabels(t *testing.T) {
 	t.Parallel()
 
+	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -108,17 +108,10 @@ func TestCryptoKeyNextRotationCalculation_validation(t *testing.T) {
 func TestAccGoogleKmsCryptoKey_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
 	projectId := "terraform-" + acctest.RandString(10)
-	projectOrg := os.Getenv("GOOGLE_ORG")
+	projectOrg := getTestOrgFromEnv(t)
 	location := os.Getenv("GOOGLE_REGION")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -147,17 +140,10 @@ func TestAccGoogleKmsCryptoKey_basic(t *testing.T) {
 func TestAccGoogleKmsCryptoKey_rotation(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
 	projectId := "terraform-" + acctest.RandString(10)
-	projectOrg := os.Getenv("GOOGLE_ORG")
+	projectOrg := getTestOrgFromEnv(t)
 	location := os.Getenv("GOOGLE_REGION")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	rotationPeriod := "100000s"

--- a/google/resource_kms_key_ring_test.go
+++ b/google/resource_kms_key_ring_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"log"
-	"os"
 )
 
 func TestKeyRingIdParsing(t *testing.T) {
@@ -68,16 +67,9 @@ func TestKeyRingIdParsing(t *testing.T) {
 }
 
 func TestAccGoogleKmsKeyRing_basic(t *testing.T) {
-	skipIfEnvNotSet(t,
-		[]string{
-			"GOOGLE_ORG",
-			"GOOGLE_BILLING_ACCOUNT",
-		}...,
-	)
-
 	projectId := "terraform-" + acctest.RandString(10)
-	projectOrg := os.Getenv("GOOGLE_ORG")
-	projectBillingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -14,11 +13,9 @@ import (
 func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT")
-
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
-	billingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	billingAccount := getTestBillingAccountFromEnv(t)
 
 	var sink logging.LogSink
 
@@ -41,12 +38,10 @@ func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
 func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT")
-
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	updatedBucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
-	billingAccount := os.Getenv("GOOGLE_BILLING_ACCOUNT")
+	billingAccount := getTestBillingAccountFromEnv(t)
 
 	var sinkBefore, sinkAfter logging.LogSink
 

--- a/google/resource_logging_folder_sink_test.go
+++ b/google/resource_logging_folder_sink_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -15,12 +14,10 @@ import (
 func TestAccLoggingFolderSink_basic(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	folderName := "tf-test-folder-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
 
 	var sink logging.LogSink
 
@@ -43,12 +40,10 @@ func TestAccLoggingFolderSink_basic(t *testing.T) {
 func TestAccLoggingFolderSink_folderAcceptsFullFolderPath(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	folderName := "tf-test-folder-" + acctest.RandString(10)
-	org := os.Getenv("GOOGLE_ORG")
 
 	var sink logging.LogSink
 
@@ -71,13 +66,12 @@ func TestAccLoggingFolderSink_folderAcceptsFullFolderPath(t *testing.T) {
 func TestAccLoggingFolderSink_update(t *testing.T) {
 	t.Parallel()
 
-	skipIfEnvNotSet(t, "GOOGLE_ORG")
-
+	org := getTestOrgFromEnv(t)
 	sinkName := "tf-test-sink-" + acctest.RandString(10)
 	bucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	updatedBucketName := "tf-test-sink-bucket-" + acctest.RandString(10)
 	folderName := "tf-test-folder-" + acctest.RandString(10)
-	parent := "organizations/" + os.Getenv("GOOGLE_ORG")
+	parent := "organizations/" + org
 
 	var sinkBefore, sinkAfter logging.LogSink
 


### PR DESCRIPTION
Fixes the following issues:
- Consistent behavior: Some tests were skipped if GOOGLE_ORG wasn't set, some would just fail (hard to debug sometimes, the error message would be obscure but then you realize that the org variable was empty.).
- Avoid duplication: The GOOGLE_ORG string was all over the place, if we ever wanted to support two different env variables like for credentials or project, it would be a mess
- Avoid mistake: Typo in GOOGLE_ORG is easy.
- Stop using (and removed) the global `org` variable.

Same applies for billing.