### PR TITLE
Standardize on test env var for region, creds and project

### DIFF
--- a/google/data_source_google_compute_zones.go
+++ b/google/data_source_google_compute_zones.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 )
 
 func dataSourceGoogleComputeZones() *schema.Resource {

--- a/google/gcp_sweeper_test.go
+++ b/google/gcp_sweeper_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -15,14 +14,14 @@ func TestMain(m *testing.M) {
 // sharedConfigForRegion returns a common config setup needed for the sweeper
 // functions for a given region
 func sharedConfigForRegion(region string) (*Config, error) {
-	project := os.Getenv("GOOGLE_PROJECT")
+	project := getTestProjectFromEnv()
 	if project == "" {
-		return nil, fmt.Errorf("empty GOOGLE_PROJECT")
+		return nil, fmt.Errorf("set project using any of these env variables %v", projectEnvVars)
 	}
 
-	creds := os.Getenv("GOOGLE_CREDENTIALS")
+	creds := getTestCredsFromEnv()
 	if creds == "" {
-		return nil, fmt.Errorf("empty GOOGLE_CREDENTIALS")
+		return nil, fmt.Errorf("set credentials using any of these env variables %v", credsEnvVars)
 	}
 
 	conf := &Config{

--- a/google/image_test.go
+++ b/google/image_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/google/import_google_service_account_test.go
+++ b/google/import_google_service_account_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"os"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -46,7 +44,7 @@ func TestAccGoogleServiceAccount_importWithProject(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleServiceAccount_importWithProject(os.Getenv("GOOGLE_PROJECT"), "terraform-"+acctest.RandString(10)),
+				Config: testAccGoogleServiceAccount_importWithProject(getTestProjectFromEnv(), "terraform-"+acctest.RandString(10)),
 			},
 
 			resource.TestStep{

--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -110,9 +110,19 @@ func getTestProject(is *terraform.InstanceState, config *Config) (string, error)
 	return "", fmt.Errorf("%q: required field is not set", "project")
 }
 
-// getTestProjectFromEnv returns the current configured project from environment variables.
+// testAccPreCheck ensures at least one of the project env variables is set.
 func getTestProjectFromEnv() string {
 	return multiEnvSearch(projectEnvVars)
+}
+
+// testAccPreCheck ensures at least one of the credentials env variables is set.
+func getTestCredsFromEnv() string {
+	return multiEnvSearch(credsEnvVars)
+}
+
+// testAccPreCheck ensures at least one of the region env variables is set.
+func getTestRegionFromEnv() string {
+	return multiEnvSearch(regionEnvVars)
 }
 
 func getTestOrgFromEnv(t *testing.T) string {

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )

--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -177,7 +176,7 @@ func TestAccComputeFirewall_serviceAccounts(t *testing.T) {
 
 	sourceSa := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	targetSa := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
-	project := os.Getenv("GOOGLE_PROJECT")
+	project := getTestProjectFromEnv()
 	sourceSaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sourceSa, project)
 	targetSaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", targetSa, project)
 

--- a/google/resource_compute_instance_migrate.go
+++ b/google/resource_compute_instance_migrate.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/terraform"

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -864,23 +864,10 @@ func getInitializedConfig(t *testing.T) *Config {
 	// Check that all required environment variables are set
 	testAccPreCheck(t)
 
-	project := multiEnvSearch([]string{"GOOGLE_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"})
-	creds := multiEnvSearch([]string{
-		"GOOGLE_CREDENTIALS",
-		"GOOGLE_CLOUD_KEYFILE_JSON",
-		"GCLOUD_KEYFILE_JSON",
-		"GOOGLE_USE_DEFAULT_CREDENTIALS",
-	})
-	region := multiEnvSearch([]string{
-		"GOOGLE_REGION",
-		"GCLOUD_REGION",
-		"CLOUDSDK_COMPUTE_REGION",
-	})
-
 	config := &Config{
-		Project:     project,
-		Credentials: creds,
-		Region:      region,
+		Project:     getTestProjectFromEnv(),
+		Credentials: getTestCredsFromEnv(),
+		Region:      getTestRegionFromEnv(),
 	}
 	err := config.loadAndValidate()
 	if err != nil {

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -3,7 +3,6 @@ package google
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -298,8 +297,7 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 	t.Parallel()
 
 	sa := "a" + acctest.RandString(10)
-	project := os.Getenv("GOOGLE_PROJECT")
-	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sa, project)
+	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sa, getTestProjectFromEnv())
 	rnd := acctest.RandString(10)
 
 	var cluster dataproc.Cluster

--- a/google/resource_google_service_account_test.go
+++ b/google/resource_google_service_account_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"os"
 )
 
 // Test that a service account resource can be created, updated, and destroyed
@@ -18,7 +17,7 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 	uniqueId := ""
 	displayName := "Terraform Test"
 	displayName2 := "Terraform Test Update"
-	project := os.Getenv("GOOGLE_PROJECT")
+	project := getTestProjectFromEnv()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -162,7 +161,7 @@ func testAccGoogleServiceAccountWithProject(project, account, name string) strin
 	return fmt.Sprintf(t, project, account, name)
 }
 
-func testAccGoogleServiceAccountPolicy(account, name string) string {
+func testAccGoogleServiceAccountPolicy(account, project string) string {
 
 	t := `resource "google_service_account" "acceptance" {
     account_id = "%v"
@@ -179,5 +178,5 @@ data "google_iam_policy" "service_account" {
   }
 }`
 
-	return fmt.Sprintf(t, account, name, account, getTestProjectFromEnv())
+	return fmt.Sprintf(t, account, account, account, project)
 }

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -3,7 +3,6 @@ package google
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -110,7 +109,7 @@ func TestAccGoogleKmsCryptoKey_basic(t *testing.T) {
 
 	projectId := "terraform-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
-	location := os.Getenv("GOOGLE_REGION")
+	location := getTestRegionFromEnv()
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -142,7 +141,7 @@ func TestAccGoogleKmsCryptoKey_rotation(t *testing.T) {
 
 	projectId := "terraform-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
-	location := os.Getenv("GOOGLE_REGION")
+	location := getTestRegionFromEnv()
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"google.golang.org/api/googleapi"
-	storage "google.golang.org/api/storage/v1"
+	"google.golang.org/api/storage/v1"
 )
 
 func TestAccStorageBucket_basic(t *testing.T) {


### PR DESCRIPTION
Avoid duplicating the env variables names everywhere.
Consistently support all variables instead of sometimes all of them, sometimes only one (this creates subtle bug in acceptance tests that are very hard to debug :)).