### PR TITLE
Update tier setting to use db-f1-micro

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -26,7 +26,7 @@ resource "google_sql_database_instance" "master" {
   name = "master-instance"
 
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 ```


### PR DESCRIPTION
The existing setting of "D0" caused an error for me when running
`terraform apply`. This fixes the issue and allows the apply to proceed.

ping @danawillow 