### PR TITLE
Store project and region in state

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -48,6 +48,7 @@ func resourceBigQueryDataset() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -227,6 +228,7 @@ func resourceBigQueryDatasetRead(d *schema.ResourceData, meta interface{}) error
 		return handleNotFoundError(err, d, fmt.Sprintf("BigQuery dataset %q", datasetID))
 	}
 
+	d.Set("project", projectID)
 	d.Set("etag", res.Etag)
 	d.Set("labels", res.Labels)
 	d.Set("self_link", res.SelfLink)

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -42,6 +42,7 @@ func resourceBigQueryTable() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -316,6 +317,7 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
+	d.Set("project", projectID)
 	d.Set("description", res.Description)
 	d.Set("expiration_time", res.ExpirationTime)
 	d.Set("friendly_name", res.FriendlyName)

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -68,6 +68,7 @@ func resourceBigtableInstance() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -160,6 +161,7 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error retrieving instance. Could not find %s. %s", d.Id(), err)
 	}
 
+	d.Set("project", project)
 	d.Set("name", instance.Name)
 	d.Set("display_name", instance.DisplayName)
 

--- a/google/resource_bigtable_table.go
+++ b/google/resource_bigtable_table.go
@@ -38,6 +38,7 @@ func resourceBigtableTable() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -108,6 +109,8 @@ func resourceBigtableTableRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return fmt.Errorf("Error retrieving table. Could not find %s in %s. %s", name, instanceName, err)
 	}
+
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -77,6 +77,7 @@ func resourceComputeAddress() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -197,6 +198,7 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("address", addr.Address)
 	d.Set("self_link", ConvertSelfLinkToV1(addr.SelfLink))
 	d.Set("name", addr.Name)
+	d.Set("project", addressId.Project)
 	d.Set("region", GetResourceNameFromSelfLink(addr.Region))
 
 	return nil

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -120,6 +120,7 @@ func resourceComputeAutoscaler() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -316,6 +317,7 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
+	d.Set("project", project)
 	d.Set("self_link", scaler.SelfLink)
 	d.Set("name", scaler.Name)
 	d.Set("target", scaler.Target)

--- a/google/resource_compute_backend_bucket.go
+++ b/google/resource_compute_backend_bucket.go
@@ -46,6 +46,7 @@ func resourceComputeBackendBucket() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -119,6 +120,7 @@ func resourceComputeBackendBucketRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("bucket_name", bucket.BucketName)
 	d.Set("description", bucket.Description)
 	d.Set("enable_cdn", bucket.EnableCdn)
+	d.Set("project", project)
 	d.Set("self_link", bucket.SelfLink)
 
 	return nil

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -132,6 +132,7 @@ func resourceComputeBackendService() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -236,7 +237,7 @@ func resourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{})
 	d.Set("backend", flattenBackends(service.Backends))
 	d.Set("connection_draining_timeout_sec", service.ConnectionDraining.DrainingTimeoutSec)
 	d.Set("iap", flattenIap(service.Iap))
-
+	d.Set("project", project)
 	d.Set("health_checks", service.HealthChecks)
 
 	return nil

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -71,6 +71,7 @@ func resourceComputeDisk() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -313,6 +314,7 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("snapshot", disk.SourceSnapshot)
 	d.Set("labels", disk.Labels)
 	d.Set("label_fingerprint", disk.LabelFingerprint)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -36,6 +36,7 @@ func resourceComputeGlobalAddress() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -98,6 +99,7 @@ func resourceComputeGlobalAddressRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", addr.Name)
 	d.Set("ip_version", addr.IpVersion)
 	d.Set("address", addr.Address)
+	d.Set("project", project)
 	d.Set("self_link", ConvertSelfLinkToV1(addr.SelfLink))
 
 	return nil

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -89,6 +89,7 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -288,6 +289,7 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 	d.Set("self_link", ConvertSelfLinkToV1(frule.SelfLink))
 	d.Set("labels", frule.Labels)
 	d.Set("label_fingerprint", frule.LabelFingerprint)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_https_health_check.go
+++ b/google/resource_compute_https_health_check.go
@@ -56,6 +56,7 @@ func resourceComputeHttpsHealthCheck() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -220,6 +221,7 @@ func resourceComputeHttpsHealthCheckRead(d *schema.ResourceData, meta interface{
 	d.Set("port", hchk.Port)
 	d.Set("timeout_sec", hchk.TimeoutSec)
 	d.Set("unhealthy_threshold", hchk.UnhealthyThreshold)
+	d.Set("project", project)
 	d.Set("self_link", hchk.SelfLink)
 
 	return nil

--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -44,6 +44,7 @@ func resourceComputeImage() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -204,6 +205,7 @@ func resourceComputeImageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("self_link", image.SelfLink)
 	d.Set("labels", image.Labels)
 	d.Set("label_fingerprint", image.LabelFingerprint)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -410,6 +410,7 @@ func resourceComputeInstance() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -786,6 +787,11 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	instance, err := getInstance(config, d)
 	if err != nil || instance == nil {
 		return err
@@ -956,6 +962,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("min_cpu_platform", instance.MinCpuPlatform)
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
 	d.Set("instance_id", fmt.Sprintf("%d", instance.Id))
+	d.Set("project", project)
 	d.SetId(instance.Name)
 
 	return nil

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -79,6 +79,7 @@ func resourceComputeInstanceGroup() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -232,6 +233,7 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	// Set computed fields
 	d.Set("network", instanceGroup.Network)
 	d.Set("size", instanceGroup.Size)
+	d.Set("project", project)
 	d.Set("self_link", instanceGroup.SelfLink)
 
 	return nil

--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -53,6 +53,7 @@ func resourceComputeNetwork() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -117,6 +118,7 @@ func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("self_link", network.SelfLink)
 	d.Set("name", network.Name)
 	d.Set("auto_create_subnetworks", network.AutoCreateSubnetworks)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -27,6 +27,7 @@ func resourceComputeProjectMetadata() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -115,6 +116,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error setting metadata: %s", err)
 	}
 
+	d.Set("project", project)
 	d.SetId("common_metadata")
 
 	return nil

--- a/google/resource_compute_project_metadata_item.go
+++ b/google/resource_compute_project_metadata_item.go
@@ -31,6 +31,7 @@ func resourceComputeProjectMetadataItem() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -80,6 +81,7 @@ func resourceComputeProjectMetadataItemRead(d *schema.ResourceData, meta interfa
 		return nil
 	}
 
+	d.Set("project", projectID)
 	d.Set("key", d.Id())
 	d.Set("value", val)
 

--- a/google/resource_compute_region_autoscaler.go
+++ b/google/resource_compute_region_autoscaler.go
@@ -45,6 +45,7 @@ func resourceComputeRegionAutoscaler() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -125,6 +126,7 @@ func resourceComputeRegionAutoscalerRead(d *schema.ResourceData, meta interface{
 	d.Set("target", scaler.Target)
 	d.Set("region", GetResourceNameFromSelfLink(scaler.Region))
 	d.Set("description", scaler.Description)
+	d.Set("project", project)
 	if scaler.AutoscalingPolicy != nil {
 		d.Set("autoscaling_policy", flattenAutoscalingPolicy(scaler.AutoscalingPolicy))
 	}

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -65,6 +65,7 @@ func resourceComputeRegionBackendService() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -83,6 +84,7 @@ func resourceComputeRegionBackendService() *schema.Resource {
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -211,6 +213,8 @@ func resourceComputeRegionBackendServiceRead(d *schema.ResourceData, meta interf
 	d.Set("self_link", service.SelfLink)
 	d.Set("backend", flattenBackends(service.Backends))
 	d.Set("health_checks", service.HealthChecks)
+	d.Set("project", project)
+	d.Set("region", region)
 
 	return nil
 }

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -78,6 +78,7 @@ func resourceComputeRoute() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -217,6 +218,7 @@ func resourceComputeRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("next_hop_vpn_tunnel", route.NextHopVpnTunnel)
 	d.Set("tags", route.Tags)
 	d.Set("next_hop_network", route.NextHopNetwork)
+	d.Set("project", project)
 	d.Set("self_link", route.SelfLink)
 
 	return nil

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -68,6 +68,7 @@ func resourceComputeSnapshot() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -174,6 +175,7 @@ func resourceComputeSnapshotRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("labels", snapshot.Labels)
 	d.Set("label_fingerprint", snapshot.LabelFingerprint)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -73,6 +73,7 @@ func resourceComputeSslCertificate() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -148,6 +149,7 @@ func resourceComputeSslCertificateRead(d *schema.ResourceData, meta interface{})
 	d.Set("description", cert.Description)
 	d.Set("name", cert.Name)
 	d.Set("certificate", cert.Certificate)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -54,12 +54,14 @@ func resourceComputeSubnetwork() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -175,6 +177,8 @@ func resourceComputeSubnetworkRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("private_ip_google_access", subnetwork.PrivateIpGoogleAccess)
 	d.Set("gateway_address", subnetwork.GatewayAddress)
 	d.Set("secondary_ip_range", flattenSecondaryRanges(subnetwork.SecondaryIpRanges))
+	d.Set("project", project)
+	d.Set("region", region)
 	d.Set("self_link", ConvertSelfLinkToV1(subnetwork.SelfLink))
 
 	return nil

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -46,6 +46,7 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -142,6 +143,7 @@ func resourceComputeTargetHttpProxyRead(d *schema.ResourceData, meta interface{}
 	d.Set("description", proxy.Description)
 	d.Set("url_map", proxy.UrlMap)
 	d.Set("name", proxy.Name)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -68,6 +68,7 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -187,6 +188,7 @@ func resourceComputeTargetHttpsProxyRead(d *schema.ResourceData, meta interface{
 	d.Set("description", proxy.Description)
 	d.Set("url_map", proxy.UrlMap)
 	d.Set("name", proxy.Name)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -57,6 +57,7 @@ func resourceComputeTargetSslProxy() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -203,6 +204,7 @@ func resourceComputeTargetSslProxyRead(d *schema.ResourceData, meta interface{})
 	d.Set("proxy_header", proxy.ProxyHeader)
 	d.Set("backend_service", proxy.Service)
 	d.Set("ssl_certificates", proxy.SslCertificates)
+	d.Set("project", project)
 	d.Set("self_link", proxy.SelfLink)
 	d.Set("proxy_id", strconv.FormatUint(proxy.Id, 10))
 

--- a/google/resource_compute_target_tcp_proxy.go
+++ b/google/resource_compute_target_tcp_proxy.go
@@ -52,6 +52,7 @@ func resourceComputeTargetTcpProxy() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -147,6 +148,7 @@ func resourceComputeTargetTcpProxyRead(d *schema.ResourceData, meta interface{})
 	d.Set("backend_service", proxy.Service)
 	d.Set("proxy_header", proxy.ProxyHeader)
 	d.Set("description", proxy.Description)
+	d.Set("project", project)
 	d.Set("self_link", proxy.SelfLink)
 	d.Set("proxy_id", strconv.FormatUint(proxy.Id, 10))
 

--- a/google/resource_compute_url_map.go
+++ b/google/resource_compute_url_map.go
@@ -117,6 +117,7 @@ func resourceComputeUrlMap() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -318,6 +319,7 @@ func resourceComputeUrlMapRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(name)
+	d.Set("project", project)
 	d.Set("self_link", urlMap.SelfLink)
 	d.Set("map_id", strconv.FormatUint(urlMap.Id, 10))
 	d.Set("fingerprint", urlMap.Fingerprint)

--- a/google/resource_compute_vpn_gateway.go
+++ b/google/resource_compute_vpn_gateway.go
@@ -39,12 +39,14 @@ func resourceComputeVpnGateway() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -124,6 +126,8 @@ func resourceComputeVpnGatewayRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("name", vpnGateway.Name)
 	d.Set("description", vpnGateway.Description)
 	d.Set("network", vpnGateway.Network)
+	d.Set("project", project)
+	d.Set("region", region)
 	d.Set("self_link", vpnGateway.SelfLink)
 	d.SetId(name)
 

--- a/google/resource_compute_vpn_tunnel.go
+++ b/google/resource_compute_vpn_tunnel.go
@@ -85,12 +85,14 @@ func resourceComputeVpnTunnel() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -220,6 +222,8 @@ func resourceComputeVpnTunnelRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("remote_traffic_selector", remoteTrafficSelectors)
 
 	d.Set("detailed_status", vpnTunnel.DetailedStatus)
+	d.Set("project", project)
+	d.Set("region", region)
 	d.Set("self_link", vpnTunnel.SelfLink)
 
 	d.SetId(name)

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -313,6 +313,7 @@ func resourceContainerCluster() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -580,6 +581,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("network", cluster.Network)
 	d.Set("subnetwork", cluster.Subnetwork)
 	d.Set("node_config", flattenNodeConfig(cluster.NodeConfig))
+	d.Set("project", project)
 	if cluster.AddonsConfig != nil {
 		d.Set("addons_config", flattenClusterAddonsConfig(cluster.AddonsConfig))
 	}

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -39,6 +39,7 @@ func resourceContainerNodePool() *schema.Resource {
 				"project": &schema.Schema{
 					Type:     schema.TypeString,
 					Optional: true,
+					Computed: true,
 					ForceNew: true,
 				},
 				"zone": &schema.Schema{
@@ -197,6 +198,8 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 	for k, v := range npMap {
 		d.Set(k, v)
 	}
+
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -62,6 +62,7 @@ func resourceDataprocCluster() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -648,6 +649,7 @@ func resourceDataprocClusterRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set("name", cluster.ClusterName)
+	d.Set("project", project)
 	d.Set("region", region)
 	d.Set("labels", cluster.Labels)
 

--- a/google/resource_dataproc_job.go
+++ b/google/resource_dataproc_job.go
@@ -26,6 +26,7 @@ func resourceDataprocJob() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -277,6 +278,7 @@ func resourceDataprocJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("placement", flattenJobPlacement(job.Placement))
 	d.Set("status", flattenJobStatus(job.Status))
 	d.Set("reference", flattenJobReference(job.Reference))
+	d.Set("project", project)
 
 	if job.PysparkJob != nil {
 		d.Set("pyspark_config", flattenPySparkJob(job.PysparkJob))

--- a/google/resource_dns_managed_zone.go
+++ b/google/resource_dns_managed_zone.go
@@ -49,6 +49,7 @@ func resourceDnsManagedZone() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -105,6 +106,7 @@ func resourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", zone.Name)
 	d.Set("dns_name", zone.DnsName)
 	d.Set("description", zone.Description)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -49,6 +49,7 @@ func resourceDnsRecordSet() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -157,6 +158,7 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("ttl", resp.Rrsets[0].Ttl)
 	d.Set("rrdatas", resp.Rrsets[0].Rrdatas)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_google_project_iam_custom_role.go
+++ b/google/resource_google_project_iam_custom_role.go
@@ -37,6 +37,7 @@ func resourceGoogleProjectIamCustomRole() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"stage": {
@@ -92,6 +93,11 @@ func resourceGoogleProjectIamCustomRoleCreate(d *schema.ResourceData, meta inter
 func resourceGoogleProjectIamCustomRoleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	role, err := config.clientIAM.Projects.Roles.Get(d.Id()).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, d.Id())
@@ -103,6 +109,7 @@ func resourceGoogleProjectIamCustomRoleRead(d *schema.ResourceData, meta interfa
 	d.Set("permissions", role.IncludedPermissions)
 	d.Set("stage", role.Stage)
 	d.Set("deleted", role.Deleted)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -22,6 +22,7 @@ func resourceGoogleProjectIamPolicy() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"policy_data": &schema.Schema{
@@ -137,6 +138,7 @@ func resourceGoogleProjectIamPolicyRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG]: Setting etag=%s", p.Etag)
 	d.Set("etag", p.Etag)
 	d.Set("policy_data", string(pBytes))
+	d.Set("project", pid)
 	return nil
 }
 

--- a/google/resource_google_project_service.go
+++ b/google/resource_google_project_service.go
@@ -22,6 +22,7 @@ func resourceGoogleProjectService() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -63,6 +64,8 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
+
+	d.Set("project", project)
 
 	for _, s := range services {
 		if s == id.service {

--- a/google/resource_kms_key_ring.go
+++ b/google/resource_kms_key_ring.go
@@ -32,6 +32,7 @@ func resourceKmsKeyRing() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -86,6 +87,11 @@ func resourceKmsKeyRingCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	keyRingId, err := parseKmsKeyRingId(d.Id(), config)
 	if err != nil {
 		return err
@@ -98,6 +104,8 @@ func resourceKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error reading KeyRing: %s", err)
 	}
+
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -43,6 +43,7 @@ func resourcePubsubSubscription() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -123,6 +124,11 @@ func getComputedTopicName(project string, topic string) string {
 func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 	subscription, err := config.clientPubsub.Projects.Subscriptions.Get(name).Do()
 	if err != nil {
@@ -134,6 +140,7 @@ func resourcePubsubSubscriptionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("ack_deadline_seconds", subscription.AckDeadlineSeconds)
 	d.Set("path", subscription.Name)
 	d.Set("push_config", flattenPubsubSubscriptionPushConfig(subscription.PushConfig))
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_pubsub_topic.go
+++ b/google/resource_pubsub_topic.go
@@ -28,6 +28,7 @@ func resourcePubsubTopic() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -59,6 +60,11 @@ func resourcePubsubTopicCreate(d *schema.ResourceData, meta interface{}) error {
 func resourcePubsubTopicRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 	call := config.clientPubsub.Projects.Topics.Get(name)
 	res, err := call.Do()
@@ -67,6 +73,7 @@ func resourcePubsubTopicRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", GetResourceNameFromSelfLink(res.Name))
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_runtimeconfig_config.go
+++ b/google/resource_runtimeconfig_config.go
@@ -33,6 +33,7 @@ func resourceRuntimeconfigConfig() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -91,6 +92,7 @@ func resourceRuntimeconfigConfigRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("name", name)
 	d.Set("description", runConfig.Description)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_runtimeconfig_variable.go
+++ b/google/resource_runtimeconfig_variable.go
@@ -72,15 +72,11 @@ func resourceRuntimeconfigVariableCreate(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(createdVariable.Name)
 
-	return setRuntimeConfigVariableToResourceData(d, project, *createdVariable)
+	return setRuntimeConfigVariableToResourceData(d, *createdVariable)
 }
 
 func resourceRuntimeconfigVariableRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
-	}
 
 	fullName := d.Id()
 	createdVariable, err := config.clientRuntimeconfig.Projects.Configs.Variables.Get(fullName).Do()
@@ -88,7 +84,7 @@ func resourceRuntimeconfigVariableRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	return setRuntimeConfigVariableToResourceData(d, project, *createdVariable)
+	return setRuntimeConfigVariableToResourceData(d, *createdVariable)
 }
 
 func resourceRuntimeconfigVariableUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -112,7 +108,7 @@ func resourceRuntimeconfigVariableUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	return setRuntimeConfigVariableToResourceData(d, project, *createdVariable)
+	return setRuntimeConfigVariableToResourceData(d, *createdVariable)
 }
 
 func resourceRuntimeconfigVariableDelete(d *schema.ResourceData, meta interface{}) error {
@@ -177,7 +173,7 @@ func newRuntimeconfigVariableFromResourceData(d *schema.ResourceData, project st
 }
 
 // setRuntimeConfigVariableToResourceData stores a provided runtimeconfig.Variable struct inside a schema.ResourceData.
-func setRuntimeConfigVariableToResourceData(d *schema.ResourceData, project string, variable runtimeconfig.Variable) error {
+func setRuntimeConfigVariableToResourceData(d *schema.ResourceData, variable runtimeconfig.Variable) error {
 	varProject, parent, name, err := resourceRuntimeconfigVariableParseFullName(variable.Name)
 	if err != nil {
 		return err

--- a/google/resource_runtimeconfig_variable.go
+++ b/google/resource_runtimeconfig_variable.go
@@ -30,6 +30,7 @@ func resourceRuntimeconfigVariable() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -183,11 +184,7 @@ func setRuntimeConfigVariableToResourceData(d *schema.ResourceData, project stri
 	}
 	d.Set("name", name)
 	d.Set("parent", parent)
-
-	if varProject != project {
-		d.Set("project", varProject)
-	}
-
+	d.Set("project", varProject)
 	d.Set("value", variable.Value)
 	d.Set("text", variable.Text)
 	d.Set("update_time", variable.UpdateTime)

--- a/google/resource_source_repos_repository.go
+++ b/google/resource_source_repos_repository.go
@@ -23,6 +23,7 @@ func resourceSourceRepoRepository() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -78,6 +79,7 @@ func resourceSourceRepoRepositoryRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("size", repo.Size)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_spanner_database.go
+++ b/google/resource_spanner_database.go
@@ -60,6 +60,7 @@ func resourceSpannerDatabase() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -131,6 +132,7 @@ func resourceSpannerDatabaseRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set("state", db.State)
+	d.Set("project", id.Project)
 	return nil
 }
 

--- a/google/resource_spanner_instance.go
+++ b/google/resource_spanner_instance.go
@@ -89,6 +89,7 @@ func resourceSpannerInstance() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -169,6 +170,7 @@ func resourceSpannerInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("display_name", instance.DisplayName)
 	d.Set("num_nodes", instance.NodeCount)
 	d.Set("state", instance.State)
+	d.Set("project", id.Project)
 
 	return nil
 }

--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -35,6 +35,7 @@ func resourceSqlDatabase() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -129,6 +130,7 @@ func resourceSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(instance_name + ":" + database_name)
 	d.Set("charset", db.Charset)
 	d.Set("collation", db.Collation)
+	d.Set("project", project)
 
 	return nil
 }

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -265,6 +265,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -686,7 +687,7 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("master_instance_name", strings.TrimPrefix(instance.MasterInstanceName, project+":"))
-
+	d.Set("project", project)
 	d.Set("self_link", instance.SelfLink)
 	d.SetId(instance.Name)
 

--- a/google/resource_sql_user.go
+++ b/google/resource_sql_user.go
@@ -50,6 +50,7 @@ func resourceSqlUser() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -141,6 +142,7 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("host", user.Host)
 	d.Set("instance", user.Instance)
 	d.Set("name", user.Name)
+	d.Set("project", project)
 	return nil
 }
 

--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -65,6 +65,7 @@ func resourceStorageBucket() *schema.Resource {
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -366,6 +367,11 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Get the bucket and acl
 	bucket := d.Get("name").(string)
 	res, err := config.clientStorage.Buckets.Get(bucket).Do()
@@ -384,6 +390,7 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cors", flattenCors(res.Cors))
 	d.Set("versioning", flattenBucketVersioning(res.Versioning))
 	d.Set("labels", res.Labels)
+	d.Set("project", project)
 	d.SetId(res.Id)
 	return nil
 }


### PR DESCRIPTION
As of now, we store the project in region in the state for some resources and not for others. 

This PR addresses this by consistently marking the project and region fields as `Computed: true` and storing it in the state inside the read method.

The main benefits apart from being consistent is that in acceptance tests, we can rely on the project property being set instead of having to do the same fallback logic that we do in the resource again (i.e. check in schema, if not set fallback to config.Project).