### PR TITLE
Always use a function to create a test config

### DIFF
--- a/google/data_source_dns_managed_zone_test.go
+++ b/google/data_source_dns_managed_zone_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceDnsManagedZone_basic,
+				Config: testAccDataSourceDnsManagedZone_basic(),
 				Check:  testAccDataSourceDnsManagedZoneCheck("data.google_dns_managed_zone.qa", "google_dns_managed_zone.foo"),
 			},
 		},
@@ -57,7 +57,8 @@ func testAccDataSourceDnsManagedZoneCheck(dsName, rsName string) resource.TestCh
 	}
 }
 
-var testAccDataSourceDnsManagedZone_basic = fmt.Sprintf(`
+func testAccDataSourceDnsManagedZone_basic() string {
+	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "foo" {
 	name		= "qa-zone-%s"
 	dns_name	= "qa.test.com."
@@ -68,3 +69,4 @@ data "google_dns_managed_zone" "qa" {
 	name	= "${google_dns_managed_zone.foo.name}"
 }
 `, acctest.RandString(10))
+}

--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceGoogleComputeInstanceGroup_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGoogleComputeInstanceGroupConfig,
+				Config: testAccCheckDataSourceGoogleComputeInstanceGroupConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGoogleComputeInstanceGroup("data.google_compute_instance_group.test"),
 				),
@@ -39,7 +39,7 @@ func TestAccDataSourceGoogleComputeInstanceGroup_withNamedPort(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort,
+				Config: testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGoogleComputeInstanceGroup("data.google_compute_instance_group.test"),
 				),
@@ -174,7 +174,8 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 	}
 }
 
-var testAccCheckDataSourceGoogleComputeInstanceGroupConfig = fmt.Sprintf(`
+func testAccCheckDataSourceGoogleComputeInstanceGroupConfig() string {
+	return fmt.Sprintf(`
 resource "google_compute_instance" "test" {
   name         = "tf-test-%s"
   machine_type = "n1-standard-1"
@@ -209,8 +210,10 @@ data "google_compute_instance_group" "test" {
   zone = "${google_compute_instance_group.test.zone}"
 }
 `, acctest.RandString(10), acctest.RandString(10))
+}
 
-var testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort = fmt.Sprintf(`
+func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort() string {
+	return fmt.Sprintf(`
 resource "google_compute_instance" "test" {
   name         = "tf-test-%s"
   machine_type = "n1-standard-1"
@@ -255,3 +258,4 @@ data "google_compute_instance_group" "test" {
   zone = "${google_compute_instance_group.test.zone}"
 }
 `, acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/import_compute_global_address_test.go
+++ b/google/import_compute_global_address_test.go
@@ -17,7 +17,7 @@ func TestAccComputeGlobalAddress_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeGlobalAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeGlobalAddress_basic,
+				Config: testAccComputeGlobalAddress_basic(),
 			},
 
 			resource.TestStep{

--- a/google/import_compute_image_test.go
+++ b/google/import_compute_image_test.go
@@ -37,7 +37,7 @@ func TestAccComputeImage_importFromSourceDisk(t *testing.T) {
 		CheckDestroy: testAccCheckComputeImageDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeImage_basedondisk,
+				Config: testAccComputeImage_basedondisk(),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_image.foobar",

--- a/google/import_compute_instance_template_test.go
+++ b/google/import_compute_instance_template_test.go
@@ -18,7 +18,7 @@ func TestAccComputeInstanceTemplate_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_basic,
+				Config: testAccComputeInstanceTemplate_basic(),
 			},
 
 			resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccComputeInstanceTemplate_importIp(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_ip,
+				Config: testAccComputeInstanceTemplate_ip(),
 			},
 
 			resource.TestStep{
@@ -64,7 +64,7 @@ func TestAccComputeInstanceTemplate_importDisks(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_disks,
+				Config: testAccComputeInstanceTemplate_disks(),
 			},
 
 			resource.TestStep{
@@ -111,7 +111,7 @@ func TestAccComputeInstanceTemplate_importSubnetCustom(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_subnet_custom,
+				Config: testAccComputeInstanceTemplate_subnet_custom(),
 			},
 
 			resource.TestStep{

--- a/google/import_compute_network_test.go
+++ b/google/import_compute_network_test.go
@@ -17,7 +17,7 @@ func TestAccComputeNetwork_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_basic,
+				Config: testAccComputeNetwork_basic(),
 			}, {
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -39,7 +39,7 @@ func TestAccComputeNetwork_importAuto_subnet(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_auto_subnet,
+				Config: testAccComputeNetwork_auto_subnet(),
 			}, {
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -60,7 +60,7 @@ func TestAccComputeNetwork_importCustom_subnet(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_custom_subnet,
+				Config: testAccComputeNetwork_custom_subnet(),
 			}, {
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/google/import_compute_ssl_certificate_test.go
+++ b/google/import_compute_ssl_certificate_test.go
@@ -14,7 +14,7 @@ func TestAccComputeSslCertificate_import(t *testing.T) {
 		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeSslCertificate_import,
+				Config: testAccComputeSslCertificate_import(),
 			},
 			resource.TestStep{
 				ResourceName:            "google_compute_ssl_certificate.foobar",

--- a/google/import_compute_target_pool_test.go
+++ b/google/import_compute_target_pool_test.go
@@ -17,7 +17,7 @@ func TestAccComputeTargetPool_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeTargetPoolDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeTargetPool_basic,
+				Config: testAccComputeTargetPool_basic(),
 			},
 
 			resource.TestStep{

--- a/google/import_dns_managed_zone_test.go
+++ b/google/import_dns_managed_zone_test.go
@@ -17,7 +17,7 @@ func TestAccDnsManagedZone_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsManagedZone_basic,
+				Config: testAccDnsManagedZone_basic(),
 			},
 
 			resource.TestStep{

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -45,7 +45,7 @@ func TestAccComputeDisk_timeout(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:      testAccComputeDisk_timeout,
+				Config:      testAccComputeDisk_timeout(),
 				ExpectError: regexp.MustCompile("timeout"),
 			},
 		},
@@ -316,7 +316,8 @@ resource "google_compute_disk" "foobar" {
 }`, diskName)
 }
 
-var testAccComputeDisk_timeout = fmt.Sprintf(`
+func testAccComputeDisk_timeout() string {
+	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	image = "debian-8-jessie-v20160803"
@@ -327,6 +328,7 @@ resource "google_compute_disk" "foobar" {
 		Create = "1s"
 	}
 }`, acctest.RandString(10))
+}
 
 func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`

--- a/google/resource_compute_global_address_test.go
+++ b/google/resource_compute_global_address_test.go
@@ -22,7 +22,7 @@ func TestAccComputeGlobalAddress_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeGlobalAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeGlobalAddress_basic,
+				Config: testAccComputeGlobalAddress_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
@@ -46,7 +46,7 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 		CheckDestroy: testAccCheckComputeGlobalAddressDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeGlobalAddress_ipv6,
+				Config: testAccComputeGlobalAddress_ipv6(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeGlobalAddressExists(
 						"google_compute_global_address.foobar", &addr),
@@ -130,13 +130,17 @@ func testAccCheckComputeGlobalAddressIpVersion(n, version string) resource.TestC
 	}
 }
 
-var testAccComputeGlobalAddress_basic = fmt.Sprintf(`
+func testAccComputeGlobalAddress_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_global_address" "foobar" {
 	name = "address-test-%s"
 }`, acctest.RandString(10))
+}
 
-var testAccComputeGlobalAddress_ipv6 = fmt.Sprintf(`
+func testAccComputeGlobalAddress_ipv6() string {
+	return fmt.Sprintf(`
 resource "google_compute_global_address" "foobar" {
 	name = "address-test-%s"
 	ip_version = "IPV6"
 }`, acctest.RandString(10))
+}

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -84,7 +84,7 @@ func TestAccComputeImage_basedondisk(t *testing.T) {
 		CheckDestroy: testAccCheckComputeImageDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeImage_basedondisk,
+				Config: testAccComputeImage_basedondisk(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeImageExists(
 						"google_compute_image.foobar", &image),
@@ -248,7 +248,8 @@ resource "google_compute_image" "foobar" {
 }`, name)
 }
 
-var testAccComputeImage_basedondisk = fmt.Sprintf(`
+func testAccComputeImage_basedondisk() string {
+	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "disk-test-%s"
 	zone = "us-central1-a"
@@ -258,3 +259,4 @@ resource "google_compute_image" "foobar" {
 	name = "image-test-%s"
 	source_disk = "${google_compute_disk.foobar.self_link}"
 }`, acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -23,7 +23,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_basic,
+				Config: testAccComputeInstanceTemplate_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -48,7 +48,7 @@ func TestAccComputeInstanceTemplate_preemptible(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_preemptible,
+				Config: testAccComputeInstanceTemplate_preemptible(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -71,7 +71,7 @@ func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_ip,
+				Config: testAccComputeInstanceTemplate_ip(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -118,7 +118,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_disks,
+				Config: testAccComputeInstanceTemplate_disks(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -164,7 +164,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_subnet_custom,
+				Config: testAccComputeInstanceTemplate_subnet_custom(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -211,7 +211,7 @@ func TestAccComputeInstanceTemplate_metadata_startup_script(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_startup_script,
+				Config: testAccComputeInstanceTemplate_startup_script(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
@@ -446,7 +446,8 @@ func testAccCheckComputeInstanceTemplateContainsLabel(instanceTemplate *compute.
 	}
 }
 
-var testAccComputeInstanceTemplate_basic = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
@@ -480,8 +481,10 @@ resource "google_compute_instance_template" "foobar" {
         my_label = "foobar"
     }
 }`, acctest.RandString(10))
+}
 
-var testAccComputeInstanceTemplate_preemptible = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_preemptible() string {
+	return fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
@@ -511,8 +514,10 @@ resource "google_compute_instance_template" "foobar" {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
 }`, acctest.RandString(10))
+}
 
-var testAccComputeInstanceTemplate_ip = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_ip() string {
+	return fmt.Sprintf(`
 resource "google_compute_address" "foo" {
 	name = "instancet-test-%s"
 }
@@ -537,6 +542,7 @@ resource "google_compute_instance_template" "foobar" {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccComputeInstanceTemplate_networkIP(networkIP string) string {
 	return fmt.Sprintf(`
@@ -560,7 +566,8 @@ resource "google_compute_instance_template" "foobar" {
 }`, acctest.RandString(10), networkIP)
 }
 
-var testAccComputeInstanceTemplate_disks = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_disks() string {
+	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "instancet-test-%s"
 	image = "debian-8-jessie-v20160803"
@@ -594,6 +601,7 @@ resource "google_compute_instance_template" "foobar" {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 	return fmt.Sprintf(`
@@ -623,7 +631,8 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 	}`, network, acctest.RandString(10))
 }
 
-var testAccComputeInstanceTemplate_subnet_custom = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_subnet_custom() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "network" {
 	name = "network-%s"
 	auto_create_subnetworks = false
@@ -656,6 +665,7 @@ resource "google_compute_instance_template" "foobar" {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccComputeInstanceTemplate_subnet_xpn(xpn_host string) string {
 	return fmt.Sprintf(`
@@ -696,7 +706,8 @@ func testAccComputeInstanceTemplate_subnet_xpn(xpn_host string) string {
 	}`, acctest.RandString(10), xpn_host, acctest.RandString(10), xpn_host, acctest.RandString(10))
 }
 
-var testAccComputeInstanceTemplate_startup_script = fmt.Sprintf(`
+func testAccComputeInstanceTemplate_startup_script() string {
+	return fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
@@ -718,3 +729,4 @@ resource "google_compute_instance_template" "foobar" {
 
 	metadata_startup_script = "echo 'Hello'"
 }`, acctest.RandString(10))
+}

--- a/google/resource_compute_network_peering_test.go
+++ b/google/resource_compute_network_peering_test.go
@@ -21,7 +21,7 @@ func TestAccComputeNetworkPeering_basic(t *testing.T) {
 		CheckDestroy: testAccComputeNetworkPeeringDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeNetworkPeering_basic,
+				Config: testAccComputeNetworkPeering_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkPeeringExist("google_compute_network_peering.foo", &peering),
 					testAccCheckComputeNetworkPeeringAutoCreateRoutes(true, &peering),
@@ -97,7 +97,8 @@ func testAccCheckComputeNetworkPeeringAutoCreateRoutes(v bool, peering *compute.
 	}
 }
 
-var testAccComputeNetworkPeering_basic = fmt.Sprintf(`
+func testAccComputeNetworkPeering_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "network1" {
 	name = "network-test-1-%s"
 	auto_create_subnetworks = false
@@ -121,3 +122,4 @@ resource "google_compute_network_peering" "bar" {
 	peer_network = "${google_compute_network.network1.self_link}"
 }
 `, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/resource_compute_network_test.go
+++ b/google/resource_compute_network_test.go
@@ -21,7 +21,7 @@ func TestAccComputeNetwork_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeNetwork_basic,
+				Config: testAccComputeNetwork_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						"google_compute_network.foobar", &network),
@@ -42,7 +42,7 @@ func TestAccComputeNetwork_auto_subnet(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeNetwork_auto_subnet,
+				Config: testAccComputeNetwork_auto_subnet(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						"google_compute_network.bar", &network),
@@ -65,7 +65,7 @@ func TestAccComputeNetwork_custom_subnet(t *testing.T) {
 		CheckDestroy: testAccCheckComputeNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeNetwork_custom_subnet,
+				Config: testAccComputeNetwork_custom_subnet(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						"google_compute_network.baz", &network),
@@ -168,19 +168,25 @@ func testAccCheckComputeNetworkIsCustomSubnet(n string, network *compute.Network
 	}
 }
 
-var testAccComputeNetwork_basic = fmt.Sprintf(`
+func testAccComputeNetwork_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "network-test-%s"
 }`, acctest.RandString(10))
+}
 
-var testAccComputeNetwork_auto_subnet = fmt.Sprintf(`
+func testAccComputeNetwork_auto_subnet() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
 	name = "network-test-%s"
 	auto_create_subnetworks = true
 }`, acctest.RandString(10))
+}
 
-var testAccComputeNetwork_custom_subnet = fmt.Sprintf(`
+func testAccComputeNetwork_custom_subnet() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "baz" {
 	name = "network-test-%s"
 	auto_create_subnetworks = false
 }`, acctest.RandString(10))
+}

--- a/google/resource_compute_ssl_certificate_test.go
+++ b/google/resource_compute_ssl_certificate_test.go
@@ -18,7 +18,7 @@ func TestAccComputeSslCertificate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeSslCertificate_basic,
+				Config: testAccComputeSslCertificate_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSslCertificateExists(
 						"google_compute_ssl_certificate.foobar"),
@@ -37,7 +37,7 @@ func TestAccComputeSslCertificate_no_name(t *testing.T) {
 		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeSslCertificate_no_name,
+				Config: testAccComputeSslCertificate_no_name(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSslCertificateExists(
 						"google_compute_ssl_certificate.foobar"),
@@ -56,7 +56,7 @@ func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
 		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeSslCertificate_name_prefix,
+				Config: testAccComputeSslCertificate_name_prefix(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSslCertificateExists(
 						"google_compute_ssl_certificate.foobar"),
@@ -111,7 +111,8 @@ func testAccCheckComputeSslCertificateExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccComputeSslCertificate_basic = fmt.Sprintf(`
+func testAccComputeSslCertificate_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
 	name = "sslcert-test-%s"
 	description = "very descriptive"
@@ -119,16 +120,20 @@ resource "google_compute_ssl_certificate" "foobar" {
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 `, acctest.RandString(10))
+}
 
-var testAccComputeSslCertificate_no_name = fmt.Sprintf(`
+func testAccComputeSslCertificate_no_name() string {
+	return fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
 	description = "really descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 `)
+}
 
-var testAccComputeSslCertificate_name_prefix = fmt.Sprintf(`
+func testAccComputeSslCertificate_name_prefix() string {
+	return fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
 	name_prefix = "sslcert-test-%s-"
 	description = "extremely descriptive"
@@ -136,8 +141,10 @@ resource "google_compute_ssl_certificate" "foobar" {
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 `, acctest.RandString(10))
+}
 
-var testAccComputeSslCertificate_import = fmt.Sprintf(`
+func testAccComputeSslCertificate_import() string {
+	return fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
 	name = "sslcert-test-%s"
 	description = "very descriptive"
@@ -145,3 +152,4 @@ resource "google_compute_ssl_certificate" "foobar" {
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
 `, acctest.RandString(10))
+}

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -18,7 +18,7 @@ func TestAccComputeTargetPool_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeTargetPoolDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeTargetPool_basic,
+				Config: testAccComputeTargetPool_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeTargetPoolExists(
 						"google_compute_target_pool.foo"),
@@ -98,7 +98,8 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 	}
 }
 
-var testAccComputeTargetPool_basic = fmt.Sprintf(`
+func testAccComputeTargetPool_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_http_health_check" "foobar" {
 	name = "healthcheck-test-%s"
 	host = "example.com"
@@ -137,3 +138,4 @@ resource "google_compute_target_pool" "bar" {
 		"${google_compute_http_health_check.foobar.self_link}"
 	]
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/resource_compute_url_map_test.go
+++ b/google/resource_compute_url_map_test.go
@@ -70,7 +70,7 @@ func TestAccComputeUrlMap_advanced(t *testing.T) {
 		CheckDestroy: testAccCheckComputeUrlMapDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeUrlMap_advanced1,
+				Config: testAccComputeUrlMap_advanced1(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeUrlMapExists(
 						"google_compute_url_map.foobar"),
@@ -78,7 +78,7 @@ func TestAccComputeUrlMap_advanced(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccComputeUrlMap_advanced2,
+				Config: testAccComputeUrlMap_advanced2(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeUrlMapExists(
 						"google_compute_url_map.foobar"),
@@ -245,7 +245,8 @@ resource "google_compute_url_map" "foobar" {
 `, bsName, hcName, umName)
 }
 
-var testAccComputeUrlMap_advanced1 = fmt.Sprintf(`
+func testAccComputeUrlMap_advanced1() string {
+	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
 	name          = "urlmap-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
@@ -293,8 +294,10 @@ resource "google_compute_url_map" "foobar" {
 	}
 }
 `, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
-var testAccComputeUrlMap_advanced2 = fmt.Sprintf(`
+func testAccComputeUrlMap_advanced2() string {
+	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
 	name          = "urlmap-test-%s"
 	health_checks = ["${google_compute_http_health_check.zero.self_link}"]
@@ -362,6 +365,7 @@ resource "google_compute_url_map" "foobar" {
 	}
 }
 `, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccComputeUrlMap_noPathRules(bsName, hcName, umName string) string {
 	return fmt.Sprintf(`

--- a/google/resource_compute_vpn_gateway_test.go
+++ b/google/resource_compute_vpn_gateway_test.go
@@ -20,7 +20,7 @@ func TestAccComputeVpnGateway_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeVpnGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeVpnGateway_basic,
+				Config: testAccComputeVpnGateway_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeVpnGatewayExists(
 						"google_compute_vpn_gateway.foobar"),
@@ -84,7 +84,8 @@ func testAccCheckComputeVpnGatewayExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccComputeVpnGateway_basic = fmt.Sprintf(`
+func testAccComputeVpnGateway_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "gateway-test-%s"
 	auto_create_subnetworks = true
@@ -100,3 +101,4 @@ resource "google_compute_vpn_gateway" "baz" {
 	network = "${google_compute_network.foobar.name}"
 	region = "us-central1"
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/resource_compute_vpn_tunnel_test.go
+++ b/google/resource_compute_vpn_tunnel_test.go
@@ -20,7 +20,7 @@ func TestAccComputeVpnTunnel_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeVpnTunnelDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeVpnTunnel_basic,
+				Config: testAccComputeVpnTunnel_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeVpnTunnelExists(
 						"google_compute_vpn_tunnel.foobar"),
@@ -65,7 +65,7 @@ func TestAccComputeVpnTunnel_defaultTrafficSelectors(t *testing.T) {
 		CheckDestroy: testAccCheckComputeVpnTunnelDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeVpnTunnelDefaultTrafficSelectors,
+				Config: testAccComputeVpnTunnelDefaultTrafficSelectors(),
 				Check: testAccCheckComputeVpnTunnelExists(
 					"google_compute_vpn_tunnel.foobar"),
 			},
@@ -125,7 +125,8 @@ func testAccCheckComputeVpnTunnelExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccComputeVpnTunnel_basic = fmt.Sprintf(`
+func testAccComputeVpnTunnel_basic() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "tunnel-test-%s"
 }
@@ -176,8 +177,9 @@ resource "google_compute_vpn_tunnel" "foobar" {
 	local_traffic_selector = ["${google_compute_subnetwork.foobar.ip_cidr_range}"]
 	remote_traffic_selector = ["192.168.0.0/24", "192.168.1.0/24"]
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10), acctest.RandString(10))
+		acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+		acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccComputeVpnTunnelRouter(router string) string {
 	testId := acctest.RandString(10)
@@ -242,7 +244,8 @@ func testAccComputeVpnTunnelRouter(router string) string {
 	`, testId, testId, testId, testId, testId, testId, testId, router, testId)
 }
 
-var testAccComputeVpnTunnelDefaultTrafficSelectors = fmt.Sprintf(`
+func testAccComputeVpnTunnelDefaultTrafficSelectors() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "tunnel-test-%s"
 	auto_create_subnetworks = "true"
@@ -286,5 +289,6 @@ resource "google_compute_vpn_tunnel" "foobar" {
 	shared_secret = "unguessable"
 	peer_ip = "8.8.8.8"
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
-	acctest.RandString(10))
+		acctest.RandString(10), acctest.RandString(10), acctest.RandString(10),
+		acctest.RandString(10))
+}

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -45,7 +45,7 @@ func TestAccContainerCluster_withTimeout(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withTimeout,
+				Config: testAccContainerCluster_withTimeout(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.primary"),
@@ -97,7 +97,7 @@ func TestAccContainerCluster_withMasterAuth(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withMasterAuth,
+				Config: testAccContainerCluster_withMasterAuth(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_master_auth"),
@@ -283,7 +283,7 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodeConfig,
+				Config: testAccContainerCluster_withNodeConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_node_config"),
@@ -302,7 +302,7 @@ func TestAccContainerCluster_withNodeConfigScopeAlias(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodeConfigScopeAlias,
+				Config: testAccContainerCluster_withNodeConfigScopeAlias(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_node_config_scope_alias"),
@@ -321,7 +321,7 @@ func TestAccContainerCluster_network(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_networkRef,
+				Config: testAccContainerCluster_networkRef(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_net_ref_by_url"),
@@ -342,7 +342,7 @@ func TestAccContainerCluster_backend(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_backendRef,
+				Config: testAccContainerCluster_backendRef(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.primary"),
@@ -512,7 +512,7 @@ func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodePoolNamePrefix,
+				Config: testAccContainerCluster_withNodePoolNamePrefix(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_node_pool_name_prefix"),
@@ -531,7 +531,7 @@ func TestAccContainerCluster_withNodePoolMultiple(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodePoolMultiple,
+				Config: testAccContainerCluster_withNodePoolMultiple(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerCluster(
 						"google_container_cluster.with_node_pool_multiple"),
@@ -550,7 +550,7 @@ func TestAccContainerCluster_withNodePoolConflictingNameFields(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerCluster_withNodePoolConflictingNameFields,
+				Config:      testAccContainerCluster_withNodePoolConflictingNameFields(),
 				ExpectError: regexp.MustCompile("Cannot specify both name and name_prefix for a node_pool"),
 			},
 		},
@@ -893,7 +893,8 @@ resource "google_container_cluster" "primary" {
 }`, name)
 }
 
-var testAccContainerCluster_withTimeout = fmt.Sprintf(`
+func testAccContainerCluster_withTimeout() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
@@ -905,6 +906,7 @@ resource "google_container_cluster" "primary" {
 		update = "30m"
 	}
 }`, acctest.RandString(10))
+}
 
 func testAccContainerCluster_withAddons(clusterName string) string {
 	return fmt.Sprintf(`
@@ -935,7 +937,8 @@ resource "google_container_cluster" "primary" {
 }`, clusterName)
 }
 
-var testAccContainerCluster_withMasterAuth = fmt.Sprintf(`
+func testAccContainerCluster_withMasterAuth() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_auth" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
@@ -946,6 +949,7 @@ resource "google_container_cluster" "with_master_auth" {
 		password = "adoy.rm"
 	}
 }`, acctest.RandString(10))
+}
 
 func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName string, cidrs []string) string {
 
@@ -1103,7 +1107,8 @@ resource "google_container_cluster" "with_version" {
 }`, clusterName)
 }
 
-var testAccContainerCluster_withNodeConfig = fmt.Sprintf(`
+func testAccContainerCluster_withNodeConfig() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
 	name = "cluster-test-%s"
 	zone = "us-central1-f"
@@ -1137,8 +1142,10 @@ resource "google_container_cluster" "with_node_config" {
 		min_cpu_platform = "Intel Broadwell"
 	}
 }`, acctest.RandString(10))
+}
 
-var testAccContainerCluster_withNodeConfigScopeAlias = fmt.Sprintf(`
+func testAccContainerCluster_withNodeConfigScopeAlias() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config_scope_alias" {
 	name = "cluster-test-%s"
 	zone = "us-central1-f"
@@ -1155,8 +1162,10 @@ resource "google_container_cluster" "with_node_config_scope_alias" {
 		oauth_scopes = [ "compute-rw", "storage-ro", "logging-write", "monitoring" ]
 	}
 }`, acctest.RandString(10))
+}
 
-var testAccContainerCluster_networkRef = fmt.Sprintf(`
+func testAccContainerCluster_networkRef() string {
+	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
 	name = "container-net-%s"
 	auto_create_subnetworks = true
@@ -1187,8 +1196,10 @@ resource "google_container_cluster" "with_net_ref_by_name" {
 
 	network = "${google_compute_network.container_network.name}"
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
-var testAccContainerCluster_backendRef = fmt.Sprintf(`
+func testAccContainerCluster_backendRef() string {
+	return fmt.Sprintf(`
 resource "google_compute_backend_service" "my-backend-service" {
   name      = "terraform-test-%s"
   port_name = "http"
@@ -1233,6 +1244,7 @@ resource "google_container_cluster" "primary" {
   }
 }
 `, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccContainerCluster_withLogging(clusterName string) string {
 	return fmt.Sprintf(`
@@ -1376,7 +1388,8 @@ resource "google_container_cluster" "with_node_pool" {
 }`, cluster, np)
 }
 
-var testAccContainerCluster_withNodePoolNamePrefix = fmt.Sprintf(`
+func testAccContainerCluster_withNodePoolNamePrefix() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_name_prefix" {
 	name = "tf-cluster-nodepool-test-%s"
 	zone = "us-central1-a"
@@ -1391,8 +1404,10 @@ resource "google_container_cluster" "with_node_pool_name_prefix" {
 		node_count  = 2
 	}
 }`, acctest.RandString(10))
+}
 
-var testAccContainerCluster_withNodePoolMultiple = fmt.Sprintf(`
+func testAccContainerCluster_withNodePoolMultiple() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_multiple" {
 	name = "tf-cluster-nodepool-test-%s"
 	zone = "us-central1-a"
@@ -1412,8 +1427,10 @@ resource "google_container_cluster" "with_node_pool_multiple" {
 		node_count = 3
 	}
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}
 
-var testAccContainerCluster_withNodePoolConflictingNameFields = fmt.Sprintf(`
+func testAccContainerCluster_withNodePoolConflictingNameFields() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_multiple" {
 	name = "tf-cluster-nodepool-test-%s"
 	zone = "us-central1-a"
@@ -1430,6 +1447,7 @@ resource "google_container_cluster" "with_node_pool_multiple" {
 		node_count  = 1
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+}
 
 func testAccContainerCluster_withNodePoolNodeConfig() string {
 	testId := acctest.RandString(10)

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -83,7 +83,7 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerNodePoolDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccContainerNodePool_withNodeConfig,
+				Config: testAccContainerNodePool_withNodeConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerNodePoolMatches("google_container_node_pool.np_with_node_config"),
 				),
@@ -146,7 +146,7 @@ func TestAccContainerNodePool_withNodeConfigScopeAlias(t *testing.T) {
 		CheckDestroy: testAccCheckContainerNodePoolDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccContainerNodePool_withNodeConfigScopeAlias,
+				Config: testAccContainerNodePool_withNodeConfigScopeAlias(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerNodePoolMatches("google_container_node_pool.np_with_node_config_scope_alias"),
 				),
@@ -571,7 +571,8 @@ func nodepoolMatchError(attr, tf interface{}, gcp interface{}) string {
 	return fmt.Sprintf("NodePool has mismatched %s.\nTF State: %+v\nGCP State: %+v", attr, tf, gcp)
 }
 
-var testAccContainerNodePool_withNodeConfig = fmt.Sprintf(`
+func testAccContainerNodePool_withNodeConfig() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name = "tf-cluster-nodepool-test-%s"
 	zone = "us-central1-a"
@@ -599,8 +600,10 @@ resource "google_container_node_pool" "np_with_node_config" {
 		min_cpu_platform = "Intel Broadwell"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+}
 
-var testAccContainerNodePool_withNodeConfigScopeAlias = fmt.Sprintf(`
+func testAccContainerNodePool_withNodeConfigScopeAlias() string {
+	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name = "tf-cluster-nodepool-test-%s"
 	zone = "us-central1-a"
@@ -621,3 +624,4 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
 		oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
+}

--- a/google/resource_dns_managed_zone_test.go
+++ b/google/resource_dns_managed_zone_test.go
@@ -21,7 +21,7 @@ func TestAccDnsManagedZone_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsManagedZone_basic,
+				Config: testAccDnsManagedZone_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsManagedZoneExists(
 						"google_dns_managed_zone.foobar", &zone),
@@ -78,8 +78,10 @@ func testAccCheckDnsManagedZoneExists(n string, zone *dns.ManagedZone) resource.
 	}
 }
 
-var testAccDnsManagedZone_basic = fmt.Sprintf(`
+func testAccDnsManagedZone_basic() string {
+	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
 	name = "mzone-test-%s"
 	dns_name = "hashicorptest.com."
 }`, acctest.RandString(10))
+}

--- a/google/resource_pubsub_topic_test.go
+++ b/google/resource_pubsub_topic_test.go
@@ -18,7 +18,7 @@ func TestAccPubsubTopicCreate(t *testing.T) {
 		CheckDestroy: testAccCheckPubsubTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccPubsubTopic,
+				Config: testAccPubsubTopic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPubsubTopicExists(
 						"google_pubsub_topic.foobar"),
@@ -64,7 +64,9 @@ func testAccPubsubTopicExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccPubsubTopic = fmt.Sprintf(`
+func testAccPubsubTopic() string {
+	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foobar" {
 	name = "pstopic-test-%s"
 }`, acctest.RandString(10))
+}


### PR DESCRIPTION
The main issue with using a var instead of a func is that when you reuse the same config (let's say in an import test and a resource test), the random resource name are the same. When running in parallel, this cause a race condition and tests are failing.

The CI is not affected by this because it creates a new process for each test which means that the global variable are set for each processes.

Some of the config weren't for more than one test but for consistency and safety (in case they are use in more than one test in the future), I also updated them to be a function.