### PR TITLE
Revert "Added support for updating a cloud storage object using source field"

### DIFF
--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -2,11 +2,8 @@ package google
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -95,9 +92,6 @@ func resourceStorageBucketObject() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"content"},
-				StateFunc: func(src interface{}) string {
-					return fileNameWithMd5(src.(string))
-				},
 			},
 
 			"storage_class": &schema.Schema{
@@ -112,20 +106,6 @@ func resourceStorageBucketObject() *schema.Resource {
 
 func objectGetId(object *storage.Object) string {
 	return object.Bucket + "-" + object.Name
-}
-
-func fileNameWithMd5(filename string) string {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		log.Printf("[WARN] Failed to read source file %s. Will not compute md5 to store in state", filename)
-		return filename
-	}
-
-	h := md5.New()
-	h.Write(data)
-	md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-	return filename + ":" + md5
 }
 
 func resourceStorageBucketObjectCreate(d *schema.ResourceData, meta interface{}) error {

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -42,51 +41,6 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectBasic(bucketName),
 				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
-			},
-		},
-	})
-}
-
-func TestAccGoogleStorageObject_recreate(t *testing.T) {
-	t.Parallel()
-
-	bucketName := testBucketName()
-
-	writeFile := func(name string, data []byte) string {
-		h := md5.New()
-		h.Write(data)
-		data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-		ioutil.WriteFile(name, data, 0644)
-		return data_md5
-	}
-	data_md5 := writeFile(tf.Name(), []byte("data data data"))
-	updated_data_md5 := writeFile(tf.Name()+".update", []byte("datum"))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			if err != nil {
-				panic(err)
-			}
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testGoogleStorageBucketsObjectBasic(bucketName),
-				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, data_md5),
-			},
-			resource.TestStep{
-				PreConfig: func() {
-					updateName := tf.Name() + ".update"
-					err := os.Rename(updateName, tf.Name())
-					if err != nil {
-						t.Errorf("Failed to rename %s to %s", updateName, tf.Name())
-					}
-				},
-				Config: testGoogleStorageBucketsObjectBasic(bucketName),
-				Check:  testAccCheckGoogleStorageObject(bucketName, objectName, updated_data_md5),
 			},
 		},
 	})


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-google#362

This creates a diff for all the storage object when people will update to the next version. We should find a way that does not create diff.

cc/ @rodcloutier