### PR TITLE
Detect changes to cloud storage object when using source field.

### DIFF
--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -810,7 +810,7 @@ func runInstanceMigrateTest(t *testing.T, id, testName string, version int, attr
 		ID:         id,
 		Attributes: attributes,
 	}
-	is, err = resourceComputeInstanceMigrateState(version, is, meta)
+	is, err := resourceComputeInstanceMigrateState(version, is, meta)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -864,6 +864,7 @@ func checkMapMatch(attributes map[string]string, attr string, gcpMap map[string]
 func checkBoolMatch(attributes map[string]string, attr string, gcpBool bool) string {
 	// Handle the case where an unset value defaults to false
 	var tf bool
+	var err error
 	if attributes[attr] == "" {
 		tf = false
 	} else {

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -58,7 +58,8 @@ func TestAccGoogleStorageObject_recreate(t *testing.T) {
 	}
 	testFile := getNewTmpTestFile(t, "tf-test")
 	data_md5 := writeFile(testFile.Name(), []byte("data data data"))
-	updated_data_md5 := writeFile(testFile.Name()+".update", []byte("datum"))
+	updatedName := testFile.Name() + ".update"
+	updated_data_md5 := writeFile(updatedName, []byte("datum"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,10 +72,9 @@ func TestAccGoogleStorageObject_recreate(t *testing.T) {
 			},
 			resource.TestStep{
 				PreConfig: func() {
-					updateName := testFile.Name() + ".update"
-					err := os.Rename(updateName, testFile.Name())
+					err := os.Rename(updatedName, testFile.Name())
 					if err != nil {
-						t.Errorf("Failed to rename %s to %s", updateName, testFile.Name())
+						t.Errorf("Failed to rename %s to %s", updatedName, testFile.Name())
 					}
 				},
 				Config: testGoogleStorageBucketsObjectBasic(bucketName, testFile.Name()),


### PR DESCRIPTION
Fixes #788 

Detect changes to the file when using the `source` field whether the local file content is updated or the file stored on GCP is updated outside of Terraform.

cc/ @rodcloutier