### PR TITLE
Fix service_account_id field validation in service account key

### DIFF
--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -20,7 +20,7 @@ func resourceGoogleServiceAccountKey() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateRFC1035Name(6, 30),
+				ValidateFunc: validateRegexp(ServiceAccountLinkRegex),
 			},
 			// Optional
 			"key_algorithm": &schema.Schema{

--- a/google/validation.go
+++ b/google/validation.go
@@ -16,6 +16,18 @@ const (
 	SubnetworkRegex = "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"
 
 	SubnetworkLinkRegex = "projects/(" + ProjectRegex + ")/regions/(" + RegionRegex + ")/subnetworks/(" + SubnetworkRegex + ")$"
+
+	RFC1035NameTemplate = "[a-z](?:[-a-z0-9]{%d,%d}[a-z0-9])"
+)
+
+var (
+	// Service account name must have a length between 6 and 30.
+	// The first and last characters have different restrictions, than
+	// the middle characters. The middle characters length must be between
+	// 4 and 28 since the first and last character are excluded.
+	ServiceAccountNameRegex = fmt.Sprintf(RFC1035NameTemplate, 4, 28)
+
+	ServiceAccountLinkRegex = "projects/" + ProjectRegex + "/serviceAccounts/" + ServiceAccountNameRegex + "@" + ProjectRegex + "\\.iam\\.gserviceaccount\\.com$"
 )
 
 var rfc1918Networks = []string{
@@ -93,5 +105,5 @@ func validateRFC1035Name(min, max int) schema.SchemaValidateFunc {
 		}
 	}
 
-	return validateRegexp(fmt.Sprintf(`^[a-z]([-a-z0-9]{%d,%d}[a-z0-9])$`, min-2, max-2))
+	return validateRegexp(fmt.Sprintf("^"+RFC1035NameTemplate+"$", min-2, max-2))
 }


### PR DESCRIPTION
Fixes bug introduced in #793.

The `service_account_id` field in the `google_service_account_key` resource must be a `self_link`.

The validation func introduced in #793 assumed that it was simply the `account_id` like in `google_service_account.account_id` but this was wrong.

Validation is important for this field because the error message returned from the API is unhelpful:
```
* google_service_account_key.test: 1 error(s) occurred:

* google_service_account_key.test: Error creating service account key: googleapi: got HTTP response code 404 with body: <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/v1/rosbo-personal/serviceAccounts/testid@rosbo-personal.iam.gserviceaccount.com/keys?alt=json</code> was not found on this server.  <ins>That’s all we know.</ins>
```