### PR TITLE
compute instance helpers / metadata cleanup

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -30,6 +30,10 @@ func ParseSubnetworkFieldValue(subnetwork string, d TerraformResourceData, confi
 	return parseRegionalFieldValue("subnetworks", subnetwork, "project", "region", d, config, true)
 }
 
+func ParseSubnetworkFieldValueWithProjectField(subnetwork, projectField string, d TerraformResourceData, config *Config) (*RegionalFieldValue, error) {
+	return parseRegionalFieldValue("subnetworks", subnetwork, projectField, "region", d, config, true)
+}
+
 func ParseSslCertificateFieldValue(sslCertificate string, d TerraformResourceData, config *Config) (*GlobalFieldValue, error) {
 	return parseGlobalFieldValue("sslCertificates", sslCertificate, "project", d, config, false)
 }

--- a/google/metadata.go
+++ b/google/metadata.go
@@ -135,9 +135,9 @@ func flattenMetadataBeta(metadata *computeBeta.Metadata) map[string]string {
 	return metadataMap
 }
 
-// This function differs from flattenMetadata only in that it takes
+// This function differs from flattenMetadataBeta only in that it takes
 // compute.metadata rather than computeBeta.metadata as an argument. It should
-// be removed in favour of flattenMetadata if/when all resources using it get
+// be removed in favour of flattenMetadataBeta if/when all resources using it get
 // beta support.
 func flattenMetadata(metadata *compute.Metadata) map[string]string {
 	metadataMap := make(map[string]string)

--- a/google/metadata.go
+++ b/google/metadata.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -111,29 +110,6 @@ func BetaMetadataUpdate(oldMDMap map[string]interface{}, newMDMap map[string]int
 	}
 }
 
-// flattenComputeMetadata transforms a list of MetadataItems (as returned via the GCP client) into a simple map from key
-// to value.
-func flattenComputeMetadata(metadata []*compute.MetadataItems) map[string]string {
-	m := map[string]string{}
-
-	for _, item := range metadata {
-		// check for duplicates
-		if item.Value == nil {
-			continue
-		}
-		if val, ok := m[item.Key]; ok {
-			// warn loudly!
-			log.Printf("[WARN] Key '%s' already has value '%s' when flattening - ignoring incoming value '%s'",
-				item.Key,
-				val,
-				*item.Value)
-		}
-		m[item.Key] = *item.Value
-	}
-
-	return m
-}
-
 // expandComputeMetadata transforms a map representing computing metadata into a list of compute.MetadataItems suitable
 // for the GCP client.
 func expandComputeMetadata(m map[string]string) []*compute.MetadataItems {
@@ -151,7 +127,7 @@ func expandComputeMetadata(m map[string]string) []*compute.MetadataItems {
 	return metadata
 }
 
-func flattenMetadata(metadata *computeBeta.Metadata) map[string]string {
+func flattenMetadataBeta(metadata *computeBeta.Metadata) map[string]string {
 	metadataMap := make(map[string]string)
 	for _, item := range metadata.Items {
 		metadataMap[item.Key] = *item.Value
@@ -161,9 +137,9 @@ func flattenMetadata(metadata *computeBeta.Metadata) map[string]string {
 
 // This function differs from flattenMetadata only in that it takes
 // compute.metadata rather than computeBeta.metadata as an argument. It should
-// be removed in favour of flattenMetadata if/when this resource gets beta
-// support.
-func flattenCommonInstanceMetadata(metadata *compute.Metadata) map[string]string {
+// be removed in favour of flattenMetadata if/when all resources using it get
+// beta support.
+func flattenMetadata(metadata *compute.Metadata) map[string]string {
 	metadataMap := make(map[string]string)
 	for _, item := range metadata.Items {
 		metadataMap[item.Key] = *item.Value

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -720,7 +720,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	md := flattenMetadata(instance.Metadata)
+	md := flattenMetadataBeta(instance.Metadata)
 
 	if _, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
 		d.Set("metadata_startup_script", md["startup-script"])

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -750,7 +750,10 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 
 	// Set the networks
 	// Use the first external IP found for the default connection info.
-	networkInterfaces, _, internalIP, externalIP := flattenNetworkInterfaces(instance.NetworkInterfaces)
+	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, instance.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
 	d.Set("network_interface", networkInterfaces)
 
 	// Fall back on internal ip if there is no external ip.  This makes sense in the situation where

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -686,7 +686,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 
 		md := instanceTemplate.Properties.Metadata
 
-		_md := flattenMetadata(md)
+		_md := flattenMetadataBeta(md)
 
 		if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
 			if err = d.Set("metadata_startup_script", script); err != nil {

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -737,7 +737,10 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting project: %s", err)
 	}
 	if instanceTemplate.Properties.NetworkInterfaces != nil {
-		networkInterfaces, region, _, _ := flattenNetworkInterfaces(instanceTemplate.Properties.NetworkInterfaces)
+		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
+		if err != nil {
+			return err
+		}
 		if err = d.Set("network_interface", networkInterfaces); err != nil {
 			return fmt.Errorf("Error setting network_interface: %s", err)
 		}

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -106,7 +106,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 		return handleNotFoundError(err, d, fmt.Sprintf("Project metadata for project %q", projectID))
 	}
 
-	md := flattenCommonInstanceMetadata(project.CommonInstanceMetadata)
+	md := flattenMetadata(project.CommonInstanceMetadata)
 	existingMetadata := d.Get("metadata").(map[string]interface{})
 	// Remove all keys not explicitly mentioned in the terraform config
 	for k := range md {

--- a/google/resource_compute_project_metadata_item.go
+++ b/google/resource_compute_project_metadata_item.go
@@ -73,7 +73,7 @@ func resourceComputeProjectMetadataItemRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 	}
 
-	md := flattenComputeMetadata(project.CommonInstanceMetadata.Items)
+	md := flattenMetadata(project.CommonInstanceMetadata)
 	val, ok := md[d.Id()]
 	if !ok {
 		// Resource no longer exists
@@ -136,7 +136,7 @@ func updateComputeCommonInstanceMetadata(config *Config, projectID string, key s
 			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
 
-		md := flattenComputeMetadata(project.CommonInstanceMetadata.Items)
+		md := flattenMetadata(project.CommonInstanceMetadata)
 
 		val, ok := md[key]
 

--- a/google/resource_compute_project_metadata_item_test.go
+++ b/google/resource_compute_project_metadata_item_test.go
@@ -113,7 +113,7 @@ func testAccCheckProjectMetadataItem_hasMetadata(key, value string) resource.Tes
 			return err
 		}
 
-		metadata := flattenComputeMetadata(project.CommonInstanceMetadata.Items)
+		metadata := flattenMetadata(project.CommonInstanceMetadata)
 
 		val, ok := metadata[key]
 		if !ok {
@@ -134,7 +134,7 @@ func testAccCheckProjectMetadataItemDestroy(s *terraform.State) error {
 		return err
 	}
 
-	metadata := flattenComputeMetadata(project.CommonInstanceMetadata.Items)
+	metadata := flattenMetadata(project.CommonInstanceMetadata)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "google_compute_project_metadata_item" {

--- a/google/utils.go
+++ b/google/utils.go
@@ -5,7 +5,6 @@ package google
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -122,33 +121,6 @@ func getZonalBetaResourceFromRegion(getResource func(string) (interface{}, error
 	}
 	// Resource does not exist in this region
 	return nil, nil
-}
-
-// getSubnetworkLink takes the "subnetwork" field and if the value is:
-// - a resource URL, returns the string unchanged
-// - a subnetwork name, looks up the resource URL using the google client.
-//
-// If `subnetworkField` is a resource url, `subnetworkProjectField` cannot be set.
-// If `subnetworkField` is a subnetwork name, `subnetworkProjectField` will be used
-// 	as the project if set. If not, we fallback on the default project.
-func getSubnetworkLink(config *Config, defaultProject, region, subnetworkProject, subnetwork string) (string, error) {
-	if subnetwork == "" {
-		return "", nil
-	}
-
-	if regexp.MustCompile(SubnetworkLinkRegex).MatchString(subnetwork) {
-		return subnetwork, nil
-	}
-
-	project := defaultProject
-	if subnetworkProject != "" {
-		project = subnetworkProject
-	}
-	subnetworkData, err := config.clientCompute.Subnetworks.Get(project, region, subnetwork).Do()
-	if err != nil {
-		return "", fmt.Errorf("Error referencing subnetwork '%s' in region '%s': %s", subnetwork, region, err)
-	}
-	return subnetworkData.SelfLink, nil
 }
 
 // getNetworkName reads the "network" field from the given resource data and if the value:


### PR DESCRIPTION
A few things I noticed while reviewing #639, this:
- uses the new ParseSubnetwork field helpers, and adds a new one in order to remove the getSubnetworkLink family of functions
- dedupes metadata flatteners, since there were two that did approximately the same thing. I opted to keep the one that doesn't do any logging/deduping to match a bit more what we tend to do elsewhere but I could just as easily use that one

Since these changes were pretty small I put them in one PR, but they're separate commits in case you feel like reviewing separately.

```
=== RUN   TestAccComputeProjectMetadataItem_importBasic
=== RUN   TestAccComputeProjectMetadataItem_basic
=== RUN   TestAccComputeProjectMetadataItem_basicMultiple
=== RUN   TestAccComputeProjectMetadataItem_basicWithEmptyVal
=== RUN   TestAccComputeProjectMetadataItem_basicUpdate
--- PASS: TestAccComputeProjectMetadataItem_importBasic (36.09s)
--- PASS: TestAccComputeProjectMetadataItem_basicWithEmptyVal (36.85s)
--- PASS: TestAccComputeProjectMetadataItem_basicMultiple (40.20s)
--- PASS: TestAccComputeProjectMetadataItem_basicUpdate (52.17s)
--- PASS: TestAccComputeProjectMetadataItem_basic (26.98s)

=== RUN   TestAccComputeProjectMetadata_basic
=== RUN   TestAccComputeProjectMetadata_modify_1
=== RUN   TestAccComputeProjectMetadata_modify_2
--- PASS: TestAccComputeProjectMetadata_basic (152.01s)
--- PASS: TestAccComputeProjectMetadata_modify_1 (166.95s)
--- PASS: TestAccComputeProjectMetadata_modify_2 (167.65s)

=== RUN   TestAccComputeInstance_basic1
=== RUN   TestAccComputeInstance_basic2
=== RUN   TestAccComputeInstance_basic3
=== RUN   TestAccComputeInstance_basic4
=== RUN   TestAccComputeInstance_basic5
=== RUN   TestAccComputeInstance_IP
=== RUN   TestAccComputeInstance_GenerateIP
--- PASS: TestAccComputeInstance_GenerateIP (75.19s)
=== RUN   TestAccComputeInstance_diskEncryption
=== RUN   TestAccComputeInstance_attachedDisk
=== RUN   TestAccComputeInstance_attachedDisk_sourceUrl
=== RUN   TestAccComputeInstance_attachedDiskUpdate
=== RUN   TestAccComputeInstance_bootDisk_source
=== RUN   TestAccComputeInstance_bootDisk_sourceUrl
=== RUN   TestAccComputeInstance_bootDisk_type
=== RUN   TestAccComputeInstance_scratchDisk
=== RUN   TestAccComputeInstance_forceNewAndChangeMetadata
=== RUN   TestAccComputeInstance_update
=== RUN   TestAccComputeInstance_service_account
=== RUN   TestAccComputeInstance_scheduling
=== RUN   TestAccComputeInstance_subnet_auto
=== RUN   TestAccComputeInstance_subnet_custom
=== RUN   TestAccComputeInstance_subnet_xpn
=== RUN   TestAccComputeInstance_address_auto
=== RUN   TestAccComputeInstance_address_custom
=== RUN   TestAccComputeInstance_private_image_family
=== RUN   TestAccComputeInstance_forceChangeMachineTypeManually
=== RUN   TestAccComputeInstance_multiNic
=== RUN   TestAccComputeInstance_guestAccelerator
=== RUN   TestAccComputeInstance_minCpuPlatform
=== RUN   TestAccComputeInstance_primaryAliasIpRange
=== RUN   TestAccComputeInstance_secondaryAliasIpRange
--- PASS: TestAccComputeInstance_basic1 (71.96s)
--- FAIL: TestAccComputeInstance_subnet_xpn (1.42s)
	testing.go:435: Step 0 error: Error applying: 1 error(s) occurred:

		* google_compute_network.inst-test-network: 1 error(s) occurred:

		* google_compute_network.inst-test-network: Error creating network: googleapi: Error 403: Required 'compute.networks.create' permission for 'projects/pod5-xpn-host', forbidden
--- PASS: TestAccComputeInstance_service_account (84.07s)
--- PASS: TestAccComputeInstance_subnet_custom (125.01s)
--- PASS: TestAccComputeInstance_private_image_family (286.22s)
--- PASS: TestAccComputeInstance_address_auto (416.30s)
--- PASS: TestAccComputeInstance_address_custom (427.01s)
--- PASS: TestAccComputeInstance_primaryAliasIpRange (38.22s)
--- PASS: TestAccComputeInstance_scheduling (65.45s)
--- PASS: TestAccComputeInstance_guestAccelerator (62.65s)
--- PASS: TestAccComputeInstance_subnet_auto (384.65s)
--- PASS: TestAccComputeInstance_forceChangeMachineTypeManually (213.04s)
--- PASS: TestAccComputeInstance_minCpuPlatform (180.32s)
--- PASS: TestAccComputeInstance_secondaryAliasIpRange (398.26s)
--- PASS: TestAccComputeInstance_basic5 (58.41s)
--- PASS: TestAccComputeInstance_attachedDisk_sourceUrl (81.68s)
--- PASS: TestAccComputeInstance_update (113.44s)
--- PASS: TestAccComputeInstance_multiNic (417.82s)
--- PASS: TestAccComputeInstance_attachedDisk (71.91s)
--- PASS: TestAccComputeInstance_scratchDisk (61.45s)
--- PASS: TestAccComputeInstance_forceNewAndChangeMetadata (116.71s)
--- PASS: TestAccComputeInstance_diskEncryption (81.78s)
--- PASS: TestAccComputeInstance_bootDisk_type (58.98s)
--- PASS: TestAccComputeInstance_bootDisk_source (61.12s)
--- PASS: TestAccComputeInstance_bootDisk_sourceUrl (71.10s)
--- PASS: TestAccComputeInstance_IP (89.02s)
--- PASS: TestAccComputeInstance_basic2 (57.60s)
--- PASS: TestAccComputeInstance_basic3 (65.97s)
--- PASS: TestAccComputeInstance_basic4 (59.92s)
--- PASS: TestAccComputeInstance_attachedDiskUpdate (176.96s)
```