### PR TITLE
Detect changes to local file or changes made outside of Terraform to the file stored on the server.

### DIFF
--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -99,7 +99,7 @@ func resourceStorageBucketObject() *schema.Resource {
 
 			// Detect changes to local file or changes made outside of Terraform to the file stored on the server.
 			"detect_md5hash": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 				// This field is not Computed because it needs to trigger a diff.
 				Optional: true,
 				ForceNew: true,

--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -100,6 +100,7 @@ func resourceStorageBucketObject() *schema.Resource {
 			// Detect changes to local file or changes made outside of Terraform to the file stored on the server.
 			"detect_md5hash": &schema.Schema{
 				Type:     schema.TypeString,
+				// This field is not Computed because it needs to trigger a diff.
 				Optional: true,
 				ForceNew: true,
 				// Makes the diff message nicer:


### PR DESCRIPTION
Fixes bug introduced by #789.
Add support to detect changes to the file stored on the server outside of Terraform when the `content` field is used. Before, it only worked if you were using the `source` field to specify the object content.

The bug because it is not possible to reference an optional field if the value is not set in the config when the resource is not already in the state. By changing `md5hash` from Computed to Optional, we prevented this valid use case.

The following test was failing because of that:

We were trying to access the "${google_storage_bucket_object.story.md5hash}" field. Since the state is empty at the beginning of the test. We can't reference the md5hash optional field.
```
TestAccStorageSignedUrl_accTest
        * data.google_storage_object_signed_url.story_url_w_md5: Resource 'google_storage_bucket_object.story' does not have attribute 'md5hash' for variable 'google_storage_bucket_object.story.md5hash'
```
