### PR TITLE
Unremove ipv4_range on networks.

### DIFF
--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -362,6 +362,8 @@ func testAccComputeFirewall_basic(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -380,6 +382,8 @@ func testAccComputeFirewall_update(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -399,6 +403,8 @@ func testAccComputeFirewall_priority(network, firewall string, priority int) str
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -418,6 +424,8 @@ func testAccComputeFirewall_noSource(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -436,6 +444,8 @@ func testAccComputeFirewall_denied(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {
@@ -455,6 +465,8 @@ func testAccComputeFirewall_egress(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
 		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
 	}
 
 	resource "google_compute_firewall" "foobar" {

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -129,22 +129,17 @@ func testAccComputeRoute_basic() string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "route-test-%s"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "route-test-%s"
-  ip_cidr_range = "10.0.0.0/16"
-  network       = "${google_compute_network.foobar.self_link}"
-  region        = "us-central1"
+	auto_create_subnetworks = false
+	ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_route" "foobar" {
 	name = "route-test-%s"
 	dest_range = "15.0.0.0/24"
 	network = "${google_compute_network.foobar.name}"
-	next_hop_ip = "10.154.0.1"
+	next_hop_ip = "10.0.1.5"
 	priority = 100
-}`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+}`, acctest.RandString(10), acctest.RandString(10))
 }
 
 func testAccComputeRoute_defaultInternetGateway() string {

--- a/google/resource_compute_vpn_gateway_test.go
+++ b/google/resource_compute_vpn_gateway_test.go
@@ -88,7 +88,8 @@ func testAccComputeVpnGateway_basic() string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
 	name = "gateway-test-%s"
-	auto_create_subnetworks = true
+	auto_create_subnetworks = false
+	ipv4_range = "10.0.0.0/16"
 }
 
 resource "google_compute_vpn_gateway" "foobar" {

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -34,7 +34,11 @@ The following arguments are supported:
 * `auto_create_subnetworks` - (Optional) If set to true, this network will be
     created in auto subnet mode, and Google will create a subnet for each region
     automatically. If set to false, a custom subnetted network will be created that
-    can support `google_compute_subnetwork` resources.
+    can support `google_compute_subnetwork` resources. Defaults to true.
+
+* `ipv4_range` - (Optional) If set to a CIDR block, uses the legacy VPC API with the
+  specified range. This API is deprecated. If set, `auto_create_subnetworks` must be
+  explicitly set to false.
 
 * `description` - (Optional) A brief description of this resource.
 


### PR DESCRIPTION
We removed ipv4_range, but the API still exists, it's just deprecated.
This breaks configs for users that haven't migrated off yet. I added it
back, added some tests to use it, included it in the docs, and basically
tried to put things back the way they were. The main difference now is
that the auto_create_subnetworks field defaults to true, and we want to
keep that behaviour to avoid a breaking change. So now if users want to
use the lagacy API, they need to set auto_create_subnetworks to false
explicitly.

Fixes #609.