### PR TITLE
give disk_autoresize a default in `google_sql_database_instance`

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -121,9 +121,8 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 						"disk_autoresize": &schema.Schema{
 							Type:             schema.TypeBool,
 							Optional:         true,
+							Default:          true,
 							DiffSuppressFunc: suppressFirstGen,
-							// Set computed instead of default because this property is for second-gen only.
-							Computed: true,
 						},
 						"disk_size": &schema.Schema{
 							Type:     schema.TypeInt,


### PR DESCRIPTION
Fixes #614.

Disk auto-resize defaults to true server-side for all gen 2 SQL instances. Currently, we attempt to use that default by setting the field to computed, but then we override it in the create function by setting `ForceSendFields` for the value, which will be false if unset. We can't get rid of the `ForceSendFields` since people need to be allowed to set the value to be false, but since the API doesn't complain when setting `StorageAutoResize` for gen 1 instances, we can just have a default.

```
=== RUN   TestAccGoogleSqlDatabaseInstance_importBasic
=== RUN   TestAccGoogleSqlDatabaseInstance_importBasic3
=== RUN   TestAccGoogleSqlDatabaseInstance_basic
=== RUN   TestAccGoogleSqlDatabaseInstance_basic2
=== RUN   TestAccGoogleSqlDatabaseInstance_basic3
=== RUN   TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_basic
=== RUN   TestAccGoogleSqlDatabaseInstance_slave
=== RUN   TestAccGoogleSqlDatabaseInstance_diskspecs
=== RUN   TestAccGoogleSqlDatabaseInstance_maintenance
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_upgrade
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_downgrade
=== RUN   TestAccGoogleSqlDatabaseInstance_authNets
=== RUN   TestAccGoogleSqlDatabaseInstance_multipleOperations
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_upgrade (59.27s)
--- PASS: TestAccGoogleSqlDatabaseInstance_importBasic (62.89s)
--- PASS: TestAccGoogleSqlDatabaseInstance_authNets (76.98s)
--- PASS: TestAccGoogleSqlDatabaseInstance_multipleOperations (89.80s)
--- PASS: TestAccGoogleSqlDatabaseInstance_diskspecs (450.95s)
--- PASS: TestAccGoogleSqlDatabaseInstance_basic3 (399.64s)
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_basic (41.65s)
--- PASS: TestAccGoogleSqlDatabaseInstance_maintenance (441.24s)
--- PASS: TestAccGoogleSqlDatabaseInstance_basic (50.68s)
--- PASS: TestAccGoogleSqlDatabaseInstance_basic2 (52.45s)
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_downgrade (49.19s)
--- PASS: TestAccGoogleSqlDatabaseInstance_slave (933.03s)
--- PASS: TestAccGoogleSqlDatabaseInstance_importBasic3 (429.28s)
--- PASS: TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica (707.19s)
```