### PR TITLE
Only handle root NS records special.

### DIFF
--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -180,15 +180,12 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 	// CAN and MUST be deleted, so we need to retrieve the managed zone,
 	// check if what we're looking at is a subdomain, and only not delete
 	// if it's not actually a subdomain
-	var domain string
 	if d.Get("type").(string) == "NS" {
-		if domain == "" {
-			mz, err := config.clientDns.ManagedZones.Get(project, zone).Do()
-			if err != nil {
-				return fmt.Errorf("Error retrieving managed zone %q from %q: %s", zone, project, err)
-			}
-			domain = mz.DnsName
+		mz, err := config.clientDns.ManagedZones.Get(project, zone).Do()
+		if err != nil {
+			return fmt.Errorf("Error retrieving managed zone %q from %q: %s", zone, project, err)
 		}
+		domain := mz.DnsName
 
 		if domain == d.Get("name").(string) {
 			log.Println("[DEBUG] NS records can't be deleted due to API restrictions, so they're being left in place. See https://www.terraform.io/docs/providers/google/r/dns_record_set.html for more information.")


### PR DESCRIPTION
We introduced special handling for NS records in 1.2.0 under the
assumption that ALL NS records can't be deleted. This isn't actually
true. Only NS records for the naked domain of the managed zone can't be
removed; all other NS records can be. Because of this, 1.2.0 contains a
bug where all NS records are removed.

This update fixes the situation to only use special handling on NS
records that are for the naked root domain of the managed zone, and
treat all subdomain NS records as normal records. It also adds a test to
ensure this functionality.

Fixes #729.