### PR TITLE
Add support for min_cpu_platform to instance_template

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -384,6 +384,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				},
 			},
 
+			"min_cpu_platform": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -524,6 +530,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	instanceProperties.CanIpForward = d.Get("can_ip_forward").(bool)
 	instanceProperties.Description = d.Get("instance_description").(string)
 	instanceProperties.MachineType = d.Get("machine_type").(string)
+	instanceProperties.MinCpuPlatform = d.Get("min_cpu_platform").(string)
 	disks, err := buildDisks(d, config)
 	if err != nil {
 		return err
@@ -724,6 +731,9 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 	if err = d.Set("machine_type", instanceTemplate.Properties.MachineType); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
+	}
+	if err = d.Set("min_cpu_platform", instanceTemplate.Properties.MinCpuPlatform); err != nil {
+		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
 	}
 
 	if err = d.Set("can_ip_forward", instanceTemplate.Properties.CanIpForward); err != nil {

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -525,12 +525,13 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	instanceProperties := &computeBeta.InstanceProperties{}
+	instanceProperties := &computeBeta.InstanceProperties{
+		CanIpForward:   d.Get("can_ip_forward").(bool),
+		Description:    d.Get("instance_description").(string),
+		MachineType:    d.Get("machine_type").(string),
+		MinCpuPlatform: d.Get("min_cpu_platform").(string),
+	}
 
-	instanceProperties.CanIpForward = d.Get("can_ip_forward").(bool)
-	instanceProperties.Description = d.Get("instance_description").(string)
-	instanceProperties.MachineType = d.Get("machine_type").(string)
-	instanceProperties.MinCpuPlatform = d.Get("min_cpu_platform").(string)
 	disks, err := buildDisks(d, config)
 	if err != nil {
 		return err

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+const DEFAULT_MIN_CPU_TEST_VALUE = "Intel Haswell"
+
 func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 	t.Parallel()
 
@@ -323,7 +325,7 @@ func TestAccComputeInstanceTemplate_minCpuPlatform(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_minCpuPlatform(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateHasMinCpuPlatform(&instanceTemplate, "Intel Haswell"),
+					testAccCheckComputeInstanceTemplateHasMinCpuPlatform(&instanceTemplate, DEFAULT_MIN_CPU_TEST_VALUE),
 				),
 			},
 		},
@@ -1037,6 +1039,6 @@ resource "google_compute_instance_template" "foobar" {
 		on_host_maintenance = "TERMINATE"
 	}
 
-	min_cpu_platform = "Intel Haswell"
-}`, i)
+	min_cpu_platform = "%s"
+}`, i, DEFAULT_MIN_CPU_TEST_VALUE)
 }


### PR DESCRIPTION
Fixes #516 

```sh
--- PASS: TestAccComputeInstanceTemplate_minCpuPlatform (24.27s)
--- PASS: TestAccComputeInstanceTemplate_preemptible (24.30s)
--- PASS: TestAccComputeInstanceTemplate_address (24.31s)
--- PASS: TestAccComputeInstanceTemplate_basic (24.33s)
--- PASS: TestAccComputeInstanceTemplate_networkIP (24.33s)
--- PASS: TestAccComputeInstanceTemplate_primaryAliasIpRange (24.33s)
--- PASS: TestAccComputeInstanceTemplate_importBasic (24.33s)
--- PASS: TestAccComputeInstanceTemplate_disks (24.34s)
--- FAIL: TestAccComputeInstanceTemplate_subnet_xpn (0.24s)
```
