### PR TITLE
Add an example of use of shared VPC networking.

### DIFF
--- a/examples/shared-vpc/.gitignore
+++ b/examples/shared-vpc/.gitignore
@@ -1,0 +1,3 @@
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -8,13 +8,11 @@ four projects:
 
 It is based on the diagram in the overview at [https://cloud.google.com/vpc/docs/shared-vpc](https://cloud.google.com/vpc/docs/shared-vpc).
 
-This example creates projects within an organization - to run it, you will need to have an Organization ID.  To get started using Organizations, read the quickstart [here](https://cloud.google.com/resource-manager/docs/quickstart-organizations).  Since it uses organizations, project-specific credentials won't work, and consequently this example is configured to use [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials).  Ensure that the application default credentials have permission to create and manage projects and Shared VPCs (sometimes called 'XPN').
+Begin by [downloading your credentials from Google Cloud Console](https://www.terraform.io/docs/providers/google/#credentials); the default path for the downloaded file is `~/.gcloud/Terraform.json`.  If you use another path, update the `credentials_file_path` variable.  Ensure that these credentials have Organization-level permissions - this example will create and administer projects.
 
-Since projects require globally unique names, you will need to provide a `project_base_id` variable.  Since project names can't be too long, make sure it's short - if it is too long, Terraform won't be able to create the project.
+This example creates projects within an organization - to run it, you will need to have an Organization ID.  To get started using Organizations, read the quickstart [here](https://cloud.google.com/resource-manager/docs/quickstart-organizations).  Since it uses organizations, project-specific credentials won't work, and consequently this example is configured to use [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials).  Ensure that the application default credentials have permission to create and manage projects and Shared VPCs (sometimes called 'XPN').  The example also requires you to specify a billing account, since it does start up a few VMs.
 
-The example allows you to specify a billing account, if you want to ensure that the charges (which are minor) are grouped together.
-
-After you run `terraform apply` on this configuration, it will output the IP address of the second service project's VM, which displays a page checking network connectivity to the other two VMs.
+After you run `terraform apply` on this configuration, it will output the IP address of the second service project's VM, which (after it's done starting up) displays a page checking network connectivity to the other two VMs.
 
 Run with a command like:
 ```
@@ -22,14 +20,5 @@ terraform apply \
         -var="region=us-central1" \
         -var="region_zone=us-central1-f" \
         -var="org_id=1234567" \
-        -var="project_base_id=unique_string"
-```
-
-When you run `terraform destroy` (with the same variables), the projects created by `terraform apply` will not be deleted.  This is for convenience - because deleted projects cannot be recreated with the same name, you would need to create new projects with new globally-unique names for each `terraform apply` / `terraform destroy` pair.  However, you will need to re-import the projects if you wish to rerun `apply` after `destroy` - use commands like these, replacing `$PROJECT_BASE_ID` with the `project_base_id` you used above:
-
-```
-terraform import google_project.host_project host-project-$PROJECT_BASE_ID
-terraform import google_project.service_project_1 service-project-$PROJECT_BASE_ID-1
-terraform import google_project.service_project_2 service-project-$PROJECT_BASE_ID-2
-terraform import google_project.standalone_project standalone-$PROJECT_BASE_ID
+        -var="billing_account_id=XXXXXXXXXXXX"
 ```

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -1,0 +1,35 @@
+# Shared Virtual Private Cloud Networking in Google Cloud
+
+This is a template showcasing the shared VPC feature in Google Cloud.  It features
+four projects:
+- A host project, which owns a VPC
+- Two service projects, each of which owns a VM connected to the VPC
+- A fourth project, which owns a VM not connected to the VPC.
+
+It is based on the diagram in the overview at [https://cloud.google.com/vpc/docs/shared-vpc](https://cloud.google.com/vpc/docs/shared-vpc).
+
+This example creates projects within an organization - to run it, you will need to have an Organization ID.  To get started using Organizations, read the quickstart [here](https://cloud.google.com/resource-manager/docs/quickstart-organizations).  Since it uses organizations, project-specific credentials won't work, and consequently this example is configured to use [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials).  Ensure that the application default credentials have permission to create and manage projects and Shared VPCs (sometimes called 'XPN').
+
+Since projects require globally unique names, you will need to provide a `project_base_id` variable.  Since project names can't be too long, make sure it's short - if it is too long, Terraform won't be able to create the project.
+
+The example allows you to specify a billing account, if you want to ensure that the charges (which are minor) are grouped together.
+
+After you run `terraform apply` on this configuration, it will output the IP address of the second service project's VM, which displays a page checking network connectivity to the other two VMs.
+
+Run with a command like:
+```
+terraform apply \
+        -var="region=us-central1" \
+        -var="region_zone=us-central1-f" \
+        -var="org_id=1234567" \
+        -var="project_base_id=unique_string"
+```
+
+When you run `terraform destroy` (with the same variables), the projects created by `terraform apply` will not be deleted.  This is for convenience - because deleted projects cannot be recreated with the same name, you would need to create new projects with new globally-unique names for each `terraform apply` / `terraform destroy` pair.  However, you will need to re-import the projects if you wish to rerun `apply` after `destroy` - use commands like these, replacing `$PROJECT_BASE_ID` with the `project_base_id` you used above:
+
+```
+terraform import google_project.host_project host-project-$PROJECT_BASE_ID
+terraform import google_project.service_project_1 service-project-$PROJECT_BASE_ID-1
+terraform import google_project.service_project_2 service-project-$PROJECT_BASE_ID-2
+terraform import google_project.standalone_project standalone-$PROJECT_BASE_ID
+```

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -84,6 +84,24 @@ resource "google_compute_network" "shared_network" {
   name                    = "shared-network"
   auto_create_subnetworks = "true"
   project                 = "${google_compute_shared_vpc_host_project.host_project.project}"
+
+  depends_on = ["google_compute_shared_vpc_service_project.service_project_1",
+    "google_compute_shared_vpc_service_project.service_project_2",
+  ]
+}
+
+resource "google_compute_firewall" "shared_network" {
+  name    = "allow-ssh-and-icmp"
+  network = "${google_compute_network.shared_network.self_link}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80"]
+  }
 }
 
 resource "google_compute_network" "standalone_network" {
@@ -93,18 +111,35 @@ resource "google_compute_network" "standalone_network" {
   depends_on              = ["google_project_service.standalone_project"]
 }
 
+resource "google_compute_firewall" "standalone_network" {
+  name    = "allow-ssh-and-icmp"
+  network = "${google_compute_network.standalone_network.self_link}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80"]
+  }
+
+  project = "${google_project.standalone_project.project_id}"
+}
+
 resource "google_compute_instance" "project_1_vm" {
   name         = "tf-project-1-vm"
   project      = "${google_project.service_project_1.project_id}"
   machine_type = "f1-micro"
   zone         = "${var.region_zone}"
-  tags         = ["http-tag"]
 
   boot_disk {
     initialize_params {
       image = "projects/debian-cloud/global/images/family/debian-8"
     }
   }
+
+  metadata_startup_script = "VM_NAME=VM1\n${file("scripts/install-vm.sh")}"
 
   network_interface {
     network = "${google_compute_network.shared_network.self_link}"
@@ -126,13 +161,20 @@ resource "google_compute_instance" "project_2_vm" {
   machine_type = "f1-micro"
   project      = "${google_project.service_project_2.project_id}"
   zone         = "${var.region_zone}"
-  tags         = ["http-tag"]
 
   boot_disk {
     initialize_params {
       image = "projects/debian-cloud/global/images/family/debian-8"
     }
   }
+
+  metadata_startup_script = <<EOF
+VM1_EXT_IP=${google_compute_instance.project_1_vm.network_interface.0.access_config.0.assigned_nat_ip}
+ST_VM_EXT_IP=${google_compute_instance.standalone_project_vm.network_interface.0.access_config.0.assigned_nat_ip}
+VM1_INT_IP=${google_compute_instance.project_1_vm.network_interface.0.address}
+ST_VM_INT_IP=${google_compute_instance.standalone_project_vm.network_interface.0.address}
+${file("scripts/install-network-page.sh")}
+EOF
 
   network_interface {
     network = "${google_compute_network.shared_network.self_link}"
@@ -154,13 +196,14 @@ resource "google_compute_instance" "standalone_project_vm" {
   machine_type = "f1-micro"
   project      = "${google_project.standalone_project.project_id}"
   zone         = "${var.region_zone}"
-  tags         = ["http-tag"]
 
   boot_disk {
     initialize_params {
       image = "projects/debian-cloud/global/images/family/debian-8"
     }
   }
+
+  metadata_startup_script = "VM_NAME=standalone\n${file("scripts/install-vm.sh")}"
 
   network_interface {
     network = "${google_compute_network.standalone_network.self_link}"
@@ -175,17 +218,4 @@ resource "google_compute_instance" "standalone_project_vm" {
   }
 
   depends_on = ["google_project_service.standalone_project"]
-}
-
-resource "google_compute_firewall" "default" {
-  name    = "tf-www-firewall-allow-internal-only"
-  network = "default"
-
-  allow {
-    protocol = "tcp"
-    ports    = ["80"]
-  }
-
-  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = ["http-tag"]
 }

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -1,0 +1,191 @@
+# https://cloud.google.com/vpc/docs/shared-vpc
+
+provider "google" {
+  region  = "${var.region}"
+  project = "host-project-${var.project_base_id}"
+}
+
+resource "google_project" "host_project" {
+  name            = "Host Project"
+  project_id      = "host-project-${var.project_base_id}"
+  org_id          = "${var.org_id}"
+  billing_account = "${var.billing_account_id}"
+  skip_delete     = "true"
+}
+
+resource "google_project" "service_project_1" {
+  name            = "Service Project 1"
+  project_id      = "service-project-${var.project_base_id}-1"
+  org_id          = "${var.org_id}"
+  billing_account = "${var.billing_account_id}"
+  skip_delete     = "true"
+}
+
+resource "google_project" "service_project_2" {
+  name            = "Service Project 2"
+  project_id      = "service-project-${var.project_base_id}-2"
+  org_id          = "${var.org_id}"
+  billing_account = "${var.billing_account_id}"
+  skip_delete     = "true"
+}
+
+resource "google_project" "standalone_project" {
+  name            = "Standalone Project"
+  project_id      = "standalone-${var.project_base_id}"
+  org_id          = "${var.org_id}"
+  billing_account = "${var.billing_account_id}"
+  skip_delete     = "true"
+}
+
+resource "google_project_service" "host_project" {
+  project = "${google_project.host_project.project_id}"
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "service_project_1" {
+  project = "${google_project.service_project_1.project_id}"
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "service_project_2" {
+  project = "${google_project.service_project_2.project_id}"
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "standalone_project" {
+  project = "${google_project.standalone_project.project_id}"
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_shared_vpc_host_project" "host_project" {
+  project    = "${google_project.host_project.project_id}"
+  depends_on = ["google_project_service.host_project"]
+}
+
+resource "google_compute_shared_vpc_service_project" "service_project_1" {
+  host_project    = "${google_project.host_project.project_id}"
+  service_project = "${google_project.service_project_1.project_id}"
+
+  depends_on = ["google_compute_shared_vpc_host_project.host_project",
+    "google_project_service.service_project_1",
+  ]
+}
+
+resource "google_compute_shared_vpc_service_project" "service_project_2" {
+  host_project    = "${google_project.host_project.project_id}"
+  service_project = "${google_project.service_project_2.project_id}"
+
+  depends_on = ["google_compute_shared_vpc_host_project.host_project",
+    "google_project_service.service_project_2",
+  ]
+}
+
+resource "google_compute_network" "shared_network" {
+  name                    = "shared-network"
+  auto_create_subnetworks = "true"
+  project                 = "${google_compute_shared_vpc_host_project.host_project.project}"
+}
+
+resource "google_compute_network" "standalone_network" {
+  name                    = "standalone-network"
+  auto_create_subnetworks = "true"
+  project                 = "${google_project.standalone_project.project_id}"
+  depends_on              = ["google_project_service.standalone_project"]
+}
+
+resource "google_compute_instance" "project_1_vm" {
+  name         = "tf-project-1-vm"
+  project      = "${google_project.service_project_1.project_id}"
+  machine_type = "f1-micro"
+  zone         = "${var.region_zone}"
+  tags         = ["http-tag"]
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-8"
+    }
+  }
+
+  network_interface {
+    network = "${google_compute_network.shared_network.self_link}"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+
+  depends_on = ["google_project_service.service_project_1"]
+}
+
+resource "google_compute_instance" "project_2_vm" {
+  name         = "tf-project-2-vm"
+  machine_type = "f1-micro"
+  project      = "${google_project.service_project_2.project_id}"
+  zone         = "${var.region_zone}"
+  tags         = ["http-tag"]
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-8"
+    }
+  }
+
+  network_interface {
+    network = "${google_compute_network.shared_network.self_link}"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+
+  depends_on = ["google_project_service.service_project_2"]
+}
+
+resource "google_compute_instance" "standalone_project_vm" {
+  name         = "tf-standalone-vm"
+  machine_type = "f1-micro"
+  project      = "${google_project.standalone_project.project_id}"
+  zone         = "${var.region_zone}"
+  tags         = ["http-tag"]
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-8"
+    }
+  }
+
+  network_interface {
+    network = "${google_compute_network.standalone_network.self_link}"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+
+  depends_on = ["google_project_service.standalone_project"]
+}
+
+resource "google_compute_firewall" "default" {
+  name    = "tf-www-firewall-allow-internal-only"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["http-tag"]
+}

--- a/examples/shared-vpc/output.tf
+++ b/examples/shared-vpc/output.tf
@@ -1,0 +1,3 @@
+output "application_public_ip" {
+  value = "1"
+}

--- a/examples/shared-vpc/output.tf
+++ b/examples/shared-vpc/output.tf
@@ -1,3 +1,3 @@
-output "application_public_ip" {
-  value = "1"
+output "status_page_public_ip" {
+  value = "${google_compute_instance.project_2_vm.network_interface.0.access_config.0.assigned_nat_ip}"
 }

--- a/examples/shared-vpc/scripts/install-network-page.sh
+++ b/examples/shared-vpc/scripts/install-network-page.sh
@@ -1,0 +1,46 @@
+sudo apt-get update
+sudo apt-get install apache2 -y
+sudo a2ensite default-ssl
+sudo a2enmod ssl
+sudo service apache2 restart
+sudo cat > /var/www/html/index.html << EOF
+<!doctype html><html><body>
+<h1>Network Status for Shared VPC Terraform/Google Cloud Example</h1>
+<h2>VM 1</h2>
+<h3>Internal IP: $VM1_INT_IP</h3>
+<pre>
+$ ping -c 4 -W 1 $VM1_INT_IP
+$(ping -c 4 -W 1 $VM1_INT_IP)
+
+$ curl $VM1_INT_IP
+$(curl $VM1_INT_IP)
+</pre>
+<h3>External IP: $VM1_EXT_IP</h3>
+<pre>
+$ ping -c 4 -W 1 $VM1_EXT_IP
+$(ping -c 4 -W 1 $VM1_EXT_IP)
+
+$ curl $VM1_EXT_IP
+$(curl $VM1_EXT_IP)
+</pre>
+<h2>Standalone VM</h2>
+<h3>Internal IP: $ST_VM_INT_IP</h3>
+$(if [ $ST_VM_INT_IP = $VM1_INT_IP ]; then echo "<h4>Same internal IP as VM1</h4>"; fi)
+<pre>
+$ ping -c 4 -W 1 $ST_VM_INT_IP
+$(ping -c 4 -W 1 $ST_VM_INT_IP)
+
+$ curl $ST_VM_INT_IP
+$(curl $ST_VM_INT_IP)
+</pre>
+<h3>External IP: $ST_VM_EXT_IP</h3>
+<pre>
+$ ping -c 4 -W 1 $ST_VM_EXT_IP
+$(ping -c 4 -W 1 $ST_VM_EXT_IP)
+
+$ curl $ST_VM_EXT_IP
+$(curl $ST_VM_EXT_IP)
+</pre>
+</body></html>
+
+EOF

--- a/examples/shared-vpc/scripts/install-vm.sh
+++ b/examples/shared-vpc/scripts/install-vm.sh
@@ -1,0 +1,6 @@
+sudo apt-get update
+sudo apt-get install apache2 -y
+sudo a2ensite default-ssl
+sudo a2enmod ssl
+sudo service apache2 restart
+echo "This is $VM_NAME" | sudo tee /var/www/html/index.html

--- a/examples/shared-vpc/terraform.tfvars.example
+++ b/examples/shared-vpc/terraform.tfvars.example
@@ -1,0 +1,4 @@
+region = "us-central1"
+region_zone = "us-central1-b"
+project_name = "my-project-id-123"
+credentials_file_path = "~/.gcloud/Terraform.json"

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -8,7 +8,6 @@ variable "region_zone" {
 
 variable "project_base_id" {
   description = "A string to use in the middle of the generated project names.  If you delete a project, its name cannot be used again, so if you run this example repeatedly, you might need to modify this."
-  default     = "ex-vpc"
 }
 
 variable "org_id" {

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -6,15 +6,15 @@ variable "region_zone" {
   default = "us-central1-f"
 }
 
-variable "project_base_id" {
-  description = "A string to use in the middle of the generated project names.  If you delete a project, its name cannot be used again, so if you run this example repeatedly, you might need to modify this."
-}
-
 variable "org_id" {
   description = "The ID of the Google Cloud Organization."
 }
 
 variable "billing_account_id" {
   description = "The ID of the associated billing account (optional)."
-  default     = ""
+}
+
+variable "credentials_file_path" {
+  description = "Location of the credentials to use."
+  default = "~/.gcloud/Terraform.json"
 }

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  default = "us-central1"
+}
+
+variable "region_zone" {
+  default = "us-central1-f"
+}
+
+variable "project_base_id" {
+  description = "A string to use in the middle of the generated project names.  If you delete a project, its name cannot be used again, so if you run this example repeatedly, you might need to modify this."
+  default     = "ex-vpc"
+}
+
+variable "org_id" {
+  description = "The ID of the Google Cloud Organization."
+}
+
+variable "billing_account_id" {
+  description = "The ID of the associated billing account (optional)."
+  default     = ""
+}


### PR DESCRIPTION
The example brings up four projects:
  - one to host the VPC
  - two to use the VPC
  - one which is outside the VPC

This is based on the diagram in https://cloud.google.com/vpc/docs/shared-vpc and uses the names from there (where possible) for clarity.

It eventually outputs an IP address - on that page you can see a demonstration that one of the VMs on the VPC can ping another VM on the same VPC (but in a different project) using the internal IP.

The page looks like this:
![terraform-cloud-page](https://user-images.githubusercontent.com/605324/33407793-db56a8e4-d527-11e7-9f01-4842640baefc.png)

This is my first contribution to this project, so please let me know if I'm missing something.  I've run `terraform fmt` and I've tested this on my account, but that's about it.  :)