### PR TITLE
Remove all instances of GOOGLE_XPN_HOST_PROJECT environment variable.

### DIFF
--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -325,7 +325,7 @@ func TestAccComputeInstanceTemplate_minCpuPlatform(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_minCpuPlatform(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasMinCpuPlatform(&instanceTemplate, DEFAULT_MIN_CPU_TEST_VALUE),
 				),
 			},

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -28,7 +28,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
@@ -53,7 +53,7 @@ func TestAccComputeInstanceTemplate_preemptible(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_preemptible(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateAutomaticRestart(&instanceTemplate, false),
 					testAccCheckComputeInstanceTemplatePreemptible(&instanceTemplate, true),
 				),
@@ -76,7 +76,7 @@ func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_ip(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 				),
 			},
@@ -99,7 +99,7 @@ func TestAccComputeInstanceTemplate_networkIP(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_networkIP(networkIP),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetworkIP(
 						"google_compute_instance_template.foobar", networkIP, &instanceTemplate),
@@ -123,7 +123,7 @@ func TestAccComputeInstanceTemplate_address(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_address(address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 					testAccCheckComputeInstanceTemplateAddress(
 						"google_compute_instance_template.foobar", address, &instanceTemplate),
@@ -147,7 +147,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_disks(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
@@ -171,7 +171,7 @@ func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_subnet_auto(network),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetworkName(&instanceTemplate, network),
 				),
 			},
@@ -193,7 +193,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_subnet_custom(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
 				),
 			},
@@ -217,7 +217,7 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists(
+					testAccCheckComputeInstanceTemplateExistsInProject(
 						"google_compute_instance_template.foobar", fmt.Sprintf("%s-service", projectName),
 						&instanceTemplate),
 					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
@@ -241,7 +241,7 @@ func TestAccComputeInstanceTemplate_metadata_startup_script(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_startup_script(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateStartupScript(&instanceTemplate, "echo 'Hello'"),
 				),
 			},
@@ -261,7 +261,7 @@ func TestAccComputeInstanceTemplate_primaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_primaryAliasIpRange(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasAliasIpRange(&instanceTemplate, "", "/24"),
 				),
 			},
@@ -282,7 +282,7 @@ func TestAccComputeInstanceTemplate_secondaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_secondaryAliasIpRange(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasAliasIpRange(&instanceTemplate, "inst-test-secondary", "/24"),
 				),
 			},
@@ -303,7 +303,7 @@ func TestAccComputeInstanceTemplate_guestAccelerator(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_guestAccelerator(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasGuestAccelerator(&instanceTemplate, "nvidia-tesla-k80", 1),
 				),
 			},
@@ -325,7 +325,7 @@ func TestAccComputeInstanceTemplate_minCpuPlatform(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_minCpuPlatform(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasMinCpuPlatform(&instanceTemplate, DEFAULT_MIN_CPU_TEST_VALUE),
 				),
 			},
@@ -351,7 +351,11 @@ func testAccCheckComputeInstanceTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeInstanceTemplateExists(n, p string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+func testAccCheckComputeInstanceTemplateExists(n string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return testAccCheckComputeInstanceTemplateExistsInProject(n, getTestProjectFromEnv(), instanceTemplate)
+}
+
+func testAccCheckComputeInstanceTemplateExistsInProject(n, p string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -26,7 +26,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
@@ -51,7 +51,7 @@ func TestAccComputeInstanceTemplate_preemptible(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_preemptible(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateAutomaticRestart(&instanceTemplate, false),
 					testAccCheckComputeInstanceTemplatePreemptible(&instanceTemplate, true),
 				),
@@ -74,7 +74,7 @@ func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_ip(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 				),
 			},
@@ -97,7 +97,7 @@ func TestAccComputeInstanceTemplate_networkIP(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_networkIP(networkIP),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetworkIP(
 						"google_compute_instance_template.foobar", networkIP, &instanceTemplate),
@@ -121,7 +121,7 @@ func TestAccComputeInstanceTemplate_address(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_address(address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
 					testAccCheckComputeInstanceTemplateAddress(
 						"google_compute_instance_template.foobar", address, &instanceTemplate),
@@ -145,7 +145,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_disks(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
@@ -169,7 +169,7 @@ func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_subnet_auto(network),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetworkName(&instanceTemplate, network),
 				),
 			},
@@ -191,7 +191,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_subnet_custom(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
 				),
 			},
@@ -215,7 +215,7 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExistsInProject(
+					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", fmt.Sprintf("%s-service", projectName),
 						&instanceTemplate),
 					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
@@ -239,7 +239,7 @@ func TestAccComputeInstanceTemplate_metadata_startup_script(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_startup_script(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
-						"google_compute_instance_template.foobar", &instanceTemplate),
+						"google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateStartupScript(&instanceTemplate, "echo 'Hello'"),
 				),
 			},
@@ -259,7 +259,7 @@ func TestAccComputeInstanceTemplate_primaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_primaryAliasIpRange(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasAliasIpRange(&instanceTemplate, "", "/24"),
 				),
 			},
@@ -280,7 +280,7 @@ func TestAccComputeInstanceTemplate_secondaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_secondaryAliasIpRange(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasAliasIpRange(&instanceTemplate, "inst-test-secondary", "/24"),
 				),
 			},
@@ -301,7 +301,7 @@ func TestAccComputeInstanceTemplate_guestAccelerator(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstanceTemplate_guestAccelerator(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateExists("google_compute_instance_template.foobar", getTestProjectFromEnv(), &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasGuestAccelerator(&instanceTemplate, "nvidia-tesla-k80", 1),
 				),
 			},
@@ -328,7 +328,7 @@ func testAccCheckComputeInstanceTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeInstanceTemplateExistsInProject(n, p string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+func testAccCheckComputeInstanceTemplateExists(n, p string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -343,35 +343,6 @@ func testAccCheckComputeInstanceTemplateExistsInProject(n, p string, instanceTem
 
 		found, err := config.clientCompute.InstanceTemplates.Get(
 			p, rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != rs.Primary.ID {
-			return fmt.Errorf("Instance template not found")
-		}
-
-		*instanceTemplate = *found
-
-		return nil
-	}
-}
-
-func testAccCheckComputeInstanceTemplateExists(n string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		found, err := config.clientCompute.InstanceTemplates.Get(
-			config.Project, rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -28,7 +28,7 @@ func TestAccComputeInstance_basic1(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasInstanceId(&instance, "google_compute_instance.foobar"),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceLabel(&instance, "my_key", "my_value"),
@@ -56,7 +56,7 @@ func TestAccComputeInstance_basic2(t *testing.T) {
 				Config: testAccComputeInstance_basic2(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -81,7 +81,7 @@ func TestAccComputeInstance_basic3(t *testing.T) {
 				Config: testAccComputeInstance_basic3(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -106,7 +106,7 @@ func TestAccComputeInstance_basic4(t *testing.T) {
 				Config: testAccComputeInstance_basic4(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -131,7 +131,7 @@ func TestAccComputeInstance_basic5(t *testing.T) {
 				Config: testAccComputeInstance_basic5(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -157,7 +157,7 @@ func TestAccComputeInstance_IP(t *testing.T) {
 				Config: testAccComputeInstance_ip(ipName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceAccessConfigHasIP(&instance),
 				),
 			},
@@ -178,7 +178,7 @@ func TestAccComputeInstance_GenerateIP(t *testing.T) {
 				Config: testAccComputeInstance_generateIp(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceAccessConfigHasIP(&instance),
 					testAccCheckComputeInstanceHasAssignedIP,
 				),
@@ -218,7 +218,7 @@ func TestAccComputeInstance_diskEncryption(t *testing.T) {
 				Config: testAccComputeInstance_disks_encryption(bootEncryptionKey, diskNameToEncryptionKey, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDiskEncryptionKey("google_compute_instance.foobar", &instance, bootEncryptionKeyHash, diskNameToEncryptionKey),
 				),
 			},
@@ -242,7 +242,7 @@ func TestAccComputeInstance_attachedDisk(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -266,7 +266,7 @@ func TestAccComputeInstance_attachedDisk_sourceUrl(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk_sourceUrl(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -291,7 +291,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -300,7 +300,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_addAttachedDisk(diskName, diskName2, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 					testAccCheckComputeInstanceDisk(&instance, diskName2, false, false),
 				),
@@ -310,7 +310,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_detachDisk(diskName, diskName2, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -319,7 +319,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_updateAttachedDiskEncryptionKey(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -343,7 +343,7 @@ func TestAccComputeInstance_bootDisk_source(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_source(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceBootDisk(&instance, diskName),
 				),
 			},
@@ -367,7 +367,7 @@ func TestAccComputeInstance_bootDisk_sourceUrl(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_sourceUrl(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceBootDisk(&instance, diskName),
 				),
 			},
@@ -391,7 +391,7 @@ func TestAccComputeInstance_bootDisk_type(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_type(instanceName, diskType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceBootDiskType(instanceName, diskType),
 				),
 			},
@@ -414,7 +414,7 @@ func TestAccComputeInstance_scratchDisk(t *testing.T) {
 				Config: testAccComputeInstance_scratchDisk(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.scratch", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.scratch", &instance),
 					testAccCheckComputeInstanceScratchDisk(&instance, []string{"NVME", "SCSI"}),
 				),
 			},
@@ -437,14 +437,14 @@ func TestAccComputeInstance_forceNewAndChangeMetadata(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 				),
 			},
 			resource.TestStep{
 				Config: testAccComputeInstance_forceNewAndChangeMetadata(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceMetadata(
 						&instance, "qux", "true"),
 				),
@@ -468,14 +468,14 @@ func TestAccComputeInstance_update(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 				),
 			},
 			resource.TestStep{
 				Config: testAccComputeInstance_update(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceMetadata(
 						&instance, "bar", "baz"),
 					testAccCheckComputeInstanceLabel(&instance, "only_me", "nothing_else"),
@@ -502,7 +502,7 @@ func TestAccComputeInstance_service_account(t *testing.T) {
 				Config: testAccComputeInstance_service_account(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceServiceAccount(&instance,
 						"https://www.googleapis.com/auth/compute.readonly"),
 					testAccCheckComputeInstanceServiceAccount(&instance,
@@ -530,7 +530,7 @@ func TestAccComputeInstance_scheduling(t *testing.T) {
 				Config: testAccComputeInstance_scheduling(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 				),
 			},
 		},
@@ -552,7 +552,7 @@ func TestAccComputeInstance_subnet_auto(t *testing.T) {
 				Config: testAccComputeInstance_subnet_auto(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
 				),
 			},
@@ -575,7 +575,7 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 				Config: testAccComputeInstance_subnet_custom(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
 				),
 			},
@@ -600,7 +600,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_subnet_xpn(org, billingId, projectName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
+					testAccCheckComputeInstanceExistsInProject(
 						"google_compute_instance.foobar", fmt.Sprintf("%s-service", projectName),
 						&instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
@@ -625,7 +625,7 @@ func TestAccComputeInstance_address_auto(t *testing.T) {
 				Config: testAccComputeInstance_address_auto(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasAnyAddress(&instance),
 				),
 			},
@@ -648,7 +648,7 @@ func TestAccComputeInstance_address_custom(t *testing.T) {
 				Config: testAccComputeInstance_address_custom(instanceName, address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasAddress(&instance, address),
 				),
 			},
@@ -674,7 +674,7 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 				Config: testAccComputeInstance_private_image_family(diskName, imageName, familyName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+						"google_compute_instance.foobar", &instance),
 				),
 			},
 		},
@@ -695,7 +695,7 @@ func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceUpdateMachineType("google_compute_instance.foobar"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -720,7 +720,7 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_multiNic(instanceName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasMultiNic(&instance),
 				),
 			},
@@ -742,7 +742,7 @@ func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_guestAccelerator(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasGuestAccelerator(&instance, "nvidia-tesla-k80", 1),
 				),
 			},
@@ -765,7 +765,7 @@ func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_minCpuPlatform(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasMinCpuPlatform(&instance, "Intel Haswell"),
 				),
 			},
@@ -787,7 +787,7 @@ func TestAccComputeInstance_primaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_primaryAliasIpRange(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "", "/24"),
 				),
 			},
@@ -809,7 +809,7 @@ func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_secondaryAliasIpRange(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "inst-test-secondary", "172.16.0.0/24"),
 				),
 			},
@@ -874,7 +874,11 @@ func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeInstanceExists(n, p string, instance *compute.Instance) resource.TestCheckFunc {
+func testAccCheckComputeInstanceExists(n string, instance *compute.Instance) resource.TestCheckFunc {
+	return testAccCheckComputeInstanceExistsInProject(n, getTestProjectFromEnv(), instance)
+}
+
+func testAccCheckComputeInstanceExistsInProject(n, p string, instance *compute.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -28,7 +28,7 @@ func TestAccComputeInstance_basic1(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasInstanceId(&instance, "google_compute_instance.foobar"),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceLabel(&instance, "my_key", "my_value"),
@@ -56,7 +56,7 @@ func TestAccComputeInstance_basic2(t *testing.T) {
 				Config: testAccComputeInstance_basic2(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -81,7 +81,7 @@ func TestAccComputeInstance_basic3(t *testing.T) {
 				Config: testAccComputeInstance_basic3(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -106,7 +106,7 @@ func TestAccComputeInstance_basic4(t *testing.T) {
 				Config: testAccComputeInstance_basic4(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -131,7 +131,7 @@ func TestAccComputeInstance_basic5(t *testing.T) {
 				Config: testAccComputeInstance_basic5(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceTag(&instance, "foo"),
 					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
@@ -157,7 +157,7 @@ func TestAccComputeInstance_IP(t *testing.T) {
 				Config: testAccComputeInstance_ip(ipName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceAccessConfigHasIP(&instance),
 				),
 			},
@@ -178,7 +178,7 @@ func TestAccComputeInstance_GenerateIP(t *testing.T) {
 				Config: testAccComputeInstance_generateIp(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceAccessConfigHasIP(&instance),
 					testAccCheckComputeInstanceHasAssignedIP,
 				),
@@ -218,7 +218,7 @@ func TestAccComputeInstance_diskEncryption(t *testing.T) {
 				Config: testAccComputeInstance_disks_encryption(bootEncryptionKey, diskNameToEncryptionKey, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDiskEncryptionKey("google_compute_instance.foobar", &instance, bootEncryptionKeyHash, diskNameToEncryptionKey),
 				),
 			},
@@ -242,7 +242,7 @@ func TestAccComputeInstance_attachedDisk(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -266,7 +266,7 @@ func TestAccComputeInstance_attachedDisk_sourceUrl(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk_sourceUrl(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -291,7 +291,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_attachedDisk(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -300,7 +300,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_addAttachedDisk(diskName, diskName2, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 					testAccCheckComputeInstanceDisk(&instance, diskName2, false, false),
 				),
@@ -310,7 +310,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_detachDisk(diskName, diskName2, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -319,7 +319,7 @@ func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 				Config: testAccComputeInstance_updateAttachedDiskEncryptionKey(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
 				),
 			},
@@ -343,7 +343,7 @@ func TestAccComputeInstance_bootDisk_source(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_source(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceBootDisk(&instance, diskName),
 				),
 			},
@@ -367,7 +367,7 @@ func TestAccComputeInstance_bootDisk_sourceUrl(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_sourceUrl(diskName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceBootDisk(&instance, diskName),
 				),
 			},
@@ -391,7 +391,7 @@ func TestAccComputeInstance_bootDisk_type(t *testing.T) {
 				Config: testAccComputeInstance_bootDisk_type(instanceName, diskType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceBootDiskType(instanceName, diskType),
 				),
 			},
@@ -414,7 +414,7 @@ func TestAccComputeInstance_scratchDisk(t *testing.T) {
 				Config: testAccComputeInstance_scratchDisk(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.scratch", &instance),
+						"google_compute_instance.scratch", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceScratchDisk(&instance, []string{"NVME", "SCSI"}),
 				),
 			},
@@ -437,14 +437,14 @@ func TestAccComputeInstance_forceNewAndChangeMetadata(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 				),
 			},
 			resource.TestStep{
 				Config: testAccComputeInstance_forceNewAndChangeMetadata(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceMetadata(
 						&instance, "qux", "true"),
 				),
@@ -468,14 +468,14 @@ func TestAccComputeInstance_update(t *testing.T) {
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 				),
 			},
 			resource.TestStep{
 				Config: testAccComputeInstance_update(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceMetadata(
 						&instance, "bar", "baz"),
 					testAccCheckComputeInstanceLabel(&instance, "only_me", "nothing_else"),
@@ -502,7 +502,7 @@ func TestAccComputeInstance_service_account(t *testing.T) {
 				Config: testAccComputeInstance_service_account(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceServiceAccount(&instance,
 						"https://www.googleapis.com/auth/compute.readonly"),
 					testAccCheckComputeInstanceServiceAccount(&instance,
@@ -530,7 +530,7 @@ func TestAccComputeInstance_scheduling(t *testing.T) {
 				Config: testAccComputeInstance_scheduling(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 				),
 			},
 		},
@@ -552,7 +552,7 @@ func TestAccComputeInstance_subnet_auto(t *testing.T) {
 				Config: testAccComputeInstance_subnet_auto(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
 				),
 			},
@@ -575,7 +575,7 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 				Config: testAccComputeInstance_subnet_custom(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
 				),
 			},
@@ -600,7 +600,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_subnet_xpn(org, billingId, projectName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExistsInProject(
+					testAccCheckComputeInstanceExists(
 						"google_compute_instance.foobar", fmt.Sprintf("%s-service", projectName),
 						&instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
@@ -625,7 +625,7 @@ func TestAccComputeInstance_address_auto(t *testing.T) {
 				Config: testAccComputeInstance_address_auto(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasAnyAddress(&instance),
 				),
 			},
@@ -648,7 +648,7 @@ func TestAccComputeInstance_address_custom(t *testing.T) {
 				Config: testAccComputeInstance_address_custom(instanceName, address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasAddress(&instance, address),
 				),
 			},
@@ -674,7 +674,7 @@ func TestAccComputeInstance_private_image_family(t *testing.T) {
 				Config: testAccComputeInstance_private_image_family(diskName, imageName, familyName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
-						"google_compute_instance.foobar", &instance),
+						"google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 				),
 			},
 		},
@@ -695,7 +695,7 @@ func TestAccComputeInstance_forceChangeMachineTypeManually(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceUpdateMachineType("google_compute_instance.foobar"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -720,7 +720,7 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_multiNic(instanceName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasMultiNic(&instance),
 				),
 			},
@@ -742,7 +742,7 @@ func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_guestAccelerator(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasGuestAccelerator(&instance, "nvidia-tesla-k80", 1),
 				),
 			},
@@ -765,7 +765,7 @@ func TestAccComputeInstance_minCpuPlatform(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_minCpuPlatform(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasMinCpuPlatform(&instance, "Intel Haswell"),
 				),
 			},
@@ -787,7 +787,7 @@ func TestAccComputeInstance_primaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_primaryAliasIpRange(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "", "/24"),
 				),
 			},
@@ -809,7 +809,7 @@ func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeInstance_secondaryAliasIpRange(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists("google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceExists("google_compute_instance.foobar", getTestProjectFromEnv(), &instance),
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "inst-test-secondary", "172.16.0.0/24"),
 				),
 			},
@@ -874,7 +874,7 @@ func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeInstanceExistsInProject(n, p string, instance *compute.Instance) resource.TestCheckFunc {
+func testAccCheckComputeInstanceExists(n, p string, instance *compute.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -889,35 +889,6 @@ func testAccCheckComputeInstanceExistsInProject(n, p string, instance *compute.I
 
 		found, err := config.clientCompute.Instances.Get(
 			p, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != rs.Primary.ID {
-			return fmt.Errorf("Instance not found")
-		}
-
-		*instance = *found
-
-		return nil
-	}
-}
-
-func testAccCheckComputeInstanceExists(n string, instance *compute.Instance) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		found, err := config.clientCompute.Instances.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Instead of GOOGLE_XPN_HOST_PROJECT being required to run some tests, I added the ability to create and tear down the necessary project structure.  This allows us to remove one environment variable, and use two others which are already widely-required: org and billing ID.

After this PR, no instances of GOOGLE_XPN_HOST_PROJECT appear in the repository.  This closes #715.