### PR TITLE
Enable 'zone' to be specified at the provider level instead of per-resource.

### DIFF
--- a/examples/content-based-load-balancing/main.tf
+++ b/examples/content-based-load-balancing/main.tf
@@ -4,12 +4,12 @@ provider "google" {
   region      = "${var.region}"
   project     = "${var.project_name}"
   credentials = "${file("${var.credentials_file_path}")}"
+  zone        = "${var.region_zone}"
 }
 
 resource "google_compute_instance" "www" {
   name         = "tf-www-compute"
   machine_type = "f1-micro"
-  zone         = "${var.region_zone}"
   tags         = ["http-tag"]
 
   boot_disk {
@@ -36,7 +36,6 @@ resource "google_compute_instance" "www" {
 resource "google_compute_instance" "www-video" {
   name         = "tf-www-video-compute"
   machine_type = "f1-micro"
-  zone         = "${var.region_zone}"
   tags         = ["http-tag"]
 
   boot_disk {
@@ -66,7 +65,6 @@ resource "google_compute_global_address" "external-address" {
 
 resource "google_compute_instance_group" "www-resources" {
   name = "tf-www-resources"
-  zone = "${var.region_zone}"
 
   instances = ["${google_compute_instance.www.self_link}"]
 
@@ -78,7 +76,6 @@ resource "google_compute_instance_group" "www-resources" {
 
 resource "google_compute_instance_group" "video-resources" {
   name = "tf-video-resources"
-  zone = "${var.region_zone}"
 
   instances = ["${google_compute_instance.www-video.self_link}"]
 

--- a/google/config.go
+++ b/google/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Credentials string
 	Project     string
 	Region      string
+	Zone        string
 
 	clientBilling                *cloudbilling.Service
 	clientCompute                *compute.Service

--- a/google/data_source_google_compute_instance_group.go
+++ b/google/data_source_google_compute_instance_group.go
@@ -17,7 +17,7 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 
 			"zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"project": {
@@ -74,7 +74,11 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 }
 
 func dataSourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
-	zone := d.Get("zone").(string)
+
+	zone, err := getZone(d, meta.(*Config))
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 
 	d.SetId(fmt.Sprintf("%s/%s", zone, name))

--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -17,7 +17,7 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 			},
 			"zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"latest_master_version": {
 				Type:     schema.TypeString,
@@ -49,7 +49,10 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, meta.(*Config))
+	if err != nil {
+		return err
+	}
 
 	resp, err := config.clientContainer.Projects.Zones.GetServerconfig(project, zone).Do()
 	if err != nil {

--- a/google/provider.go
+++ b/google/provider.go
@@ -49,7 +49,7 @@ func Provider() terraform.ResourceProvider {
 
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"GOOGLE_ZONE",
 					"GCLOUD_ZONE",

--- a/google/provider.go
+++ b/google/provider.go
@@ -46,6 +46,16 @@ func Provider() terraform.ResourceProvider {
 					"CLOUDSDK_COMPUTE_REGION",
 				}, nil),
 			},
+
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"GOOGLE_ZONE",
+					"GCLOUD_ZONE",
+					"CLOUDSDK_COMPUTE_ZONE",
+				}, nil),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -167,6 +177,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Credentials: credentials,
 		Project:     d.Get("project").(string),
 		Region:      d.Get("region").(string),
+		Zone:        d.Get("zone").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -32,7 +32,7 @@ func resourceBigtableInstance() *schema.Resource {
 
 			"zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -111,6 +111,11 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		instanceType = bigtable.PRODUCTION
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	instanceConf := &bigtable.InstanceConf{
 		InstanceId:   name,
 		DisplayName:  displayName.(string),
@@ -118,7 +123,7 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		NumNodes:     numNodes,
 		InstanceType: instanceType,
 		StorageType:  storageType,
-		Zone:         d.Get("zone").(string),
+		Zone:         zone,
 	}
 
 	c, err := config.bigtableClientFactory.NewInstanceAdminClient(project)

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -302,8 +302,6 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 		if e != nil {
 			return handleNotFoundError(e, d, fmt.Sprintf("Autoscaler %q", d.Id()))
 		}
-	} else if err != nil {
-		return err
 	} else {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource
 		// by searching in the region of the project.

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -297,7 +297,7 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 
 	var scaler *compute.Autoscaler
 	var e error
-	if zone, err := getZone(d, config); err == nil && zone != "" {
+	if zone, _ := getZone(d, config); zone != "" {
 		scaler, e = config.clientCompute.Autoscalers.Get(project, zone, d.Id()).Do()
 		if e != nil {
 			return handleNotFoundError(e, d, fmt.Sprintf("Autoscaler %q", d.Id()))

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -45,7 +45,7 @@ func resourceComputeDisk() *schema.Resource {
 
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -130,12 +130,16 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Get the zone
-	log.Printf("[DEBUG] Loading zone: %s", d.Get("zone").(string))
+	z, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Loading zone: %s", z)
 	zone, err := config.clientCompute.Zones.Get(
-		project, d.Get("zone").(string)).Do()
+		project, z).Do()
 	if err != nil {
 		return fmt.Errorf(
-			"Error loading zone '%s': %s", d.Get("zone").(string), err)
+			"Error loading zone '%s': %s", z, err)
 	}
 
 	// Build the disk parameter
@@ -199,7 +203,7 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	op, err := config.clientCompute.Disks.Insert(
-		project, d.Get("zone").(string), disk).Do()
+		project, z, disk).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating disk: %s", err)
 	}
@@ -221,13 +225,17 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	z, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	d.Partial(true)
 	if d.HasChange("size") {
 		rb := &compute.DisksResizeRequest{
 			SizeGb: int64(d.Get("size").(int)),
 		}
 		op, err := config.clientCompute.Disks.Resize(
-			project, d.Get("zone").(string), d.Id(), rb).Do()
+			project, z, d.Id(), rb).Do()
 		if err != nil {
 			return fmt.Errorf("Error resizing disk: %s", err)
 		}
@@ -245,7 +253,7 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 			LabelFingerprint: d.Get("label_fingerprint").(string),
 		}
 		op, err := config.clientCompute.Disks.SetLabels(
-			project, d.Get("zone").(string), d.Id(), &zslr).Do()
+			project, z, d.Id(), &zslr).Do()
 		if err != nil {
 			return fmt.Errorf("Error when setting labels: %s", err)
 		}
@@ -279,12 +287,14 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var disk *compute.Disk
-	if zone, ok := d.GetOk("zone"); ok {
+	if zone, err := getZone(d, config); zone != "" && err == nil {
 		disk, err = config.clientCompute.Disks.Get(
-			project, zone.(string), d.Id()).Do()
+			project, zone, d.Id()).Do()
 		if err != nil {
 			return handleNotFoundError(err, d, fmt.Sprintf("Disk %q", d.Get("name").(string)))
 		}
+	} else if err != nil {
+		return err
 	} else {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource
 		// by searching in the region of the project.
@@ -323,6 +333,10 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	z, err := getZone(d, config)
 	if err != nil {
 		return err
 	}
@@ -376,7 +390,7 @@ func resourceComputeDiskDelete(d *schema.ResourceData, meta interface{}) error {
 
 	// Delete the disk
 	op, err := config.clientCompute.Disks.Delete(
-		project, d.Get("zone").(string), d.Id()).Do()
+		project, z, d.Id()).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing Disk %q because it's gone", d.Get("name").(string))

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -287,7 +287,7 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var disk *compute.Disk
-	if zone, err := getZone(d, config); zone != "" && err == nil {
+	if zone, _ := getZone(d, config); zone != "" {
 		disk, err = config.clientCompute.Disks.Get(
 			project, zone, d.Id()).Do()
 		if err != nil {

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -293,8 +293,6 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return handleNotFoundError(err, d, fmt.Sprintf("Disk %q", d.Get("name").(string)))
 		}
-	} else if err != nil {
-		return err
 	} else {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource
 		// by searching in the region of the project.

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -33,7 +33,7 @@ func resourceComputeInstanceGroup() *schema.Resource {
 
 			"zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -122,7 +122,10 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 
 	// Build the parameter
@@ -195,7 +198,10 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 
 	// retrieve instance group
@@ -246,7 +252,10 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 
 	d.Partial(true)
@@ -347,7 +356,10 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 	op, err := config.clientCompute.InstanceGroups.Delete(project, zone, name).Do()
 	if err != nil {

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -320,8 +320,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			if e != nil {
 				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
-		} else if err != nil {
-			return err
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
 			// by searching in the region of the project.

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -47,7 +47,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -178,6 +178,11 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	// Build the parameter
 	manager := &computeBeta.InstanceGroupManager{
 		Name:                d.Get("name").(string),
@@ -204,7 +209,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 		managerV1.ForceSendFields = manager.ForceSendFields
 		op, err = config.clientCompute.InstanceGroupManagers.Insert(
-			project, d.Get("zone").(string), managerV1).Do()
+			project, zone, managerV1).Do()
 	case v0beta:
 		managerV0beta := &computeBeta.InstanceGroupManager{}
 		err = Convert(manager, managerV0beta)
@@ -214,7 +219,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 		managerV0beta.ForceSendFields = manager.ForceSendFields
 		op, err = config.clientComputeBeta.InstanceGroupManagers.Insert(
-			project, d.Get("zone").(string), managerV0beta).Do()
+			project, zone, managerV0beta).Do()
 	}
 
 	if err != nil {
@@ -268,12 +273,14 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 		var v1Manager *compute.InstanceGroupManager
 		var e error
-		if zone, ok := d.GetOk("zone"); ok {
-			v1Manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
+		if zone, err := getZone(d, config); zone != "" && err == nil {
+			v1Manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {
 				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
+		} else if err != nil {
+			return err
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
 			// by searching in the region of the project.
@@ -307,12 +314,14 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 		var v0betaManager *computeBeta.InstanceGroupManager
 		var e error
-		if zone, ok := d.GetOk("zone"); ok {
-			v0betaManager, e = config.clientComputeBeta.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
+		if zone, err := getZone(d, config); zone != "" && err == nil {
+			v0betaManager, e = config.clientComputeBeta.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {
 				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
+		} else if err != nil {
+			return err
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
 			// by searching in the region of the project.
@@ -367,6 +376,11 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		return err
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 
 	// If target_pools changes then update
@@ -389,7 +403,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientCompute.InstanceGroupManagers.SetTargetPools(
-				project, d.Get("zone").(string), d.Id(), setTargetPoolsV1).Do()
+				project, zone, d.Id(), setTargetPoolsV1).Do()
 		case v0beta:
 			setTargetPoolsV0beta := &computeBeta.InstanceGroupManagersSetTargetPoolsRequest{}
 			err = Convert(setTargetPools, setTargetPoolsV0beta)
@@ -398,7 +412,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientComputeBeta.InstanceGroupManagers.SetTargetPools(
-				project, d.Get("zone").(string), d.Id(), setTargetPoolsV0beta).Do()
+				project, zone, d.Id(), setTargetPoolsV0beta).Do()
 		}
 
 		if err != nil {
@@ -431,7 +445,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientCompute.InstanceGroupManagers.SetInstanceTemplate(
-				project, d.Get("zone").(string), d.Id(), setInstanceTemplateV1).Do()
+				project, zone, d.Id(), setInstanceTemplateV1).Do()
 		case v0beta:
 			setInstanceTemplateV0beta := &computeBeta.InstanceGroupManagersSetInstanceTemplateRequest{}
 			err = Convert(setInstanceTemplate, setInstanceTemplateV0beta)
@@ -440,7 +454,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientComputeBeta.InstanceGroupManagers.SetInstanceTemplate(
-				project, d.Get("zone").(string), d.Id(), setInstanceTemplateV0beta).Do()
+				project, zone, d.Id(), setInstanceTemplateV0beta).Do()
 		}
 
 		if err != nil {
@@ -458,7 +472,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			switch computeApiVersion {
 			case v1:
 				managedInstancesV1, err := config.clientCompute.InstanceGroupManagers.ListManagedInstances(
-					project, d.Get("zone").(string), d.Id()).Do()
+					project, zone, d.Id()).Do()
 				if err != nil {
 					return fmt.Errorf("Error getting instance group managers instances: %s", err)
 				}
@@ -469,7 +483,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				}
 			case v0beta:
 				managedInstancesV0beta, err := config.clientComputeBeta.InstanceGroupManagers.ListManagedInstances(
-					project, d.Get("zone").(string), d.Id()).Do()
+					project, zone, d.Id()).Do()
 				if err != nil {
 					return fmt.Errorf("Error getting instance group managers instances: %s", err)
 				}
@@ -500,7 +514,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				}
 
 				op, err = config.clientCompute.InstanceGroupManagers.RecreateInstances(
-					project, d.Get("zone").(string), d.Id(), recreateInstancesV1).Do()
+					project, zone, d.Id(), recreateInstancesV1).Do()
 				if err != nil {
 					return fmt.Errorf("Error restarting instance group managers instances: %s", err)
 				}
@@ -512,7 +526,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 				}
 
 				op, err = config.clientComputeBeta.InstanceGroupManagers.RecreateInstances(
-					project, d.Get("zone").(string), d.Id(), recreateInstancesV0beta).Do()
+					project, zone, d.Id(), recreateInstancesV0beta).Do()
 				if err != nil {
 					return fmt.Errorf("Error restarting instance group managers instances: %s", err)
 				}
@@ -548,7 +562,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientCompute.InstanceGroups.SetNamedPorts(
-				project, d.Get("zone").(string), d.Id(), setNamedPortsV1).Do()
+				project, zone, d.Id(), setNamedPortsV1).Do()
 		case v0beta:
 			setNamedPortsV0beta := &computeBeta.InstanceGroupsSetNamedPortsRequest{}
 			err = Convert(setNamedPorts, setNamedPortsV0beta)
@@ -557,7 +571,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			}
 
 			op, err = config.clientComputeBeta.InstanceGroups.SetNamedPorts(
-				project, d.Get("zone").(string), d.Id(), setNamedPortsV0beta).Do()
+				project, zone, d.Id(), setNamedPortsV0beta).Do()
 		}
 
 		if err != nil {
@@ -579,10 +593,10 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		switch computeApiVersion {
 		case v1:
 			op, err = config.clientCompute.InstanceGroupManagers.Resize(
-				project, d.Get("zone").(string), d.Id(), targetSize).Do()
+				project, zone, d.Id(), targetSize).Do()
 		case v0beta:
 			op, err = config.clientComputeBeta.InstanceGroupManagers.Resize(
-				project, d.Get("zone").(string), d.Id(), targetSize).Do()
+				project, zone, d.Id(), targetSize).Do()
 		}
 
 		if err != nil {
@@ -606,7 +620,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		op, err := config.clientComputeBeta.InstanceGroupManagers.SetAutoHealingPolicies(
-			project, d.Get("zone").(string), d.Id(), setAutoHealingPoliciesRequest).Do()
+			project, zone, d.Id(), setAutoHealingPoliciesRequest).Do()
 
 		if err != nil {
 			return fmt.Errorf("Error updating AutoHealingPolicies: %s", err)
@@ -635,7 +649,10 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 
 	var op interface{}
 	switch computeApiVersion {
@@ -675,7 +692,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		switch computeApiVersion {
 		case v1:
 			instanceGroup, err := config.clientCompute.InstanceGroups.Get(
-				project, d.Get("zone").(string), d.Id()).Do()
+				project, zone, d.Id()).Do()
 			if err != nil {
 				return fmt.Errorf("Error getting instance group size: %s", err)
 			}
@@ -683,7 +700,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 			instanceGroupSize = instanceGroup.Size
 		case v0beta:
 			instanceGroup, err := config.clientComputeBeta.InstanceGroups.Get(
-				project, d.Get("zone").(string), d.Id()).Do()
+				project, zone, d.Id()).Do()
 			if err != nil {
 				return fmt.Errorf("Error getting instance group size: %s", err)
 			}

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -273,14 +273,12 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 		var v1Manager *compute.InstanceGroupManager
 		var e error
-		if zone, err := getZone(d, config); zone != "" && err == nil {
+		if zone, _ := getZone(d, config); zone != "" {
 			v1Manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {
 				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
-		} else if err != nil {
-			return err
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
 			// by searching in the region of the project.
@@ -314,7 +312,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 		var v0betaManager *computeBeta.InstanceGroupManager
 		var e error
-		if zone, err := getZone(d, config); zone != "" && err == nil {
+		if zone, _ := getZone(d, config); zone != "" {
 			v0betaManager, e = config.clientComputeBeta.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -26,7 +26,7 @@ func resourceComputeSnapshot() *schema.Resource {
 
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -117,8 +117,13 @@ func resourceComputeSnapshotCreate(d *schema.ResourceData, meta interface{}) err
 		snapshot.SourceDiskEncryptionKey.RawKey = v.(string)
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	op, err := config.clientCompute.Disks.CreateSnapshot(
-		project, d.Get("zone").(string), source_disk, snapshot).Do()
+		project, zone, source_disk, snapshot).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating snapshot: %s", err)
 	}

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -68,7 +68,7 @@ func resourceContainerCluster() *schema.Resource {
 
 			"zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -393,7 +393,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	zoneName := d.Get("zone").(string)
+	zoneName, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	clusterName := d.Get("name").(string)
 
 	cluster := &container.Cluster{
@@ -561,7 +564,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	zoneName := d.Get("zone").(string)
+	zoneName, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 
 	var cluster *container.Cluster
 	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -671,7 +677,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	zoneName := d.Get("zone").(string)
+	zoneName, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
@@ -935,7 +944,10 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	zoneName := d.Get("zone").(string)
+	zoneName, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -44,7 +44,7 @@ func resourceContainerNodePool() *schema.Resource {
 				},
 				"zone": &schema.Schema{
 					Type:     schema.TypeString,
-					Required: true,
+					Optional: true,
 					ForceNew: true,
 				},
 				"cluster": &schema.Schema{
@@ -148,7 +148,10 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		NodePool: nodePool,
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	cluster := d.Get("cluster").(string)
 
 	op, err := config.clientContainer.Projects.Zones.Clusters.NodePools.Create(project, zone, cluster, req).Do()
@@ -180,7 +183,10 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	cluster := d.Get("cluster").(string)
 	name := getNodePoolName(d.Id())
 
@@ -225,7 +231,10 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 	cluster := d.Get("cluster").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
@@ -257,7 +266,10 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 		return false, err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return false, err
+	}
 	cluster := d.Get("cluster").(string)
 	name := getNodePoolName(d.Id())
 
@@ -391,7 +403,10 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, clusterName, prefi
 		return err
 	}
 
-	zone := d.Get("zone").(string)
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
 	npName := d.Get(prefix + "name").(string)
 
 	if d.HasChange(prefix + "autoscaling") {


### PR DESCRIPTION
Fixes #772.  Tested:

```
22:44 $ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
        xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-google github.com/terraform-providers/terraform-provider-google/google github.com/terraform-providers/terraform-provider-google/scripts 
?       github.com/terraform-providers/terraform-provider-google        [no test files]
ok      github.com/terraform-providers/terraform-provider-google/google 0.065s
ok      github.com/terraform-providers/terraform-provider-google/scripts        0.012s
```

and confirmed I got all the places I needed to replace:

```
22:46 $ grep '.GetOk("zone")' google/*.go
google/utils.go:        res, ok := d.GetOk("zone")
22:46 $ grep '.Get("zone")' google/*.go
google/provider.go:             Zone:        d.Get("zone").(string),
```

(both of which are correct)