### PR TITLE
Explain that compute_url_map needs self link for test.service

### DIFF
--- a/website/docs/r/compute_url_map.html.markdown
+++ b/website/docs/r/compute_url_map.html.markdown
@@ -142,7 +142,7 @@ The `path_rule` block supports:
 
 The `test` block supports:
 
-* `service` - (Required) The backend service or backend bucket that should be matched by this test.
+* `service` - (Required) The backend service or backend bucket link that should be matched by this test.
 
 * `host` - (Required) The host component of the URL being tested.
 


### PR DESCRIPTION
This bit me in https://issuetracker.google.com/issues/70196297