### PR TITLE
Fix the database sweeper.

### DIFF
--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -63,7 +63,7 @@ func testSweepDatabases(region string) error {
 		if !testDbInstance {
 			continue
 		}
-		if !d.State == "RUNNABLE" {
+		if d.State != "RUNNABLE" {
 			continue
 		}
 		running[d.Name] = struct{}{}

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -63,6 +63,9 @@ func testSweepDatabases(region string) error {
 		if !testDbInstance {
 			continue
 		}
+		if !d.State == "RUNNABLE" {
+			continue
+		}
 		running[d.Name] = struct{}{}
 	}
 

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -49,6 +49,8 @@ func testSweepDatabases(region string) error {
 		return nil
 	}
 
+	running := map[string]struct{}{}
+
 	for _, d := range found.Items {
 		var testDbInstance bool
 		for _, testName := range []string{"tf-lw-", "sqldatabasetest"} {
@@ -61,7 +63,15 @@ func testSweepDatabases(region string) error {
 		if !testDbInstance {
 			continue
 		}
+		running[d.Name] = struct{}{}
+	}
 
+	for _, d := range found.Items {
+		// don't delete replicas, we'll take care of that
+		// when deleting the database they replicate
+		if d.ReplicaConfiguration != nil {
+			continue
+		}
 		log.Printf("Destroying SQL Instance (%s)", d.Name)
 
 		// replicas need to be stopped and destroyed before destroying a master
@@ -69,6 +79,12 @@ func testSweepDatabases(region string) error {
 		// and we call destroy on them before destroying the master
 		var ordering []string
 		for _, replicaName := range d.ReplicaNames {
+			// don't try to stop replicas that aren't running
+			if _, ok := running[replicaName]; !ok {
+				ordering = append(ordering, replicaName)
+				continue
+			}
+
 			// need to stop replication before being able to destroy a database
 			op, err := config.clientSqlAdmin.Instances.StopReplica(config.Project, replicaName).Do()
 


### PR DESCRIPTION
It's getting hung up on a database replica instance that's not running,
so it can't stop it.

To resolve, we're only trying to stop replica instances that are in a
running state. Also, I noticed a bug that we'd try to delete replicas
twice, so I fixed that, as well.