### PR TITLE
Make network name unique between each test run

### DIFF
--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestAccDataSourceGoogleSubnetwork(t *testing.T) {

--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
@@ -16,7 +17,7 @@ func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: TestAccDataSourceGoogleSubnetworkConfig,
+				Config: testAccDataSourceGoogleSubnetwork(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork", "google_compute_subnetwork.foobar"),
 				),
@@ -66,10 +67,11 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 	}
 }
 
-var TestAccDataSourceGoogleSubnetworkConfig = `
+func testAccDataSourceGoogleSubnetwork() string {
+	return fmt.Sprintf(`
 
 resource "google_compute_network" "foobar" {
-	name = "network-test"
+	name = "%s"
 	description = "my-description"
 }
 resource "google_compute_subnetwork" "foobar" {
@@ -87,4 +89,5 @@ resource "google_compute_subnetwork" "foobar" {
 data "google_compute_subnetwork" "my_subnetwork" {
 	name = "${google_compute_subnetwork.foobar.name}"
 }
-`
+`, acctest.RandomWithPrefix("network-test"))
+}


### PR DESCRIPTION
Concurrent runs were failing because this test tries to create a network with a static name.