### PR TITLE
Fix our provider validation to allow file paths.

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -3,6 +3,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -198,6 +199,10 @@ func validateCredentials(v interface{}, k string) (warnings []string, errors []e
 		return
 	}
 	creds := v.(string)
+	// if this is a path and we can stat it, assume it's ok
+	if _, err := os.Stat(creds); err == nil {
+		return
+	}
 	var account accountFile
 	if err := json.Unmarshal([]byte(creds), &account); err != nil {
 		errors = append(errors,

--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -88,6 +88,30 @@ func TestProvider_getRegionFromZone(t *testing.T) {
 	}
 }
 
+func TestProvider_loadCredentialsFromFile(t *testing.T) {
+	ws, es := validateCredentials(testFakeCredentialsPath, "")
+	if len(ws) != 0 {
+		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
+	}
+	if len(es) != 0 {
+		t.Errorf("Expected %d errors, got %v", len(es), es)
+	}
+}
+
+func TestProvider_loadCredentialsFromJSON(t *testing.T) {
+	contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	ws, es := validateCredentials(string(contents), "")
+	if len(ws) != 0 {
+		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
+	}
+	if len(es) != 0 {
+		t.Errorf("Expected %d errors, got %v", len(es), es)
+	}
+}
+
 // getTestRegion has the same logic as the provider's getRegion, to be used in tests.
 func getTestRegion(is *terraform.InstanceState, config *Config) (string, error) {
 	if res, ok := is.Attributes["region"]; ok {


### PR DESCRIPTION
Previously, provider credentials were _supposed_ to be able to be
specified as the file contents or the path to the file. We even had a
test for the code for this!

Then we updated the validation for the provider, and forgot to validate
filepaths as ok. So provider validation failed. And because our test
only tested the config validation, and not the provider validation, our
tests thought this was just fine still.

This fixes that oversight, accepting filepaths as valid. It also adds
tests to ensure that provider validation allows both file paths and
contents.