### PR TITLE
WIP: Add "internal IP only" support for Dataproc clusters

### DIFF
--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -174,6 +174,13 @@ func resourceDataprocCluster() *schema.Resource {
 										},
 										Set: stringScopeHashcode,
 									},
+
+									"internal_ip_only": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Default:  false,
+									},
 								},
 							},
 						},
@@ -479,6 +486,9 @@ func expandGceClusterConfig(cfg map[string]interface{}) *dataproc.GceClusterConf
 		}
 		conf.ServiceAccountScopes = scopes
 	}
+	if v, ok := cfg["internal_ip_only"]; ok {
+		conf.InternalIpOnly = v.(bool)
+	}
 	return conf
 }
 
@@ -720,9 +730,10 @@ func flattenInitializationActions(nia []*dataproc.NodeInitializationAction) ([]m
 func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterConfig) []map[string]interface{} {
 
 	gceConfig := map[string]interface{}{
-		"tags":            gcc.Tags,
-		"service_account": gcc.ServiceAccount,
-		"zone":            extractLastResourceFromUri(gcc.ZoneUri),
+		"tags":             gcc.Tags,
+		"service_account":  gcc.ServiceAccount,
+		"zone":             extractLastResourceFromUri(gcc.ZoneUri),
+		"internal_ip_only": gcc.InternalIpOnly,
 	}
 
 	if gcc.NetworkUri != "" {

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -108,7 +108,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.bucket"),
 
 					// Default behavior is for Dataproc to not use only internal IP addresses
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.internal_ip_only", "false"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "false"),
 
 					// Expect 1 master instances with computed values
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.#", "1"),
@@ -152,7 +152,7 @@ func TestAccDataprocCluster_basicWithInternalIpOnlyTrue(t *testing.T) {
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.basic", &cluster),
 
 					// Testing behavior for Dataproc to use only internal IP addresses
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.internal_ip_only", "true"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "true"),
 				),
 			},
 		},

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -108,7 +108,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.bucket"),
 
 					// Default behavior is for Dataproc to not use only internal IP addresses
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.gce_cluster_config.internal_ip_only", "false"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.internal_ip_only", "false"),
 
 					// Expect 1 master instances with computed values
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.#", "1"),
@@ -152,7 +152,7 @@ func TestAccDataprocCluster_basicWithInternalIpOnlyTrue(t *testing.T) {
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.basic", &cluster),
 
 					// Testing behavior for Dataproc to use only internal IP addresses
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.gce_cluster_config.internal_ip_only", "true"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.internal_ip_only", "true"),
 				),
 			},
 		},

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -728,6 +728,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 resource "google_dataproc_cluster" "basic" {
 	name                  = "dproc-cluster-test-%s"
 	region                = "us-central1"
+	depends_on            = ["google_compute_firewall.dataproc_network_firewall"]
 	
 	cluster_config {
 		gce_cluster_config {

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -677,7 +677,7 @@ resource "google_dataproc_cluster" "basic" {
 func testAccDataprocCluster_basicWithInternalIpOnlyTrue(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "dataproc_network" {
-	name = "dataproc-internalip-network"
+	name = "dataproc-internalip-network-%s"
 	auto_create_subnetworks = false
 }
 
@@ -686,7 +686,7 @@ resource "google_compute_network" "dataproc_network" {
 # deploying a Dataproc cluster with Internal IP Only enabled.
 #
 resource "google_compute_subnetwork" "dataproc_subnetwork" {
-	name                     = "dataproc-internalip-subnetwork"
+	name                     = "dataproc-internalip-subnetwork-%s"
 	ip_cidr_range            = "10.0.0.0/16"
 	network                  = "${google_compute_network.dataproc_network.self_link}"
 	region                   = "us-central1"
@@ -730,7 +730,7 @@ resource "google_dataproc_cluster" "basic" {
 		}
 	}
 }
-`, rnd)
+`, rnd, rnd, rnd)
 }
 
 func testAccDataprocCluster_basicWithAutogenDeleteTrue(rnd string) string {

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -676,6 +676,10 @@ resource "google_dataproc_cluster" "basic" {
 
 func testAccDataprocCluster_basicWithInternalIpOnlyTrue(rnd string) string {
 	return fmt.Sprintf(`
+variable subnetwork_cidr {
+	default = "10.0.0.0/16"
+}
+
 resource "google_compute_network" "dataproc_network" {
 	name = "dataproc-internalip-network-%s"
 	auto_create_subnetworks = false
@@ -687,7 +691,7 @@ resource "google_compute_network" "dataproc_network" {
 #
 resource "google_compute_subnetwork" "dataproc_subnetwork" {
 	name                     = "dataproc-internalip-subnetwork-%s"
-	ip_cidr_range            = "10.0.0.0/16"
+	ip_cidr_range            = "${var.subnetwork_cidr}"
 	network                  = "${google_compute_network.dataproc_network.self_link}"
 	region                   = "us-central1"
 	private_ip_google_access = true
@@ -718,6 +722,8 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 		protocol = "udp"
 		ports    = ["0-65535"]
 	}
+
+	source_ranges = ["${var.subnetwork_cidr}"]
 }
 resource "google_dataproc_cluster" "basic" {
 	name                  = "dproc-cluster-test-%s"

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -722,8 +722,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 resource "google_dataproc_cluster" "basic" {
 	name                  = "dproc-cluster-test-%s"
 	region                = "us-central1"
-	depends_on            = ["google_compute_firewall.dataproc_network_firewall","google_compute_subnetwork.dataproc_subnetwork"]
-
+	
 	cluster_config {
 		gce_cluster_config {
 			subnetwork       = "${google_compute_subnetwork.dataproc_subnetwork.name}"

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -107,6 +107,9 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					// Default behaviour is for Dataproc to autogen or autodiscover a config bucket
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.bucket"),
 
+					// Default behavior is for Dataproc to not use only internal IP addresses
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.gce_cluster_config.internal_ip_only", "false"),
+
 					// Expect 1 master instances with computed values
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.#", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.num_instances", "1"),

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -196,6 +196,11 @@ The **cluster_config.gce_cluster_config** block supports:
 * `tags` - (Optional) The list of instance tags applied to instances in the cluster.
    Tags are used to identify valid sources or targets for network firewalls.
 
+* `internal_ip_only` - (Optional) By default, clusters are not restricted to internal IP addresses, 
+   and will have ephemeral external IP addresses assigned to each instance. If set to true, all 
+   instances in the cluster will only have internal IP addresses. Note: Private Google Access 
+   (also known as `privateIpGoogleAccess`) must be enabled on the subnetwork that the cluster 
+   will be launched in.
 - - -
 
 The **cluster_config.master_config** block supports:


### PR DESCRIPTION
This PR creates a `internal_ip_only` boolean argument, nested in the `gce_cluster_config` schema. By default, this value is set to `false`, which is consistent with the current behavior of the API and CLI - Dataproc clusters are created with internal IPs and ephemeral external IPs. When the value is `true`, this passes through to the API and creates a Dataproc cluster with internal IP addresses only (no ephemeral external IP addresses). 

This requires use of subnetworks, as well as Private Google Access enabled in the destination subnetwork. This should be added to the provider docs.

Note: the `internalIpOnly` API argument is [available in the Dataproc v1 API](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#GceClusterConfig) (as well as v1beta2)

TODO:
- [x] create feature by adding argument to `gce_cluster_config` schema (737fd7a)
- [x] add test cases
  - [x] default test case: `internal_ip_only` is `false` (a679b18)
  - [x] test case: `internal_ip_only` is `true` (dd4521c)
- [x] validate test cases
- [x] add argument to documentation (fecee25)
- [x] augment resource schema argument to conflict when not using subnets?