### PR TITLE
Add support for compute network routing mode

### DIFF
--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -37,6 +37,13 @@ func resourceComputeNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"routing_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"gateway_ipv4": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -93,6 +100,13 @@ func resourceComputeNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		Description:           d.Get("description").(string),
 	}
 
+	if v, ok := d.GetOk("routing_mode"); ok {
+		routingConfig := &compute.NetworkRoutingConfig{
+			RoutingMode: v.(string),
+		}
+		network.RoutingConfig = routingConfig
+	}
+
 	if v, ok := d.GetOk("ipv4_range"); ok {
 		log.Printf("[DEBUG] Setting IPv4Range (%#v) for legacy network mode", v.(string))
 		network.IPv4Range = v.(string)
@@ -133,6 +147,9 @@ func resourceComputeNetworkRead(d *schema.ResourceData, meta interface{}) error 
 		return handleNotFoundError(err, d, fmt.Sprintf("Network %q", d.Get("name").(string)))
 	}
 
+	routingConfig := network.RoutingConfig
+
+	d.Set("routing_mode", routingConfig.RoutingMode)
 	d.Set("gateway_ipv4", network.GatewayIPv4)
 	d.Set("ipv4_range", network.IPv4Range)
 	d.Set("self_link", network.SelfLink)

--- a/google/resource_compute_network_test.go
+++ b/google/resource_compute_network_test.go
@@ -77,6 +77,56 @@ func TestAccComputeNetwork_custom_subnet(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetwork_routing_mode(t *testing.T) {
+	t.Parallel()
+
+	var network compute.Network
+
+	routingMode := "GLOBAL"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeNetwork_routing_mode(routingMode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						"google_compute_network.acc_network_routing_mode", &network),
+					testAccCheckComputeNetworkHasRoutingMode(
+						"google_compute_network.acc_network_routing_mode", &network, routingMode),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
+	t.Parallel()
+
+	var network compute.Network
+
+	expectedRoutingMode := "REGIONAL"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeNetwork_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						"google_compute_network.foobar", &network),
+					testAccCheckComputeNetworkHasRoutingMode(
+						"google_compute_network.foobar", &network, expectedRoutingMode),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeNetworkDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -168,6 +218,35 @@ func testAccCheckComputeNetworkIsCustomSubnet(n string, network *compute.Network
 	}
 }
 
+func testAccCheckComputeNetworkHasRoutingMode(n string, network *compute.Network, routingMode string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["routing_mode"] == "" {
+			return fmt.Errorf("Routing mode not found on resource")
+		}
+
+		found, err := config.clientCompute.Networks.Get(
+			config.Project, network.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		foundRoutingMode := found.RoutingConfig.RoutingMode
+
+		if routingMode != foundRoutingMode {
+			return fmt.Errorf("Expected routing mode %s to match actual routing mode %s", routingMode, foundRoutingMode)
+		}
+
+		return nil
+	}
+}
+
 func testAccComputeNetwork_basic() string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -189,4 +268,12 @@ resource "google_compute_network" "baz" {
 	name = "network-test-%s"
 	auto_create_subnetworks = false
 }`, acctest.RandString(10))
+}
+
+func testAccComputeNetwork_routing_mode(routingMode string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_routing_mode" {
+	name         = "network-test-%s"
+	routing_mode = "%s"
+}`, acctest.RandString(10), routingMode)
 }

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -40,6 +40,11 @@ The following arguments are supported:
   specified range. This API is deprecated. If set, `auto_create_subnetworks` must be
   explicitly set to false.
 
+* `routing_mode` - (Optional) Sets the network-wide routing mode for Cloud Routers
+  to use. Accepted values are `"GLOBAL"` or `"REGIONAL"`. Defaults to `"REGIONAL"`.
+  Refer to the [Cloud Router documentation](https://cloud.google.com/router/docs/concepts/overview#dynamic-routing-mode)
+  for more details.
+
 * `description` - (Optional) A brief description of this resource.
 
 * `project` - (Optional) The project in which the resource belongs. If it


### PR DESCRIPTION
I had a need for this when building a VPC that talks to an on-prem network, and noticed that this provider doesn't have a way to specify the VPC routing mode.  The current workaround is to add `gcloud compute networks update my-vpc --project my-project --bgp-routing-mode global` to `local-exec` after creating the VPC.

I did a quick search and found that this was asked for in #629.

Docs:

- Rest API: https://cloud.google.com/compute/docs/reference/latest/networks (refer to `routingConfig`)
- Cloud Router docs: https://cloud.google.com/router/docs/concepts/overview#dynamic-routing-mode

Tests:

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccComputeNetwork.*routing_mode -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccComputeNetwork_routing_mode
=== RUN   TestAccComputeNetwork_default_routing_mode
--- PASS: TestAccComputeNetwork_routing_mode (336.44s)
--- PASS: TestAccComputeNetwork_default_routing_mode (336.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	336.487s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-google/scripts	0.017s [no tests to run]
```

Side note: It is possible to change the routing mode after creating the VPC, but this resource doesn't have an `UpdateFunc` and I didn't want to go through the work of supporting it in this PR.  However, if you'd like me to add it before this gets merged, I can do that.
