### PR TITLE
Fix storage object detect md5 hash for dynamic content

### DIFF
--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -104,9 +104,9 @@ func resourceStorageBucketObject() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				// Makes the diff message nicer:
-				// md5hash:       "1XcnP/iFw/hNrbhXi7QTmQ==" => "different hash" (forces new resource)
+				// detect_md5hash:       "1XcnP/iFw/hNrbhXi7QTmQ==" => "different hash" (forces new resource)
 				// Instead of the more confusing:
-				// md5hash:       "1XcnP/iFw/hNrbhXi7QTmQ==" => "" (forces new resource)
+				// detect_md5hash:       "1XcnP/iFw/hNrbhXi7QTmQ==" => "" (forces new resource)
 				Default: "different hash",
 				// 1. Compute the md5 hash of the local file
 				// 2. Compare the computed md5 hash with the hash stored in Cloud Storage
@@ -119,6 +119,13 @@ func resourceStorageBucketObject() *schema.Resource {
 
 					if content, ok := d.GetOkExists("content"); ok {
 						localMd5Hash = getContentMd5Hash([]byte(content.(string)))
+					}
+
+					// If `source` or `content` is dynamically set, both field will be empty.
+					// We should not suppress the diff to avoid the following error:
+					// 'Mismatch reason: extra attributes: detect_md5hash'
+					if localMd5Hash == "" {
+						return false
 					}
 
 					// `old` is the md5 hash we retrieved from the server in the ReadFunc

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -150,6 +150,27 @@ func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
 	})
 }
 
+func TestAccGoogleStorageObject_dynamicContent(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleStorageBucketsObjectDynamicContent(testBucketName()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket_object.object", "content_type", "text/plain; charset=utf-8"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket_object.object", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
 	t.Parallel()
 
@@ -265,6 +286,20 @@ resource "google_storage_bucket_object" "object" {
 	content = "%s"
 }
 `, bucketName, objectName, content)
+}
+
+func testGoogleStorageBucketsObjectDynamicContent(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+	name = "%s"
+}
+
+resource "google_storage_bucket_object" "object" {
+	name = "%s"
+	bucket = "${google_storage_bucket.bucket.name}"
+	content = "${google_storage_bucket.bucket.project}"
+}
+`, bucketName, objectName)
 }
 
 func testGoogleStorageBucketsObjectBasic(bucketName, sourceFilename string) string {


### PR DESCRIPTION
Fixes #842 

I also added an acceptance test case to prevent regression.

cc/ @danisla