### PR TITLE
Ignore beta vs v1 network diff in subnetwork datasource test

### DIFF
--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -47,7 +47,6 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"name",
 			"description",
 			"ip_cidr_range",
-			"network",
 			"private_ip_google_access",
 			"secondary_ip_range",
 		}
@@ -61,6 +60,10 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 					rs_attr[attr_to_check],
 				)
 			}
+		}
+
+		if v1RsNetwork := ConvertSelfLinkToV1(rs_attr["network"]); ds_attr["network"] != v1RsNetwork {
+			return fmt.Errorf("network is %s; want %s", ds_attr["network"], v1RsNetwork)
 		}
 
 		return nil


### PR DESCRIPTION
Fixes the following test failure:
```sh
------- Stdout: -------
=== RUN   TestAccDataSourceGoogleSubnetwork
--- FAIL: TestAccDataSourceGoogleSubnetwork (378.81s)
    testing.go:434: Step 0 error: Check failed: Check 1/1 error: network is https://www.googleapis.com/compute/v1/projects/[REDACTED]/global/networks/network-test-4262628131369936961; want https://www.googleapis.com/compute/beta/projects/[REDACTED]/global/networks/network-test-4262628131369936961
FAIL
```