### PR TITLE
Bugfix: add read back in to the KMS crypto key read method.

### DIFF
--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -110,12 +110,13 @@ func resourceKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Executing read for KMS CryptoKey %s", cryptoKeyId.cryptoKeyId())
 
+	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Get(cryptoKeyId.cryptoKeyId()).Do()
 	if err != nil {
 		return fmt.Errorf("Error reading CryptoKey: %s", err)
 	}
 	d.Set("key_ring", cryptoKeyId.KeyRingId.terraformId())
 	d.Set("name", cryptoKeyId.Name)
-	d.Set("rotation_period", d.Get("rotation_period"))
+	d.Set("rotation_period", cryptoKey.RotationPeriod)
 
 	d.SetId(cryptoKeyId.terraformId())
 

--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -178,7 +178,9 @@ func validateKmsCryptoKeyRotationPeriod(value interface{}, _ string) (ws []strin
 	match := pattern.FindStringSubmatch(period)
 
 	if len(match) == 0 {
-		errors = append(errors, fmt.Errorf("Invalid period format: %s", period))
+		errors = append(errors, fmt.Errorf("Invalid rotation period format: %s", period))
+		// Cannot continue to validate because we cannot extract a number.
+		return
 	}
 
 	number := match[1]

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -319,8 +319,9 @@ resource "google_kms_key_ring" "key_ring" {
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-	name     = "%s"
-	key_ring = "${google_kms_key_ring.key_ring.id}"
+	name            = "%s"
+	key_ring        = "${google_kms_key_ring.key_ring.id}"
+	rotation_period = "1000000s"
 }
 	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }


### PR DESCRIPTION
Impact of this bug: if a user deleted a crypto key or changed the rotation period outside terraform and then reran `apply`, the old data would stay in the plan.  This could cause failures when the key is being used later in the plan, or false `terraform plan` output.

Ran the tests - they still pass, but I confirmed the bug manually and confirmed that the fix is applied.

This closes #813.