### PR TITLE
Add configurable timeouts to google_compute_instance

### DIFF
--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -97,6 +97,15 @@ exported:
 
 * `size` - The number of instances in the group.
 
+## Timeouts
+
+This resource provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - Default is `6 minutes`
+- `update` - Default is `6 minutes`
+- `delete` - Default is `6 minutes`
+
 ## Import
 
 Instance group can be imported using the `zone` and `name`, e.g.


### PR DESCRIPTION
Fixes #852

Additionally, I bumped the default timeout by an extra 2 minutes based on the issue filed.