### PR TITLE
Removes unsupported identities related to project iam binding

### DIFF
--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -56,8 +56,8 @@ each accept the following arguments:
 
 * `members` (Required) - An array of identites that will be granted the privilege in the `role`.
   Each entry can have one of the following values:
-  * **allUsers**: A special identifier that represents anyone who is on the internet; with or without a Google account.
-  * **allAuthenticatedUsers**: A special identifier that represents anyone who is authenticated with a Google account or a service account.
+  * **allUsers**: A special identifier that represents anyone who is on the internet; with or without a Google account. It **can't** be used with the `google_project` resource.
+  * **allAuthenticatedUsers**: A special identifier that represents anyone who is authenticated with a Google account or a service account. It **can't** be used with the `google_project` resource.
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.

--- a/website/docs/r/google_project_iam_binding.html.markdown
+++ b/website/docs/r/google_project_iam_binding.html.markdown
@@ -34,8 +34,6 @@ The following arguments are supported:
 
 * `members` (Required) - An array of identites that will be granted the privilege in the `role`.
   Each entry can have one of the following values:
-  * **allUsers**: A special identifier that represents anyone who is on the internet; with or without a Google account.
-  * **allAuthenticatedUsers**: A special identifier that represents anyone who is authenticated with a Google account or a service account.
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.

--- a/website/docs/r/google_project_iam_member.html.markdown
+++ b/website/docs/r/google_project_iam_member.html.markdown
@@ -32,8 +32,6 @@ The following arguments are supported:
 
 * `member` - (Required) The identity that will be granted the privilege in the `role`.
   This field can have one of the following values:
-  * **allUsers**: A special identifier that represents anyone who is on the internet; with or without a Google account.
-  * **allAuthenticatedUsers**: A special identifier that represents anyone who is authenticated with a Google account or a service account.
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.


### PR DESCRIPTION
The [docs](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy) is clear about that:

> Project does not support allUsers and allAuthenticatedUsers as members in a Binding of a Policy.

So i've updated the docs to avoid some confusion and head scratching because of the 400 error responses (`Request contains an invalid argument.`)
