### PR TITLE
skip guest accelerators if count is 0.

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1216,8 +1216,8 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 		return nil, nil
 	}
 	accels := configs.([]interface{})
-	guestAccelerators := make([]*computeBeta.AcceleratorConfig, len(accels))
-	for i, raw := range accels {
+	guestAccelerators := make([]*computeBeta.AcceleratorConfig, 0, len(accels))
+	for _, raw := range accels {
 		data := raw.(map[string]interface{})
 		if data["count"].(int) == 0 {
 			continue
@@ -1226,10 +1226,10 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse accelerator type: %v", err)
 		}
-		guestAccelerators[i] = &computeBeta.AcceleratorConfig{
+		guestAccelerators = append(guestAccelerators, &computeBeta.AcceleratorConfig{
 			AcceleratorCount: int64(data["count"].(int)),
 			AcceleratorType:  at.RelativeLink(),
-		}
+		})
 	}
 
 	return guestAccelerators, nil

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1219,6 +1219,9 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 	guestAccelerators := make([]*computeBeta.AcceleratorConfig, len(accels))
 	for i, raw := range accels {
 		data := raw.(map[string]interface{})
+		if data["count"].(int) == 0 {
+			continue
+		}
 		at, err := ParseAcceleratorFieldValue(data["type"].(string), d, config)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse accelerator type: %v", err)

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/mitchellh/hashstructure"
@@ -496,6 +497,7 @@ func resourceComputeInstance() *schema.Resource {
 			"guest_accelerator": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -556,6 +558,9 @@ func resourceComputeInstance() *schema.Resource {
 				Deprecated: "Use timeouts block instead.",
 			},
 		},
+		CustomizeDiff: customdiff.All(
+			suppressEmptyGuestAcceleratorDiff,
+		),
 	}
 }
 
@@ -1233,6 +1238,48 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 	}
 
 	return guestAccelerators, nil
+}
+
+// suppressEmptyGuestAcceleratorDiff is used to work around perpetual diff
+// issues when a count of `0` guest accelerators is desired. This may occur when
+// guest_accelerator support is controlled via a module variable. E.g.:
+//
+// 		guest_accelerators {
+//      	count = "${var.enable_gpu ? var.gpu_count : 0}"
+//          ...
+// 		}
+// After reconciling the desired and actual state, we would otherwise see a
+// perpetual resembling:
+// 		[] != [{"count":0, "type": "nvidia-tesla-k80"}]
+func suppressEmptyGuestAcceleratorDiff(d *schema.ResourceDiff, meta interface{}) error {
+	oldi, newi := d.GetChange("guest_accelerator")
+
+	old, ok := oldi.([]interface{})
+	if !ok {
+		return fmt.Errorf("Expected old guest accelerator diff to be a slice")
+	}
+
+	new, ok := newi.([]interface{})
+	if !ok {
+		return fmt.Errorf("Expected new guest accelerator diff to be a slice")
+	}
+
+	if len(old) != 0 && len(new) != 1 {
+		return nil
+	}
+
+	firstAccel, ok := new[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Unable to type assert guest accelerator")
+	}
+
+	if firstAccel["count"].(int) == 0 {
+		if err := d.Clear("guest_accelerator"); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -559,7 +559,12 @@ func resourceComputeInstance() *schema.Resource {
 			},
 		},
 		CustomizeDiff: customdiff.All(
-			suppressEmptyGuestAcceleratorDiff,
+			customdiff.If(
+				func(d *schema.ResourceDiff, meta interface{}) bool {
+					return d.HasChange("guest_accelerator")
+				},
+				suppressEmptyGuestAcceleratorDiff,
+			),
 		),
 	}
 }

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -502,18 +502,18 @@ func expandInstanceTemplateGuestAccelerators(d TerraformResourceData, config *Co
 		return nil
 	}
 	accels := configs.([]interface{})
-	guestAccelerators := make([]*computeBeta.AcceleratorConfig, len(accels))
-	for i, raw := range accels {
+	guestAccelerators := make([]*computeBeta.AcceleratorConfig, 0, len(accels))
+	for _, raw := range accels {
 		data := raw.(map[string]interface{})
 		if data["count"].(int) == 0 {
 			continue
 		}
-		guestAccelerators[i] = &computeBeta.AcceleratorConfig{
+		guestAccelerators = append(guestAccelerators, &computeBeta.AcceleratorConfig{
 			AcceleratorCount: int64(data["count"].(int)),
 			// We can't use ParseAcceleratorFieldValue here because an instance
 			// template does not have a zone we can use.
 			AcceleratorType: data["type"].(string),
-		}
+		})
 	}
 
 	return guestAccelerators

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -505,6 +505,9 @@ func expandInstanceTemplateGuestAccelerators(d TerraformResourceData, config *Co
 	guestAccelerators := make([]*computeBeta.AcceleratorConfig, len(accels))
 	for i, raw := range accels {
 		data := raw.(map[string]interface{})
+		if data["count"].(int) == 0 {
+			continue
+		}
 		guestAccelerators[i] = &computeBeta.AcceleratorConfig{
 			AcceleratorCount: int64(data["count"].(int)),
 			// We can't use ParseAcceleratorFieldValue here because an instance


### PR DESCRIPTION
Instances in instance groups in google will fail to provision, despite
requesting 0 GPUs. This came up for me when trying to provision
a similar instance group in all available regions, but only asking for
GPU's in those that support them by parameterizing the `count` and
setting it to 0.

This might be a violation of some terraform principles. For example,
testing locally with this change `terraform` did not recognize that
indeed my infra needed to be re-deployed. Additionally, there may be
valid reasons for creating an instance template with 0 gpu's that can be
tuned upwards.

I'm putting this out there as an RFC to (hopefully) demonstrate what I
mean but I have not yet run the acceptance tests locally.