### PR TITLE
Add min_cpu_platform docs in instance template

### DIFF
--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -6,7 +6,6 @@ description: |-
   Manages a VM instance template resource within GCE.
 ---
 
-
 # google\_compute\_instance\_template
 
 Manages a VM instance template resource within GCE. For more information see
@@ -169,6 +168,11 @@ The following arguments are supported:
 
 * `tags` - (Optional) Tags to attach to the instance.
 
+* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
+
+* `min_cpu_platform` - (Optional) Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as
+`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+
 The `disk` block supports:
 
 * `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
@@ -273,10 +277,6 @@ The `scheduling` block supports:
 * `preemptible` - (Optional) Allows instance to be preempted. This defaults to
     false. Read more on this
     [here](https://cloud.google.com/compute/docs/instances/preemptible).
-
----
-
-* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
 
 The `guest_accelerator` block supports:
 


### PR DESCRIPTION
Fixes #876 

Additionally, I moved the former beta field up with the other fields. They are not in beta anymore and don't need to be in a separate section.