### PR TITLE
Better DiffSuppressFunc for disk image field

### DIFF
--- a/google/image.go
+++ b/google/image.go
@@ -15,8 +15,8 @@ const (
 )
 
 var (
-	resolveImageProjectImage           = regexp.MustCompile(fmt.Sprintf("^projects/(%s)/global/images/(%s)$", resolveImageProjectRegex, resolveImageImageRegex))
-	resolveImageProjectFamily          = regexp.MustCompile(fmt.Sprintf("^projects/(%s)/global/images/family/(%s)$", resolveImageProjectRegex, resolveImageFamilyRegex))
+	resolveImageProjectImage           = regexp.MustCompile(fmt.Sprintf("projects/(%s)/global/images/(%s)$", resolveImageProjectRegex, resolveImageImageRegex))
+	resolveImageProjectFamily          = regexp.MustCompile(fmt.Sprintf("projects/(%s)/global/images/family/(%s)$", resolveImageProjectRegex, resolveImageFamilyRegex))
 	resolveImageGlobalImage            = regexp.MustCompile(fmt.Sprintf("^global/images/(%s)$", resolveImageImageRegex))
 	resolveImageGlobalFamily           = regexp.MustCompile(fmt.Sprintf("^global/images/family/(%s)$", resolveImageFamilyRegex))
 	resolveImageFamilyFamily           = regexp.MustCompile(fmt.Sprintf("^family/(%s)$", resolveImageFamilyRegex))
@@ -24,8 +24,21 @@ var (
 	resolveImageProjectFamilyShorthand = regexp.MustCompile(fmt.Sprintf("^(%s)/(%s)$", resolveImageProjectRegex, resolveImageFamilyRegex))
 	resolveImageFamily                 = regexp.MustCompile(fmt.Sprintf("^(%s)$", resolveImageFamilyRegex))
 	resolveImageImage                  = regexp.MustCompile(fmt.Sprintf("^(%s)$", resolveImageImageRegex))
-	resolveImageLink                   = regexp.MustCompile(fmt.Sprintf("^https://www.googleapis.com/compute/v1/projects/(%s)/global/images/(%s)", resolveImageProjectRegex, resolveImageImageRegex))
+	resolveImageLink                   = regexp.MustCompile(fmt.Sprintf("^https://www.googleapis.com/compute/[a-z0-9]+/projects/(%s)/global/images/(%s)", resolveImageProjectRegex, resolveImageImageRegex))
 )
+
+// built-in projects to look for images/families containing the string
+// on the left in
+var imageMap = map[string]string{
+	"centos":   "centos-cloud",
+	"coreos":   "coreos-cloud",
+	"debian":   "debian-cloud",
+	"opensuse": "opensuse-cloud",
+	"rhel":     "rhel-cloud",
+	"sles":     "suse-cloud",
+	"ubuntu":   "ubuntu-os-cloud",
+	"windows":  "windows-cloud",
+}
 
 func resolveImageImageExists(c *Config, project, name string) (bool, error) {
 	if _, err := c.clientCompute.Images.Get(project, name).Do(); err == nil {
@@ -68,18 +81,6 @@ func sanityTestRegexMatches(expected int, got []string, regexType, name string) 
 //    If not, check if it's a family in the current project. If it is, return it as global/images/family/{family}.
 //    If not, check if it could be a GCP-provided family, and if it exists. If it does, return it as projects/{project}/global/images/family/{family}
 func resolveImage(c *Config, project, name string) (string, error) {
-	// built-in projects to look for images/families containing the string
-	// on the left in
-	imageMap := map[string]string{
-		"centos":   "centos-cloud",
-		"coreos":   "coreos-cloud",
-		"debian":   "debian-cloud",
-		"opensuse": "opensuse-cloud",
-		"rhel":     "rhel-cloud",
-		"sles":     "suse-cloud",
-		"ubuntu":   "ubuntu-os-cloud",
-		"windows":  "windows-cloud",
-	}
 	var builtInProject string
 	for k, v := range imageMap {
 		if strings.Contains(name, k) {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -12,6 +12,45 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+func TestDiskImageDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"new is a matching short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-8-jessie-v20171213",
+			ExpectDiffSuppress: true,
+		},
+		"new is a matching latest short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"new is a different self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		"new is a different short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-7-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		"new is a different latest short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-7",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if diskImageDiffSuppress("image", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
 func TestAccComputeDisk_basic(t *testing.T) {
 	t.Parallel()
 

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -17,29 +17,134 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 		Old, New           string
 		ExpectDiffSuppress bool
 	}{
-		"new is a matching short hand": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian-cloud/debian-8-jessie-v20171213",
+		// Full & partial links
+		"matching self_link with different api version": {
+			Old:                "https://www.googleapis.com/compute/beta/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			ExpectDiffSuppress: true,
 		},
-		"new is a matching latest short hand": {
+		"matching image partial self_link": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian-cloud/debian-8",
+			New:                "projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			ExpectDiffSuppress: true,
 		},
-		"new is a different self_link": {
+		"matching image partial no project self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "global/images/debian-8-jessie-v20171213",
+			ExpectDiffSuppress: true,
+		},
+		"different image self_link": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
-		"new is a different short hand": {
+		"different image partial self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "projects/debian-cloud/global/images/debian-7-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		"different image partial no project self_link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "global/images/debian-7-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		// Image name
+		"matching image name": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-8-jessie-v20171213",
+			ExpectDiffSuppress: true,
+		},
+		"different image name": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-7-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		// Image short hand
+		"matching image short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-8-jessie-v20171213",
+			ExpectDiffSuppress: true,
+		},
+		"matching image short hand but different project": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "different-cloud/debian-8-jessie-v20171213",
+			ExpectDiffSuppress: false,
+		},
+		"different image short hand": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			New:                "debian-cloud/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
-		"new is a different latest short hand": {
+		// Latest image short hand
+		"matching latest image short hand": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian-cloud/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"matching latest image short hand with project short name": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "debian/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"matching latest image short hand but different project": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "different-cloud/debian-8",
+			ExpectDiffSuppress: false,
+		},
+		"different latest image short hand": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			New:                "debian-cloud/debian-7",
+			ExpectDiffSuppress: false,
+		},
+		// Image Family
+		"matching image family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "family/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"matching image family self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"matching image family partial self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "projects/debian-cloud/global/images/family/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"matching image family partial no project self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "global/images/family/debian-8",
+			ExpectDiffSuppress: true,
+		},
+		"different image family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "family/debian-7",
+			ExpectDiffSuppress: false,
+		},
+		"different image family self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-7",
+			ExpectDiffSuppress: false,
+		},
+		"different image family partial self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "projects/debian-cloud/global/images/family/debian-7",
+			ExpectDiffSuppress: false,
+		},
+		"different image family partial no project self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "global/images/family/debian-7",
+			ExpectDiffSuppress: false,
+		},
+		"matching image family but different project in self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "https://www.googleapis.com/compute/v1/projects/other-cloud/global/images/family/debian-8",
+			ExpectDiffSuppress: false,
+		},
+		"different image family but different project in partial self link": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			New:                "projects/other-cloud/global/images/family/debian-8",
 			ExpectDiffSuppress: false,
 		},
 	}


### PR DESCRIPTION
Fixes #861 

Resizing disk while the instance is running is already supported. The problem came from a diff in the image field causing a ForceNew.

```sh
image:                      "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213" => "debian-cloud/debian-8" (forces new resource)
```

This PR adds a better DiffSuppressFunc for the disk image field which allows to resize the disk without causing a force new.