### PR TITLE
Remove noisy log statement

### DIFF
--- a/google/datasource_helpers.go
+++ b/google/datasource_helpers.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"log"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/google/datasource_helpers.go
+++ b/google/datasource_helpers.go
@@ -15,8 +15,6 @@ import (
 func datasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
 	ds := make(map[string]*schema.Schema, len(rs))
 	for k, v := range rs {
-		log.Printf("[DEBUG] datasourceSchemaFromResourceSchema: %s", k)
-
 		dv := &schema.Schema{
 			Computed:    true,
 			ForceNew:    false,


### PR DESCRIPTION
That method is called when creating the provider and initializing each resources. This means, before each test run, we have these spammy log statements:

```sh
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: logging_service
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: instance_group_urls
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: additional_zones
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: name
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: addons_config
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: http_load_balancing
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: disabled
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: horizontal_pod_autoscaling
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: disabled
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: kubernetes_dashboard
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: disabled
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: description
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: enable_kubernetes_alpha
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: monitoring_service
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: endpoint
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: master_version
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: enable_legacy_abac
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: initial_node_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: network
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: subnetwork
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: ip_allocation_policy
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: cluster_secondary_range_name
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: services_secondary_range_name
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: zone
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: maintenance_policy
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: daily_maintenance_window
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: start_time
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: duration
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: master_auth
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: password
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: username
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: client_certificate
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: client_key
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: cluster_ca_certificate
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: min_master_version
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: network_policy
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: enabled
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: provider
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: cluster_ipv4_cidr
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: node_pool
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: node_config
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: local_ssd_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: metadata
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: min_cpu_platform
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: oauth_scopes
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: image_type
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: labels
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: preemptible
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: service_account
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: tags
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: disk_size_gb
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: machine_type
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: node_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: autoscaling
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: min_node_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: max_node_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: initial_node_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: management
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: auto_repair
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: auto_upgrade
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: name
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: name_prefix
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: node_version
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: master_authorized_networks_config
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: cidr_blocks
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: cidr_block
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: display_name
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: node_config
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: tags
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: disk_size_gb
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: machine_type
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: preemptible
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: service_account
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: min_cpu_platform
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: oauth_scopes
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: image_type
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: labels
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: local_ssd_count
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: metadata
2017/12/22 14:45:45 [DEBUG] datasourceSchemaFromResourceSchema: project
```