### PR TITLE
Remove documentation about removed region field in backend service

### DIFF
--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -73,9 +73,6 @@ The following arguments are supported:
     for checking the health of the backend service. Currently at most one health
     check can be specified, and a health check is required.
 
-* `region` - (Optional) The region this backend service has been created in. If
-    unspecified, this defaults to the region configured in the provider.
-
 - - -
 
 * `backend` - (Optional) The list of backends that serve this BackendService. Structure is documented below.


### PR DESCRIPTION
Fixes #903

This field has been removed. The `google_compute_region_backend_service` should be used instead.