### PR TITLE
Make zone field consistent and truly optional for all resources

### DIFF
--- a/google/data_source_google_compute_instance_group.go
+++ b/google/data_source_google_compute_instance_group.go
@@ -18,11 +18,13 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 			"zone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"description": {

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -33,6 +33,7 @@ func resourceBigtableInstance() *schema.Resource {
 			"zone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -152,6 +153,11 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	c, err := config.bigtableClientFactory.NewInstanceAdminClient(project)
 	if err != nil {
 		return fmt.Errorf("Error starting instance admin client. %s", err)
@@ -167,6 +173,7 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("project", project)
+	d.Set("zone", zone)
 	d.Set("name", instance.Name)
 	d.Set("display_name", instance.DisplayName)
 

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -107,6 +107,7 @@ func resourceComputeAutoscaler() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -46,6 +46,7 @@ func resourceComputeDisk() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -306,12 +307,10 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 		disk = resource.(*compute.Disk)
 	}
 
-	zoneUrlParts := strings.Split(disk.Zone, "/")
-	typeUrlParts := strings.Split(disk.Type, "/")
 	d.Set("name", disk.Name)
 	d.Set("self_link", disk.SelfLink)
-	d.Set("type", typeUrlParts[len(typeUrlParts)-1])
-	d.Set("zone", zoneUrlParts[len(zoneUrlParts)-1])
+	d.Set("type", GetResourceNameFromSelfLink(disk.Type))
+	d.Set("zone", GetResourceNameFromSelfLink(disk.Zone))
 	d.Set("size", disk.SizeGb)
 	d.Set("users", disk.Users)
 	if disk.DiskEncryptionKey != nil && disk.DiskEncryptionKey.Sha256 != "" {

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -251,6 +251,7 @@ func resourceComputeInstance() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -861,6 +862,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
 	d.Set("instance_id", fmt.Sprintf("%d", instance.Id))
 	d.Set("project", project)
+	d.Set("zone", GetResourceNameFromSelfLink(instance.Zone))
 	d.Set("name", instance.Name)
 	d.SetId(instance.Name)
 

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -34,6 +34,7 @@ func resourceComputeInstanceGroup() *schema.Resource {
 			"zone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -240,6 +241,7 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("network", instanceGroup.Network)
 	d.Set("size", instanceGroup.Size)
 	d.Set("project", project)
+	d.Set("zone", zone)
 	d.Set("self_link", instanceGroup.SelfLink)
 
 	return nil

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -48,6 +48,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -27,6 +27,7 @@ func resourceComputeSnapshot() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -160,6 +161,11 @@ func resourceComputeSnapshotRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	zone, err := getZone(d, config)
+	if err != nil {
+		return err
+	}
+
 	snapshot, err := config.clientCompute.Snapshots.Get(
 		project, d.Id()).Do()
 	if err != nil {
@@ -181,6 +187,7 @@ func resourceComputeSnapshotRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("labels", snapshot.Labels)
 	d.Set("label_fingerprint", snapshot.LabelFingerprint)
 	d.Set("project", project)
+	d.Set("zone", zone)
 
 	return nil
 }

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -69,6 +69,7 @@ func resourceContainerCluster() *schema.Resource {
 			"zone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -622,6 +623,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("network", cluster.Network)
 	d.Set("subnetwork", cluster.Subnetwork)
 	d.Set("node_config", flattenNodeConfig(cluster.NodeConfig))
+	d.Set("zone", zoneName)
 	d.Set("project", project)
 	if cluster.AddonsConfig != nil {
 		d.Set("addons_config", flattenClusterAddonsConfig(cluster.AddonsConfig))

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -45,6 +45,7 @@ func resourceContainerNodePool() *schema.Resource {
 				"zone": &schema.Schema{
 					Type:     schema.TypeString,
 					Optional: true,
+					Computed: true,
 					ForceNew: true,
 				},
 				"cluster": &schema.Schema{
@@ -205,6 +206,7 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 		d.Set(k, v)
 	}
 
+	d.Set("zone", zone)
 	d.Set("project", project)
 
 	return nil


### PR DESCRIPTION
#816 enabled the `zone` field to be specified at the provider level.

However, a few resources such as `google_compute_disk` are setting the zone field in the read method. This was causing a perpetual diff if the zone was inferred from the provider default zone:
```sh
-/+ google_compute_disk.my-disk[0] (new resource required)
      disk_encryption_key_sha256: "" => "<computed>"
      label_fingerprint:          "42WmSpB8rSM=" => "<computed>"
      name:                       "my-disk-0" => "my-disk-0"
      project:                    "rosbo-personal" => "<computed>"
      self_link:                  "https://www.googleapis.com/compute/v1/projects/REDACTED/zones/us-central1-c/disks/my-disk-0" => "<computed>"
      size:                       "100" => "<computed>"
      type:                       "pd-ssd" => "pd-ssd"
      users.#:                    "0" => "<computed>"
      zone:                       "us-central1-c" => "" (forces new resource)
```

This fix marks all the `zone` field as `Computed` and is consistent about always setting the zone field in the state inside the read method.

cc/ @ndmckinley   