### PR TITLE
Make provider-wide region optional

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -40,7 +40,7 @@ func Provider() terraform.ResourceProvider {
 
 			"region": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"GOOGLE_REGION",
 					"GCLOUD_REGION",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -68,7 +68,7 @@ The following keys can be used to configure the provider.
     * `GCLOUD_PROJECT`
     * `CLOUDSDK_CORE_PROJECT`
 
-* `region` - (Required) The region to operate under, if not specified by a given resource.
+* `region` - (Optional) The region to operate under, if not specified by a given resource.
   This can also be specified using any of the following environment variables (listed in order of
   precedence):
 


### PR DESCRIPTION
This matches all the other provider-wide variables. It means that we won't catch issues with not specifying a region until apply-time, but it also means that users setting up resources that don't need a region no longer need to specify one.