### PR TITLE
Set default scopes when creating GKE clusters/node pools

### DIFF
--- a/google/node_config.go
+++ b/google/node_config.go
@@ -115,7 +115,7 @@ var schemaNodeConfig = &schema.Schema{
 func expandNodeConfig(v interface{}) *container.NodeConfig {
 	nodeConfigs := v.([]interface{})
 	nc := &container.NodeConfig{
-		// Defaults can't be set on a list in the schema, so set the default on create here.
+		// Defaults can't be set on a list/set in the schema, so set the default on create here.
 		OauthScopes: defaultOauthScopes,
 	}
 	if len(nodeConfigs) == 0 {

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -491,10 +491,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.AddonsConfig = expandClusterAddonsConfig(v)
 	}
 
-	if v, ok := d.GetOk("node_config"); ok {
-		cluster.NodeConfig = expandNodeConfig(v)
-	}
-
 	if v, ok := d.GetOk("enable_kubernetes_alpha"); ok {
 		cluster.EnableKubernetesAlpha = v.(bool)
 	}
@@ -511,6 +507,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			nodePools = append(nodePools, nodePool)
 		}
 		cluster.NodePools = nodePools
+	} else {
+		// Node Configs have default values that are set in the expand function,
+		// but can only be set if node pools are unspecified.
+		cluster.NodeConfig = expandNodeConfig([]interface{}{})
+	}
+
+	if v, ok := d.GetOk("node_config"); ok {
+		cluster.NodeConfig = expandNodeConfig(v)
 	}
 
 	if v, ok := d.GetOk("ip_allocation_policy"); ok {

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -324,10 +324,7 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 	np := &container.NodePool{
 		Name:             name,
 		InitialNodeCount: int64(nodeCount),
-	}
-
-	if v, ok := d.GetOk(prefix + "node_config"); ok {
-		np.Config = expandNodeConfig(v)
+		Config:           expandNodeConfig(d.Get(prefix + "node_config")),
 	}
 
 	if v, ok := d.GetOk(prefix + "autoscaling"); ok {


### PR DESCRIPTION
gcloud sets a whole bunch of scopes by default, match that list here. Fixes #898.