### PR TITLE
Fix typo in error message

### DIFF
--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -167,7 +167,7 @@ func resourceStorageBucketObjectCreate(d *schema.ResourceData, meta interface{})
 	} else if v, ok := d.GetOk("content"); ok {
 		media = bytes.NewReader([]byte(v.(string)))
 	} else {
-		return fmt.Errorf("Error, either \"content\" or \"string\" must be specified")
+		return fmt.Errorf("Error, either \"content\" or \"source\" must be specified")
 	}
 
 	objectsService := storage.NewObjectsService(config.clientStorage)


### PR DESCRIPTION
The error message should have been `source` instead of `string`.