### PR TITLE
Ensure Elem is always either a *Schema or *Resource

### DIFF
--- a/google/data_source_storage_object_signed_url.go
+++ b/google/data_source_storage_object_signed_url.go
@@ -62,7 +62,7 @@ func dataSourceGoogleSignedUrl() *schema.Resource {
 			"extension_headers": &schema.Schema{
 				Type:         schema.TypeMap,
 				Optional:     true,
-				Elem:         schema.TypeString,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 				ValidateFunc: validateExtensionHeaders,
 			},
 			"http_method": &schema.Schema{

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -33,7 +33,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"local_ssd_count": {
@@ -55,7 +55,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"min_cpu_platform": {

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -105,7 +105,7 @@ func resourceBigQueryDataset() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			// SelfLink: [Output-only] A URL that can be used to access the resource

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -78,7 +78,7 @@ func resourceBigQueryTable() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			// Schema: [Optional] Describes the schema of this table.

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -271,7 +271,7 @@ func resourceComputeInstance() *schema.Resource {
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"metadata_startup_script": &schema.Schema{

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -22,7 +22,7 @@ func resourceComputeProjectMetadata() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": &schema.Schema{
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Type:     schema.TypeMap,
 				Required: true,
 			},

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -76,7 +76,7 @@ func resourceDataprocCluster() *schema.Resource {
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				// GCP automatically adds two labels
 				//    'goog-dataproc-cluster-uuid'
 				//    'goog-dataproc-cluster-name'
@@ -257,7 +257,7 @@ func resourceDataprocCluster() *schema.Resource {
 										Type:     schema.TypeMap,
 										Optional: true,
 										ForceNew: true,
-										Elem:     schema.TypeString,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 
 									"properties": {

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -61,7 +61,7 @@ func resourcePubsubSubscription() *schema.Resource {
 						"attributes": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
 						"push_endpoint": &schema.Schema{

--- a/vendor/github.com/hashicorp/terraform/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/schema.go
@@ -582,15 +582,6 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 			return fmt.Errorf("%s: ConflictsWith cannot be set with Required", k)
 		}
 
-		if v.Elem != nil {
-			switch v.Elem.(type) {
-				case *Resource:
-				case *Schema:
-				default:
-				return fmt.Errorf("%s: Elem must be a *Resource or a *Schema", k)
-				}
-			}
-
 		if len(v.ConflictsWith) > 0 {
 			for _, key := range v.ConflictsWith {
 				parts := strings.Split(key, ".")

--- a/vendor/github.com/hashicorp/terraform/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/schema.go
@@ -582,6 +582,15 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 			return fmt.Errorf("%s: ConflictsWith cannot be set with Required", k)
 		}
 
+		if v.Elem != nil {
+			switch v.Elem.(type) {
+				case *Resource:
+				case *Schema:
+				default:
+				return fmt.Errorf("%s: Elem must be a *Resource or a *Schema", k)
+				}
+			}
+
 		if len(v.ConflictsWith) > 0 {
 			for _, key := range v.ConflictsWith {
 				parts := strings.Split(key, ".")


### PR DESCRIPTION
This PR prepares this provider for hashicorp/terraform#17037, which will cause Provider.InternalValidate to reject schemas which assign invalid types (anything other than a *Schema or a *Resource) to the Elem field of a Schema.

This mostly addresses issues where the expected type for a Map is provided directly rather than wrapped in schema.Schema{}. Today this is a non-issue, but will cause problems in the future if we enforce type checking on Map types.

