### PR TITLE
Subnetwork: Infers region from zone before using the provider-level region

### DIFF
--- a/google/utils.go
+++ b/google/utils.go
@@ -26,23 +26,13 @@ func getRegionFromZone(zone string) string {
 	return ""
 }
 
-// getRegion reads the "region" field from the given resource data and falls
-// back to the provider's value if not given. If the provider's value is not
-// given, checks for "zone" in either the given resource data or provider,
-// and extracts region from zone.  If "zone" is not provided, returns an
-// error.
+// Infers the region based on the following (in order of priority):
+// - `region` field in resource schema
+// - region extracted from the `zone` field in resource schema
+// - provider-level region
+// - region extracted from the provider-level zone
 func getRegion(d *schema.ResourceData, config *Config) (string, error) {
-	res, ok := d.GetOk("region")
-	if !ok {
-		if config.Region != "" {
-			return config.Region, nil
-		}
-		if zone, err := getZone(d, config); err == nil && getRegionFromZone(zone) != "" {
-			return getRegionFromZone(zone), nil
-		}
-		return "", fmt.Errorf("Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.")
-	}
-	return res.(string), nil
+	return getRegionFromSchema("region", "zone", d, config)
 }
 
 // getZone reads the "zone" value from the given resource data and falls back


### PR DESCRIPTION
Fixes #926 

Affects resources with a `zone` field in its schema and using the `getRegion` method:
- `google_compute_instance`
- `google_compute_disk`
- `google_compute_instance_template`

This change affects how region is inferred.

The main goal is to change how the region is inferred when a subnetwork is set using the name only (not a self_link).

We used to fallback to the provider-level region first. I changed that to infer the region from the zone in the schema first.

For example, given this config:
```hcl
resource "google_compute_instance" "default" {
  name = "test"
  zone = "asia-northeast1-b"
  machine_type = "g1-small"

  boot_disk {
    initialize_params {
      image = "${var.instance_image}"
      type = "pd-ssd"
    }
  }

  network_interface {
    subnetwork = "mirror"
    # Before, wrong region 
   # After, region is
  }
}

provider "google" {
  project = "${var.provider_project}"
  region = "us-central1"
} 

Before this change, the `subnetwork` used would be `projects/a-project/regions/us-central1/subnetworks/mirror`. 

After this change, the `subnetwork` used would be `projects/a-project/regions/asia-northeast1/subnetworks/mirror` which is what we want.

This should not break anybody because the region should match the zone for existing resource. It does help when people create new config using only the name for regional resources.