### PR TITLE
Deprecate the policy_data field of the google_service_account

### DIFF
--- a/google/resource_google_service_account.go
+++ b/google/resource_google_service_account.go
@@ -51,6 +51,7 @@ func resourceGoogleServiceAccount() *schema.Resource {
 			"policy_data": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Deprecated: "Use the 'google_service_account_iam_policy' resource to define policies for a service account",
 			},
 		},
 	}

--- a/google/resource_google_service_account.go
+++ b/google/resource_google_service_account.go
@@ -49,8 +49,8 @@ func resourceGoogleServiceAccount() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy_data": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
 				Deprecated: "Use the 'google_service_account_iam_policy' resource to define policies for a service account",
 			},
 		},


### PR DESCRIPTION
The `policy_data` field of the `google_service_account` resource was marked as Deprecated but not in the actual resource implementation.

See for more context: https://github.com/terraform-providers/terraform-provider-google/commit/a575c6e824d86916d0021544b705d9ce3451e681#commitcomment-26770241

cc/ @Cidan 