### PR TITLE
google/resource_source_repos_repository: Export repository url

### DIFF
--- a/google/resource_source_repos_repository.go
+++ b/google/resource_source_repos_repository.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/sourcerepo/v1"
 )
@@ -29,6 +30,11 @@ func resourceSourceRepoRepository() *schema.Resource {
 
 			"size": &schema.Schema{
 				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -80,6 +86,7 @@ func resourceSourceRepoRepositoryRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("size", repo.Size)
 	d.Set("project", project)
+	d.Set("url", repo.Url)
 
 	return nil
 }

--- a/website/docs/r/sourcerepo_repository.html.markdown
+++ b/website/docs/r/sourcerepo_repository.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attribute is exported:
+The following attributes are exported:
 
 * `size` - The size of the repository.
+* `url` - The url to clone the repository.

--- a/website/docs/r/sourcerepo_repository.html.markdown
+++ b/website/docs/r/sourcerepo_repository.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # google\_sourcerepo\_repository
 
 For more information, see [the official
-documentation](https://cloud.google.com/compute/docs/source-repositories) and
+documentation](https://cloud.google.com/source-repositories/) and
 [API](https://cloud.google.com/source-repositories/docs/reference/rest/v1/projects.repos)
 
 ## Example Usage


### PR DESCRIPTION
This PR exports a source repositories "url" and updates the source repositories official documentation link (which was 404'in)