### PR TITLE
Fix update when changing health check type

### DIFF
--- a/google/resource_compute_health_check.go
+++ b/google/resource_compute_health_check.go
@@ -322,6 +322,9 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 	hchk := &compute.HealthCheck{
 		Name: d.Get("name").(string),
 	}
+
+	nullFields := make([]string, 0, 3)
+
 	// Optional things
 	if v, ok := d.GetOk("description"); ok {
 		hchk.Description = v.(string)
@@ -355,6 +358,8 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 			tcpHealthCheck.Response = val.(string)
 		}
 		hchk.TcpHealthCheck = tcpHealthCheck
+	} else {
+		nullFields = append(nullFields, "TcpHealthCheck")
 	}
 	if v, ok := d.GetOk("ssl_health_check"); ok {
 		hchk.Type = "SSL"
@@ -373,6 +378,8 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 			sslHealthCheck.Response = val.(string)
 		}
 		hchk.SslHealthCheck = sslHealthCheck
+	} else {
+		nullFields = append(nullFields, "SslHealthCheck")
 	}
 	if v, ok := d.GetOk("http_health_check"); ok {
 		hchk.Type = "HTTP"
@@ -391,6 +398,8 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 			httpHealthCheck.RequestPath = val.(string)
 		}
 		hchk.HttpHealthCheck = httpHealthCheck
+	} else {
+		nullFields = append(nullFields, "HttpHealthCheck")
 	}
 
 	if v, ok := d.GetOk("https_health_check"); ok {
@@ -410,7 +419,11 @@ func resourceComputeHealthCheckUpdate(d *schema.ResourceData, meta interface{}) 
 			httpsHealthCheck.RequestPath = val.(string)
 		}
 		hchk.HttpsHealthCheck = httpsHealthCheck
+	} else {
+		nullFields = append(nullFields, "HttpsHealthCheck")
 	}
+
+	hchk.NullFields = nullFields
 
 	log.Printf("[DEBUG] HealthCheck patch request: %#v", hchk)
 	op, err := config.clientCompute.HealthChecks.Patch(

--- a/google/resource_compute_health_check_test.go
+++ b/google/resource_compute_health_check_test.go
@@ -168,6 +168,35 @@ func TestAccComputeHealthCheck_https(t *testing.T) {
 	})
 }
 
+func TestAccComputeHealthCheck_typeTransition(t *testing.T) {
+	t.Parallel()
+
+	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeHealthCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_https(hckName),
+			},
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_http(hckName),
+			},
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_ssl(hckName),
+			},
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_tcp(hckName),
+			},
+			resource.TestStep{
+				Config: testAccComputeHealthCheck_https(hckName),
+			},
+		},
+	})
+}
+
 func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #92 

When updating health check type, we have to make sure the previous health check type block is set to the json null value.