### PR TITLE
Add support for setting bucket's logging config

### DIFF
--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -223,6 +223,11 @@ func resourceStorageBucket() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"log_object_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -362,8 +367,7 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("logging") {
 		if v, ok := d.GetOk("logging"); ok {
 			sb.Logging = expandBucketLogging(v.([]interface{}))
-		}
-		if sb.Logging == nil {
+		} else {
 			sb.NullFields = append(sb.NullFields, "Logging")
 		}
 	}
@@ -521,7 +525,8 @@ func expandBucketLogging(configured interface{}) *storage.BucketLogging {
 	logging := loggings[0].(map[string]interface{})
 
 	bucketLogging := &storage.BucketLogging{
-		LogBucket: logging["log_bucket"].(string),
+		LogBucket:       logging["log_bucket"].(string),
+		LogObjectPrefix: logging["log_object_prefix"].(string),
 	}
 
 	return bucketLogging
@@ -535,7 +540,8 @@ func flattenBucketLogging(bucketLogging *storage.BucketLogging) []map[string]int
 	}
 
 	logging := map[string]interface{}{
-		"log_bucket": bucketLogging.LogBucket,
+		"log_bucket":        bucketLogging.LogBucket,
+		"log_object_prefix": bucketLogging.LogObjectPrefix,
 	}
 
 	loggings = append(loggings, logging)

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -397,10 +397,12 @@ func TestAccStorageBucket_logging(t *testing.T) {
 						"google_storage_bucket.bucket", "logging.#", "1"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "logging.0.log_bucket", "log-bucket"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "logging.0.log_object_prefix", bucketName),
 				),
 			},
 			resource.TestStep{
-				Config: testAccStorageBucket_logging(bucketName, "another-log-bucket"),
+				Config: testAccStorageBucket_loggingWithPrefix(bucketName, "another-log-bucket", "object-prefix"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
@@ -408,6 +410,8 @@ func TestAccStorageBucket_logging(t *testing.T) {
 						"google_storage_bucket.bucket", "logging.#", "1"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "logging.0.log_bucket", "another-log-bucket"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "logging.0.log_object_prefix", "object-prefix"),
 				),
 			},
 			resource.TestStep{
@@ -770,6 +774,18 @@ resource "google_storage_bucket" "bucket" {
 	}
 }
 `, bucketName, logBucketName)
+}
+
+func testAccStorageBucket_loggingWithPrefix(bucketName string, logBucketName string, prefix string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+	name = "%s"
+	logging = {
+		log_bucket = "%s"
+		log_object_prefix = "%s"
+	}
+}
+`, bucketName, logBucketName, prefix)
 }
 
 func testAccStorageBucket_lifecycleRules(bucketName string) string {

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the bucket.
 
+* `logging` - (Optional) The bucket's [Access & Storage Logs](https://cloud.google.com/storage/docs/access-logs) configuration.
+
 The `lifecycle_rule` block supports:
 
 * `action` - (Required) The Lifecycle Rule's action configuration. A single block of this type is supported. Structure is documented below.
@@ -107,6 +109,10 @@ The `cors` block supports:
 * `response_header` - (Optional) The list of HTTP headers other than the [simple response headers](https://www.w3.org/TR/cors/#simple-response-header) to give permission for the user-agent to share across domains.
     
 * `max_age_seconds` - (Optional) The value, in seconds, to return in the [Access-Control-Max-Age header](https://www.w3.org/TR/cors/#access-control-max-age-response-header) used in preflight responses.
+
+The `logging` block supports:
+
+* `log_bucket` - (Required) The bucket that will receive log objects.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -114,6 +114,9 @@ The `logging` block supports:
 
 * `log_bucket` - (Required) The bucket that will receive log objects.
 
+* `log_object_prefix` - (Optional, Computed) The object prefix for log objects. If it's not provided,
+    by default GCS sets this to the log_bucket's name.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
Mostly self explanatory, this enables setting up which bucket to log access/storage logs to.

In theory, GCP also allows us to set a log_object_prefix. Unfortunately I couldn't easily get this working, so this is a first step. It's also why logging ends up being a TypeList instead of TypeString... to allow for future support of log_object_prefix.

Setting log_object_prefix wasn't obvious for the following reasons... In theory, this should an optional field but GCP sets it to the bucket name by default. It wasn't straightforward to go back and forth from an explicitly set value to the default because the expected TF state is "" but GCP reports it as the bucket name. It seems like the easiest approach would be to set a Default(Func) value for log_object_prefix dynamically to be the bucket's name, but I couldn't figure out how to make this work. Open for suggestions here...