### PR TITLE
Revert "Ensure Elem is always either a *Schema or *Resource (#929)"

### DIFF
--- a/google/data_source_storage_object_signed_url.go
+++ b/google/data_source_storage_object_signed_url.go
@@ -62,7 +62,7 @@ func dataSourceGoogleSignedUrl() *schema.Resource {
 			"extension_headers": &schema.Schema{
 				Type:         schema.TypeMap,
 				Optional:     true,
-				Elem:         &schema.Schema{Type: schema.TypeString},
+				Elem:         schema.TypeString,
 				ValidateFunc: validateExtensionHeaders,
 			},
 			"http_method": &schema.Schema{

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -43,7 +43,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 			},
 
 			"local_ssd_count": {
@@ -65,7 +65,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 			},
 
 			"min_cpu_platform": {

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -105,7 +105,7 @@ func resourceBigQueryDataset() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 			},
 
 			// SelfLink: [Output-only] A URL that can be used to access the resource

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -78,7 +78,7 @@ func resourceBigQueryTable() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 			},
 
 			// Schema: [Optional] Describes the schema of this table.

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -271,7 +271,7 @@ func resourceComputeInstance() *schema.Resource {
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 			},
 
 			"metadata_startup_script": &schema.Schema{

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -22,7 +22,7 @@ func resourceComputeProjectMetadata() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": &schema.Schema{
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 				Type:     schema.TypeMap,
 				Required: true,
 			},

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -76,7 +76,7 @@ func resourceDataprocCluster() *schema.Resource {
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     schema.TypeString,
 				// GCP automatically adds two labels
 				//    'goog-dataproc-cluster-uuid'
 				//    'goog-dataproc-cluster-name'
@@ -253,7 +253,7 @@ func resourceDataprocCluster() *schema.Resource {
 										Type:     schema.TypeMap,
 										Optional: true,
 										ForceNew: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem:     schema.TypeString,
 									},
 
 									"properties": {

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -61,7 +61,7 @@ func resourcePubsubSubscription() *schema.Resource {
 						"attributes": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem:     schema.TypeString,
 						},
 
 						"push_endpoint": &schema.Schema{


### PR DESCRIPTION
This reverts commit a3352655ac6f6861302358d394a54a1c6a74fcd5.

The matching change to the AWS provider tickled an issue in field writing. Out of caution, let's revert this change until I address the issue in Terraform which caused problems in the AWS provider.