### PR TITLE
Add support for Google Cloud IoT Core registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ IMPROVEMENTS:
 * compute: Add update support for `routing_mode` in `google_compute_network` [GH-857]
 * compute: Add import support for `google_compute_instance` [GH-873]
 * compute: More descriptive error message for health check not found in `google_compute_target_pool` [GH-883]
+* compute: Add `disable_on_destroy` (default true) for `google_project_service`. [GH-965]
 * container: Ensure operations on a cluster are applied serially [GH-937]
 * container: Don't recreate container_cluster when maintenance_window changes [GH-893]
 * dataproc: Add "internal IP only" support for Dataproc clusters [GH-837]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ BUG FIXES:
 * compute: Read IAP settings properly in `google_compute_backend_service` [GH-907]
 * compute: Fix bug causing a crash when specifying unknown network in `google_compute_network_peering` [GH-918]
 * compute: Fix failing update when changing `google_compute_health_check` type [GH-944]
+* compute: Fix bug blocking `google_compute_autoscaler` from containing multiple metrics. [GH-966]
 * container: Set default scopes when creating GKE clusters/node pools [GH-924]
 * storage: Fix bug blocking the update of a storage object if its content is dynamic/interpolated [GH-848]
 * storage: Fix bug preventing the removal of lifecycle rules for a `google_storage_bucket` [GH-850]

--- a/google/config.go
+++ b/google/config.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/cloudbilling/v1"
 	"google.golang.org/api/cloudfunctions/v1"
+	"google.golang.org/api/cloudiot/v1"
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
@@ -68,6 +69,7 @@ type Config struct {
 	clientServiceMan             *servicemanagement.APIService
 	clientBigQuery               *bigquery.Service
 	clientCloudFunctions         *cloudfunctions.Service
+	clientCloudiot               *cloudiot.Service
 
 	bigtableClientFactory *BigtableClientFactory
 }
@@ -287,6 +289,13 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientDataproc.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating Google Cloud IoT Core Client...")
+	c.clientCloudiot, err = cloudiot.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientCloudiot.UserAgent = userAgent
 
 	return nil
 }

--- a/google/provider.go
+++ b/google/provider.go
@@ -88,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 			"google_bigtable_instance":                     resourceBigtableInstance(),
 			"google_bigtable_table":                        resourceBigtableTable(),
 			"google_cloudfunctions_function":               resourceCloudFunctionsFunction(),
+			"google_cloudiot_registry":                     resourceCloudiotRegistry(),
 			"google_compute_autoscaler":                    resourceComputeAutoscaler(),
 			"google_compute_address":                       resourceComputeAddress(),
 			"google_compute_backend_bucket":                resourceComputeBackendBucket(),

--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -291,7 +291,7 @@ func resourceCloudiotRegistryCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	updateMask := make([]string, 5)
+	updateMask := make([]string, 0, 5)
 	hasChanged := false
 	deviceRegistry := &cloudiot.DeviceRegistry{}
 
@@ -362,9 +362,8 @@ func resourceCloudiotRegistryRead(d *schema.ResourceData, meta interface{}) erro
 
 	if res.EventNotificationConfigs != nil {
 		eventConfigs := make([]map[string]string, len(res.EventNotificationConfigs))
-		for _, config := range res.EventNotificationConfigs {
-			eventConfigs = append(eventConfigs,
-				map[string]string{"pubsub_topic_name": config.PubsubTopicName})
+		for i, config := range res.EventNotificationConfigs {
+			eventConfigs[i] = map[string]string{"pubsub_topic_name": config.PubsubTopicName}
 		}
 		d.Set("event_notification_configs", eventConfigs)
 	}
@@ -397,7 +396,7 @@ func resourceCloudiotRegistryRead(d *schema.ResourceData, meta interface{}) erro
 
 	if res.Credentials != nil {
 		credentials := make([]map[string]interface{}, len(res.Credentials))
-		for _, item := range res.Credentials {
+		for i, item := range res.Credentials {
 			pubcert := make(map[string]interface{})
 
 			pubcert["format"] = item.PublicKeyCertificate.Format
@@ -408,13 +407,13 @@ func resourceCloudiotRegistryRead(d *schema.ResourceData, meta interface{}) erro
 				pubcert["x509_details"] = map[string]interface{}{
 					"issuer":              x509details.Issuer,
 					"subject":             x509details.Subject,
-					"start_date":          x509details.StartTime,
+					"start_time":          x509details.StartTime,
 					"expiry_time":         x509details.ExpiryTime,
 					"signature_algorithm": x509details.SignatureAlgorithm,
 					"public_key_type":     x509details.PublicKeyType,
 				}
 			}
-			credentials = append(credentials, pubcert)
+			credentials[i] = pubcert
 		}
 		d.Set("credentials", credentials)
 	}

--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -1,0 +1,444 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"google.golang.org/api/cloudiot/v1"
+	"strings"
+)
+
+const (
+	mqttStateUnspecified  = "MQTT_STATE_UNSPECIFIED"
+	mqttEnabled           = "MQTT_ENABLED"
+	mqttDisabled          = "MQTT_DISABLED"
+	httpStateUnspecified  = "HTTP_STATE_UNSPECIFIED"
+	httpEnabled           = "HTTP_ENABLED"
+	httpDisabled          = "HTTP_DISABLED"
+	unspecifiedCertFormat = "UNSPECIFIED_PUBLIC_KEY_CERTIFICATE_FORMAT"
+	x509CertificatePEM    = "X509_CERTIFICATE_PEM"
+)
+
+func resourceCloudiotRegistry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudiotRegistryCreate,
+		Update: resourceCloudiotRegistryUpdate,
+		Read:   resourceCloudiotRegistryRead,
+		Delete: resourceCloudiotRegistryDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudiotRegistryStateImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: linkDiffSuppress,
+			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"event_notification_configs": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"pubsub_topic_name": &schema.Schema{
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+						},
+					},
+				},
+			},
+			"state_notification_config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"pubsub_topic_name": &schema.Schema{
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: compareSelfLinkOrResourceName,
+						},
+					},
+				},
+			},
+			"mqtt_config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mqtt_enabled_state": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  mqttStateUnspecified,
+							ValidateFunc: validation.StringInSlice(
+								[]string{mqttStateUnspecified, mqttEnabled, mqttDisabled}, false),
+						},
+					},
+				},
+			},
+			"http_config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_enabled_state": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  httpStateUnspecified,
+							ValidateFunc: validation.StringInSlice(
+								[]string{httpStateUnspecified, httpEnabled, httpDisabled}, false),
+						},
+					},
+				},
+			},
+			"credentials": &schema.Schema{
+				// Removed original "public_key_certificate" wrapper object. Additional nesting caused
+				// problems with schema parsing.
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"format": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{unspecifiedCertFormat, x509CertificatePEM}, false),
+						},
+						"certificate": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"x509_details": &schema.Schema{
+							Type:     schema.TypeMap,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"issuer": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"subject": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"start_time": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"expiry_time": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"signature_algorithm": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"public_key_type": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func expandEventNotificationConfigs(configs []interface{}) []*cloudiot.EventNotificationConfig {
+	eventConfigs := make([]*cloudiot.EventNotificationConfig, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		eventConfigs[i] = &cloudiot.EventNotificationConfig{
+			PubsubTopicName: data["pubsub_topic_name"].(string),
+		}
+	}
+	return eventConfigs
+}
+
+func expandStateNotificationConfig(config map[string]interface{}) *cloudiot.StateNotificationConfig {
+	if v, ok := config["pubsub_topic_name"]; ok {
+		return &cloudiot.StateNotificationConfig{
+			PubsubTopicName: v.(string),
+		}
+	}
+	return nil
+}
+
+func expandMqttConfig(config map[string]interface{}) *cloudiot.MqttConfig {
+	if v, ok := config["mqtt_enabled_state"]; ok {
+		return &cloudiot.MqttConfig{
+			MqttEnabledState: v.(string),
+		}
+	}
+	return nil
+}
+
+func expandHttpConfig(config map[string]interface{}) *cloudiot.HttpConfig {
+	if v, ok := config["http_enabled_state"]; ok {
+		return &cloudiot.HttpConfig{
+			HttpEnabledState: v.(string),
+		}
+	}
+	return nil
+}
+
+func expandX509Details(x509Details map[string]interface{}) *cloudiot.X509CertificateDetails {
+	return &cloudiot.X509CertificateDetails{
+		Issuer:             x509Details["issuer"].(string),
+		Subject:            x509Details["subject"].(string),
+		StartTime:          x509Details["start_time"].(string),
+		ExpiryTime:         x509Details["expiry_time"].(string),
+		SignatureAlgorithm: x509Details["signature_algorithm"].(string),
+		PublicKeyType:      x509Details["public_key_type"].(string),
+	}
+}
+
+func expandPublicKeyCertificate(certificate map[string]interface{}) *cloudiot.PublicKeyCertificate {
+	return &cloudiot.PublicKeyCertificate{
+		Format:      certificate["format"].(string),
+		Certificate: certificate["certificate"].(string),
+		X509Details: expandX509Details(certificate["x509_details"].(map[string]interface{})),
+	}
+}
+
+func expandCredentials(credentials []interface{}) []*cloudiot.RegistryCredential {
+	certificates := make([]*cloudiot.RegistryCredential, len(credentials))
+	for i, raw := range credentials {
+		cred := raw.(map[string]interface{})
+
+		certificates[i] = &cloudiot.RegistryCredential{
+			PublicKeyCertificate: expandPublicKeyCertificate(cred), // ["public_key_certificate"]
+		}
+	}
+	return certificates
+}
+
+func expandDeviceRegistry(d *schema.ResourceData) *cloudiot.DeviceRegistry {
+	deviceRegistry := &cloudiot.DeviceRegistry{}
+	if v, ok := d.GetOk("event_notification_configs"); ok {
+		deviceRegistry.EventNotificationConfigs = expandEventNotificationConfigs(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("state_notification_config"); ok {
+		deviceRegistry.StateNotificationConfig = expandStateNotificationConfig(v.(map[string]interface{}))
+
+	}
+	if v, ok := d.GetOk("mqtt_config"); ok {
+		deviceRegistry.MqttConfig = expandMqttConfig(v.(map[string]interface{}))
+
+	}
+	if v, ok := d.GetOk("http_config"); ok {
+		deviceRegistry.HttpConfig = expandHttpConfig(v.(map[string]interface{}))
+
+	}
+	if v, ok := d.GetOk("credentials"); ok {
+		deviceRegistry.Credentials = expandCredentials(v.([]interface{}))
+
+	}
+	return deviceRegistry
+}
+
+func resourceCloudiotRegistryCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	parent := fmt.Sprintf("projects/%s/locations/%s", project, region)
+
+	deviceRegistry := expandDeviceRegistry(d)
+	deviceRegistry.Id = d.Get("name").(string)
+
+	call := config.clientCloudiot.Projects.Locations.Registries.Create(parent, deviceRegistry)
+	res, err := call.Do()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(res.Name)
+	print(d.Id())
+
+	return nil
+}
+
+func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	updateMask := make([]string, 5)
+	hasChanged := false
+	deviceRegistry := &cloudiot.DeviceRegistry{}
+
+	d.Partial(true)
+
+	if d.HasChange("event_notification_configs") {
+		hasChanged = true
+		updateMask = append(updateMask, "event_notification_configs")
+		if v, ok := d.GetOk("event_notification_configs"); ok {
+			deviceRegistry.EventNotificationConfigs = expandEventNotificationConfigs(v.([]interface{}))
+		}
+	}
+	if d.HasChange("state_notification_config") {
+		hasChanged = true
+		if v, ok := d.GetOk("state_notification_config"); ok {
+			deviceRegistry.StateNotificationConfig = expandStateNotificationConfig(v.(map[string]interface{}))
+
+		}
+	}
+	if d.HasChange("mqtt_config") {
+		hasChanged = true
+		if v, ok := d.GetOk("mqtt_config"); ok {
+			deviceRegistry.MqttConfig = expandMqttConfig(v.(map[string]interface{}))
+
+		}
+	}
+	if d.HasChange("http_config") {
+		hasChanged = true
+		if v, ok := d.GetOk("http_config"); ok {
+			deviceRegistry.HttpConfig = expandHttpConfig(v.(map[string]interface{}))
+
+		}
+	}
+	if d.HasChange("credentials") {
+		hasChanged = true
+		if v, ok := d.GetOk("credentials"); ok {
+			deviceRegistry.Credentials = expandCredentials(v.([]interface{}))
+
+		}
+	}
+
+	if hasChanged {
+		_, err := config.clientCloudiot.Projects.Locations.Registries.Patch(d.Id(),
+			deviceRegistry).UpdateMask(strings.Join(updateMask, ",")).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating registry %s: %s", d.Get("name").(string), err)
+		}
+		for _, updateMaskItem := range updateMask {
+			d.SetPartial(updateMaskItem)
+		}
+	}
+
+	d.Partial(false)
+
+	return resourceCloudiotRegistryRead(d, meta)
+}
+
+func resourceCloudiotRegistryRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	name := d.Id()
+	res, err := config.clientCloudiot.Projects.Locations.Registries.Get(name).Do()
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Registry %q", name))
+	}
+
+	d.Set("name", res.Id)
+
+	if res.EventNotificationConfigs != nil {
+		eventConfigs := make([]map[string]string, len(res.EventNotificationConfigs))
+		for _, config := range res.EventNotificationConfigs {
+			eventConfigs = append(eventConfigs, map[string]string{"pubsub_topic_name": config.PubsubTopicName})
+		}
+		d.Set("event_notification_configs", eventConfigs)
+	}
+	if res.StateNotificationConfig != nil {
+		d.Set("state_notification_config",
+			map[string]string{"pubsub_topic_name": res.StateNotificationConfig.PubsubTopicName})
+	}
+	if res.MqttConfig != nil {
+		d.Set("mqtt_config",
+			map[string]string{"mqtt_enabled_state": res.MqttConfig.MqttEnabledState})
+	}
+	if res.HttpConfig != nil {
+		d.Set("http_config",
+			map[string]string{"http_enabled_state": res.HttpConfig.HttpEnabledState})
+	}
+
+	if res.Credentials != nil {
+		credentials := make([]map[string]interface{}, len(res.Credentials))
+		for _, item := range res.Credentials {
+			pubcert := make(map[string]interface{})
+
+			pubcert["format"] = item.PublicKeyCertificate.Format
+			pubcert["certificate"] = item.PublicKeyCertificate.Certificate
+
+			x509details := item.PublicKeyCertificate.X509Details
+			if x509details != nil {
+				pubcert["x509_details"] = map[string]interface{}{
+					"issuer":              x509details.Issuer,
+					"subject":             x509details.Subject,
+					"start_date":          x509details.StartTime,
+					"expiry_time":         x509details.ExpiryTime,
+					"signature_algorithm": x509details.SignatureAlgorithm,
+					"public_key_type":     x509details.PublicKeyType,
+				}
+			}
+			credentials = append(credentials, pubcert)
+		}
+		d.Set("credentials", credentials)
+	}
+
+	return nil
+}
+
+func resourceCloudiotRegistryDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	name := d.Id()
+	call := config.clientCloudiot.Projects.Locations.Registries.Delete(name)
+	_, err := call.Do()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceCloudiotRegistryStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	id := fmt.Sprintf("projects/%s/locations/%s/registries/%s", project, region, d.Id())
+
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -218,11 +218,14 @@ func expandX509Details(x509Details map[string]interface{}) *cloudiot.X509Certifi
 }
 
 func expandPublicKeyCertificate(certificate map[string]interface{}) *cloudiot.PublicKeyCertificate {
-	return &cloudiot.PublicKeyCertificate{
+	cert := &cloudiot.PublicKeyCertificate{
 		Format:      certificate["format"].(string),
 		Certificate: certificate["certificate"].(string),
-		X509Details: expandX509Details(certificate["x509_details"].(map[string]interface{})),
 	}
+	if len(certificate["x509_details"].(map[string]interface{})) != 0 {
+		cert.X509Details = expandX509Details(certificate["x509_details"].(map[string]interface{}))
+	}
+	return cert
 }
 
 func expandCredentials(credentials []interface{}) []*cloudiot.RegistryCredential {
@@ -307,6 +310,7 @@ func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	if d.HasChange("state_notification_config") {
 		hasChanged = true
+		updateMask = append(updateMask, "state_notification_config")
 		if v, ok := d.GetOk("state_notification_config"); ok {
 			deviceRegistry.StateNotificationConfig = expandStateNotificationConfig(v.(map[string]interface{}))
 
@@ -314,6 +318,7 @@ func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	if d.HasChange("mqtt_config") {
 		hasChanged = true
+		updateMask = append(updateMask, "mqtt_config")
 		if v, ok := d.GetOk("mqtt_config"); ok {
 			deviceRegistry.MqttConfig = expandMqttConfig(v.(map[string]interface{}))
 
@@ -321,6 +326,7 @@ func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	if d.HasChange("http_config") {
 		hasChanged = true
+		updateMask = append(updateMask, "http_config")
 		if v, ok := d.GetOk("http_config"); ok {
 			deviceRegistry.HttpConfig = expandHttpConfig(v.(map[string]interface{}))
 
@@ -328,6 +334,7 @@ func resourceCloudiotRegistryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	if d.HasChange("credentials") {
 		hasChanged = true
+		updateMask = append(updateMask, "credentials")
 		if v, ok := d.GetOk("credentials"); ok {
 			deviceRegistry.Credentials = expandCredentials(v.([]interface{}))
 

--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -54,6 +54,7 @@ func resourceCloudiotRegistry() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: false,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pubsub_topic_name": &schema.Schema{

--- a/google/resource_cloudiot_registry_test.go
+++ b/google/resource_cloudiot_registry_test.go
@@ -1,0 +1,72 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudiotRegistryCreate(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudiotRegistry(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudiotRegistryExists(
+						"google_cloudiot_registry.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudiotRegistryDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_cloudiot_registry" {
+			continue
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		registry, _ := config.clientCloudiot.Projects.Locations.Registries.Get(rs.Primary.ID).Do()
+		if registry != nil {
+			return fmt.Errorf("Registry still present")
+		}
+	}
+
+	return nil
+}
+
+func testAccCloudiotRegistryExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*Config)
+		_, err := config.clientCloudiot.Projects.Locations.Registries.Get(rs.Primary.ID).Do()
+		if err != nil {
+			return fmt.Errorf("Topic does not exist")
+		}
+
+		return nil
+	}
+}
+
+func testAccCloudiotRegistry() string {
+	return fmt.Sprintf(`
+resource "google_cloudiot_registry" "foobar" {
+	name = "psregistry-test-%s"
+}`, acctest.RandString(10))
+}

--- a/google/resource_cloudiot_registry_test.go
+++ b/google/resource_cloudiot_registry_test.go
@@ -12,13 +12,15 @@ import (
 func TestAccCloudiotRegistryCreate_basic(t *testing.T) {
 	t.Parallel()
 
+	registryName := fmt.Sprintf("psregistry-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCloudiotRegistry_basic(),
+				Config: testAccCloudiotRegistry_basic(registryName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudiotRegistryExists(
 						"google_cloudiot_registry.foobar"),
@@ -31,16 +33,46 @@ func TestAccCloudiotRegistryCreate_basic(t *testing.T) {
 func TestAccCloudiotRegistryCreate_extended(t *testing.T) {
 	t.Parallel()
 
+	registryName := fmt.Sprintf("psregistry-test-%s", acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCloudiotRegistry_extended(),
+				Config: testAccCloudiotRegistry_extended(registryName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudiotRegistryExists(
-						"google_cloudiot_registry.foobar-extended"),
+						"google_cloudiot_registry.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudiotRegistryUpdate(t *testing.T) {
+	t.Parallel()
+
+	registryName := fmt.Sprintf("psregistry-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudiotRegistry_basic(registryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudiotRegistryExists(
+						"google_cloudiot_registry.foobar"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCloudiotRegistry_extended(registryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudiotRegistryUpdate(
+						"google_cloudiot_registry.foobar"),
 				),
 			},
 		},
@@ -76,21 +108,85 @@ func testAccCloudiotRegistryExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientCloudiot.Projects.Locations.Registries.Get(rs.Primary.ID).Do()
 		if err != nil {
-			return fmt.Errorf("Topic does not exist")
+			return fmt.Errorf("Registry does not exist")
 		}
 
 		return nil
 	}
 }
 
-func testAccCloudiotRegistry_basic() string {
-	return fmt.Sprintf(`
-resource "google_cloudiot_registry" "foobar" {
-	name = "psregistry-test-%s"
-}`, acctest.RandString(10))
+func testAccCloudiotRegistryUpdate(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*Config)
+		registry, err := config.clientCloudiot.Projects.Locations.Registries.Get(rs.Primary.ID).Do()
+		if err != nil {
+			return fmt.Errorf("Registry does not exist")
+		}
+
+		if len(registry.EventNotificationConfigs) != 1 {
+			return fmt.Errorf("Registry event notification topic missing")
+		}
+		if registry.StateNotificationConfig.PubsubTopicName == "" {
+			return fmt.Errorf("Registry state notification topic is not set correctly")
+		}
+		if registry.MqttConfig.MqttEnabledState != "MQTT_DISABLED" {
+			return fmt.Errorf("Registry mqtt config is not disabled")
+		}
+		if registry.HttpConfig.HttpEnabledState != "HTTP_DISABLED" {
+			return fmt.Errorf("Registry http config is not disabled")
+		}
+		if len(registry.Credentials) != 1 {
+			return fmt.Errorf("Registry credentials missing")
+		}
+		if registry.Credentials[0].PublicKeyCertificate.Format != "X509_CERTIFICATE_PEM" {
+			return fmt.Errorf("Registry certificate format not set correctly")
+		}
+		if registry.Credentials[0].PublicKeyCertificate.Certificate == "" {
+			return fmt.Errorf("Registry certificate not set correctly")
+		}
+		x509Details := registry.Credentials[0].PublicKeyCertificate.X509Details
+		if x509Details == nil {
+			return fmt.Errorf("Registry certificate x509 details not set correctly")
+		}
+		if x509Details.Issuer != "CN=unused" {
+			return fmt.Errorf("Registry certificate x509 issuer not set correctly")
+		}
+		if x509Details.Subject != "CN=unused" {
+			return fmt.Errorf("Registry certificate x509 subject not set correctly")
+		}
+		if x509Details.StartTime != "2018-01-12T20:13:43Z" {
+			return fmt.Errorf("Registry certificate x509 start time not set correctly")
+		}
+		if x509Details.ExpiryTime != "2023-01-11T20:13:43Z" {
+			return fmt.Errorf("Registry certificate x509 expire time not set correctly")
+		}
+		if x509Details.SignatureAlgorithm != "sha256WithRSAEncryption" {
+			return fmt.Errorf("Registry certificate x509 signature algorithm not set correctly")
+		}
+		if x509Details.PublicKeyType != "PK_RSA" {
+			return fmt.Errorf("Registry certificate x509 public key type not set correctly")
+		}
+
+		return nil
+	}
 }
 
-func testAccCloudiotRegistry_extended() string {
+func testAccCloudiotRegistry_basic(registryName string) string {
+	return fmt.Sprintf(`
+resource "google_cloudiot_registry" "foobar" {
+	name = "%s"
+}`, registryName)
+}
+
+func testAccCloudiotRegistry_extended(registryName string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "default-devicestatus" {
   name = "psregistry-test-devicestatus-%s"
@@ -100,7 +196,7 @@ resource "google_pubsub_topic" "default-telemetry" {
   name = "psregistry-test-telemetry-%s"
 }
 
-resource "google_cloudiot_registry" "foobar-extended" {
+resource "google_cloudiot_registry" "foobar" {
   name = "psregistry-test-%s"
 
   event_notification_configs = [{
@@ -116,7 +212,7 @@ resource "google_cloudiot_registry" "foobar-extended" {
   }
 
   mqtt_config = {
-    mqtt_enabled_state = "MQTT_ENABLED"
+    mqtt_enabled_state = "MQTT_DISABLED"
   }
 
   credentials = [
@@ -136,5 +232,5 @@ resource "google_cloudiot_registry" "foobar-extended" {
   ]
 }
 
-`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+`, acctest.RandString(10), acctest.RandString(10), registryName)
 }

--- a/google/resource_cloudiot_registry_test.go
+++ b/google/resource_cloudiot_registry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccCloudiotRegistryCreate(t *testing.T) {
+func TestAccCloudiotRegistryCreate_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -18,10 +18,29 @@ func TestAccCloudiotRegistryCreate(t *testing.T) {
 		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCloudiotRegistry(),
+				Config: testAccCloudiotRegistry_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudiotRegistryExists(
 						"google_cloudiot_registry.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudiotRegistryCreate_extended(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudiotRegistryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCloudiotRegistry_extended(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCloudiotRegistryExists(
+						"google_cloudiot_registry.foobar-extended"),
 				),
 			},
 		},
@@ -64,9 +83,58 @@ func testAccCloudiotRegistryExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCloudiotRegistry() string {
+func testAccCloudiotRegistry_basic() string {
 	return fmt.Sprintf(`
 resource "google_cloudiot_registry" "foobar" {
 	name = "psregistry-test-%s"
 }`, acctest.RandString(10))
+}
+
+func testAccCloudiotRegistry_extended() string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "default-devicestatus" {
+  name = "psregistry-test-devicestatus-%s"
+}
+
+resource "google_pubsub_topic" "default-telemetry" {
+  name = "psregistry-test-telemetry-%s"
+}
+
+resource "google_cloudiot_registry" "foobar-extended" {
+  name = "psregistry-test-%s"
+
+  event_notification_configs = [{
+    pubsub_topic_name = "${google_pubsub_topic.default-devicestatus.id}"
+  }]
+
+  state_notification_config = {
+    pubsub_topic_name = "${google_pubsub_topic.default-telemetry.id}"
+  }
+
+  http_config = {
+    http_enabled_state = "HTTP_DISABLED"
+  }
+
+  mqtt_config = {
+    mqtt_enabled_state = "MQTT_ENABLED"
+  }
+
+  credentials = [
+    {
+      format      = "X509_CERTIFICATE_PEM"
+      certificate = "-----BEGIN CERTIFICATE-----\nMIICnjCCAYYCCQC/5gx7LgJFqTANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ1\nbnVzZWQwHhcNMTgwMTEyMjAxMzQzWhcNMjMwMTExMjAxMzQzWjARMQ8wDQYDVQQD\nDAZ1bnVzZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDStfQvJzmN\nCYLSWpwvTmyCKn8t19cfWZ69wFaB3OSglxXgYe3w9An0QHybDpKITt61PpfsKov3\nEcnzH5IA+Ox+4jUppBL1mSkO/BWig+sd1dG7pQMbGi4nMxW704A0PRUaNIOarOlR\nrNUJZQrsghkMjLayCTJ2HISBBiPnKKB3f3KCc9sDhj2Z7zy7HfeW0apZ1m6xAQCC\neSZNW0IyGIYKTd9F7HEJFzOWg9JHvabbciBEcFWKGVzM8nQr1q8KU8Xi3iN2mpNK\nJkbRLNnqKhvjPyIZ4s4cDSEZN1/OaGQ4XP2mvU03+4UAoMPoJ8IczBKTB0mFxfX8\nlDZZa5IWU9sNAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHnkTIghRj/cerR9ctji\nkancnjlsdNEuPiVpMj+SOtOH8cvlgl0oWG6segYTVzk4VEHlq3POB67Yjoz829XM\nCEgUxSqGvDrQ7IaPLPryYy8o5azMLnEZDr+Yd6CUKr/pUZzJoZxHj7z3iqeQZnMW\nS6kb6HYvG5PKlJ7+JUIKLou0RQmaM9BQ0Nln/YDRRIerD0MY9k7No2ZEDbywZqQK\nGRIqT+BlN84oHOR44h2RqWhn9O50tkbcmAIKgmeg/mxwmeAm/6hQ8VrOhDHqsFdT\nzh2l6IeCl8EF8MjNrFRcQx21TTqeU6vGIPgM3E0k8PQUc+s+lir8UFsIzKaOFsIh\nuKU=\n-----END CERTIFICATE-----\n"
+
+      x509_details = {
+        issuer              = "CN=unused"
+        subject             = "CN=unused"
+        start_time          = "2018-01-12T20:13:43Z"
+        expiry_time         = "2023-01-11T20:13:43Z"
+        signature_algorithm = "sha256WithRSAEncryption"
+        public_key_type     = "PK_RSA"
+      }
+    },
+  ]
+}
+
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 }

--- a/google/resource_cloudiot_registry_test.go
+++ b/google/resource_cloudiot_registry_test.go
@@ -152,28 +152,6 @@ func testAccCloudiotRegistryUpdate(n string) resource.TestCheckFunc {
 		if registry.Credentials[0].PublicKeyCertificate.Certificate == "" {
 			return fmt.Errorf("Registry certificate not set correctly")
 		}
-		x509Details := registry.Credentials[0].PublicKeyCertificate.X509Details
-		if x509Details == nil {
-			return fmt.Errorf("Registry certificate x509 details not set correctly")
-		}
-		if x509Details.Issuer != "CN=unused" {
-			return fmt.Errorf("Registry certificate x509 issuer not set correctly")
-		}
-		if x509Details.Subject != "CN=unused" {
-			return fmt.Errorf("Registry certificate x509 subject not set correctly")
-		}
-		if x509Details.StartTime != "2018-01-12T20:13:43Z" {
-			return fmt.Errorf("Registry certificate x509 start time not set correctly")
-		}
-		if x509Details.ExpiryTime != "2023-01-11T20:13:43Z" {
-			return fmt.Errorf("Registry certificate x509 expire time not set correctly")
-		}
-		if x509Details.SignatureAlgorithm != "sha256WithRSAEncryption" {
-			return fmt.Errorf("Registry certificate x509 signature algorithm not set correctly")
-		}
-		if x509Details.PublicKeyType != "PK_RSA" {
-			return fmt.Errorf("Registry certificate x509 public key type not set correctly")
-		}
 
 		return nil
 	}
@@ -217,20 +195,12 @@ resource "google_cloudiot_registry" "foobar" {
 
   credentials = [
     {
-      format      = "X509_CERTIFICATE_PEM"
-      certificate = "-----BEGIN CERTIFICATE-----\nMIICnjCCAYYCCQC/5gx7LgJFqTANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ1\nbnVzZWQwHhcNMTgwMTEyMjAxMzQzWhcNMjMwMTExMjAxMzQzWjARMQ8wDQYDVQQD\nDAZ1bnVzZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDStfQvJzmN\nCYLSWpwvTmyCKn8t19cfWZ69wFaB3OSglxXgYe3w9An0QHybDpKITt61PpfsKov3\nEcnzH5IA+Ox+4jUppBL1mSkO/BWig+sd1dG7pQMbGi4nMxW704A0PRUaNIOarOlR\nrNUJZQrsghkMjLayCTJ2HISBBiPnKKB3f3KCc9sDhj2Z7zy7HfeW0apZ1m6xAQCC\neSZNW0IyGIYKTd9F7HEJFzOWg9JHvabbciBEcFWKGVzM8nQr1q8KU8Xi3iN2mpNK\nJkbRLNnqKhvjPyIZ4s4cDSEZN1/OaGQ4XP2mvU03+4UAoMPoJ8IczBKTB0mFxfX8\nlDZZa5IWU9sNAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHnkTIghRj/cerR9ctji\nkancnjlsdNEuPiVpMj+SOtOH8cvlgl0oWG6segYTVzk4VEHlq3POB67Yjoz829XM\nCEgUxSqGvDrQ7IaPLPryYy8o5azMLnEZDr+Yd6CUKr/pUZzJoZxHj7z3iqeQZnMW\nS6kb6HYvG5PKlJ7+JUIKLou0RQmaM9BQ0Nln/YDRRIerD0MY9k7No2ZEDbywZqQK\nGRIqT+BlN84oHOR44h2RqWhn9O50tkbcmAIKgmeg/mxwmeAm/6hQ8VrOhDHqsFdT\nzh2l6IeCl8EF8MjNrFRcQx21TTqeU6vGIPgM3E0k8PQUc+s+lir8UFsIzKaOFsIh\nuKU=\n-----END CERTIFICATE-----\n"
-
-      x509_details = {
-        issuer              = "CN=unused"
-        subject             = "CN=unused"
-        start_time          = "2018-01-12T20:13:43Z"
-        expiry_time         = "2023-01-11T20:13:43Z"
-        signature_algorithm = "sha256WithRSAEncryption"
-        public_key_type     = "PK_RSA"
+      "public_key_certificate" = {
+        format      = "X509_CERTIFICATE_PEM"
+        certificate = "-----BEGIN CERTIFICATE-----\nMIICnjCCAYYCCQC/5gx7LgJFqTANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ1\nbnVzZWQwHhcNMTgwMTEyMjAxMzQzWhcNMjMwMTExMjAxMzQzWjARMQ8wDQYDVQQD\nDAZ1bnVzZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDStfQvJzmN\nCYLSWpwvTmyCKn8t19cfWZ69wFaB3OSglxXgYe3w9An0QHybDpKITt61PpfsKov3\nEcnzH5IA+Ox+4jUppBL1mSkO/BWig+sd1dG7pQMbGi4nMxW704A0PRUaNIOarOlR\nrNUJZQrsghkMjLayCTJ2HISBBiPnKKB3f3KCc9sDhj2Z7zy7HfeW0apZ1m6xAQCC\neSZNW0IyGIYKTd9F7HEJFzOWg9JHvabbciBEcFWKGVzM8nQr1q8KU8Xi3iN2mpNK\nJkbRLNnqKhvjPyIZ4s4cDSEZN1/OaGQ4XP2mvU03+4UAoMPoJ8IczBKTB0mFxfX8\nlDZZa5IWU9sNAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHnkTIghRj/cerR9ctji\nkancnjlsdNEuPiVpMj+SOtOH8cvlgl0oWG6segYTVzk4VEHlq3POB67Yjoz829XM\nCEgUxSqGvDrQ7IaPLPryYy8o5azMLnEZDr+Yd6CUKr/pUZzJoZxHj7z3iqeQZnMW\nS6kb6HYvG5PKlJ7+JUIKLou0RQmaM9BQ0Nln/YDRRIerD0MY9k7No2ZEDbywZqQK\nGRIqT+BlN84oHOR44h2RqWhn9O50tkbcmAIKgmeg/mxwmeAm/6hQ8VrOhDHqsFdT\nzh2l6IeCl8EF8MjNrFRcQx21TTqeU6vGIPgM3E0k8PQUc+s+lir8UFsIzKaOFsIh\nuKU=\n-----END CERTIFICATE-----\n"
       }
     },
   ]
 }
-
 `, acctest.RandString(10), acctest.RandString(10), registryName)
 }

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -34,6 +34,7 @@ var autoscalingPolicy *schema.Schema = &schema.Schema{
 			"cpu_utilization": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"target": &schema.Schema{
@@ -69,6 +70,7 @@ var autoscalingPolicy *schema.Schema = &schema.Schema{
 			"load_balancing_utilization": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"target": &schema.Schema{
@@ -145,6 +147,8 @@ func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
 		scaler.Description = v.(string)
 	}
 
+	// You can only have 0 or 1 autoscaling policy per autoscaler, but HCL can't easily express
+	// "optional object", so instead we have "list of maximum size 1".
 	prefix := "autoscaling_policy.0."
 
 	scaler.AutoscalingPolicy = &compute.AutoscalingPolicy{
@@ -153,39 +157,29 @@ func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
 		CoolDownPeriodSec: int64(d.Get(prefix + "cooldown_period").(int)),
 	}
 
-	// Check that only one autoscaling policy is defined
-	policyCounter := 0
+	// This list is MaxItems = 1 as well - you can only have 0 or 1 cpu utilization target per autoscaler.
 	if _, ok := d.GetOk(prefix + "cpu_utilization"); ok {
 		if d.Get(prefix+"cpu_utilization.0.target").(float64) != 0 {
-			cpuUtilCount := d.Get(prefix + "cpu_utilization.#").(int)
-			if cpuUtilCount != 1 {
-				return nil, fmt.Errorf("The autoscaling_policy must have exactly one cpu_utilization, found %d.", cpuUtilCount)
-			}
-			policyCounter++
 			scaler.AutoscalingPolicy.CpuUtilization = &compute.AutoscalingPolicyCpuUtilization{
 				UtilizationTarget: d.Get(prefix + "cpu_utilization.0.target").(float64),
 			}
 		}
 	}
-	if _, ok := d.GetOk("autoscaling_policy.0.metric"); ok {
-		if d.Get(prefix+"metric.0.name") != "" {
-			policyCounter++
-			metricCount := d.Get(prefix + "metric.#").(int)
-			if metricCount != 1 {
-				return nil, fmt.Errorf("The autoscaling_policy must have exactly one metric, found %d.", metricCount)
-			}
-			scaler.AutoscalingPolicy.CustomMetricUtilizations = []*compute.AutoscalingPolicyCustomMetricUtilization{
-				{
-					Metric:                d.Get(prefix + "metric.0.name").(string),
-					UtilizationTarget:     d.Get(prefix + "metric.0.target").(float64),
-					UtilizationTargetType: d.Get(prefix + "metric.0.type").(string),
-				},
+	var customMetrics []*compute.AutoscalingPolicyCustomMetricUtilization
+	if metricCount, ok := d.GetOk(prefix + "metric.#"); ok {
+		for m := 0; m < metricCount.(int); m++ {
+			if d.Get(fmt.Sprintf("%smetric.%d.name", prefix, m)) != "" {
+				customMetrics = append(customMetrics, &compute.AutoscalingPolicyCustomMetricUtilization{
+					Metric:                d.Get(fmt.Sprintf("%smetric.%d.name", prefix, m)).(string),
+					UtilizationTarget:     d.Get(fmt.Sprintf("%smetric.%d.target", prefix, m)).(float64),
+					UtilizationTargetType: d.Get(fmt.Sprintf("%smetric.%d.type", prefix, m)).(string),
+				})
 			}
 		}
 	}
+	scaler.AutoscalingPolicy.CustomMetricUtilizations = customMetrics
 	if _, ok := d.GetOk("autoscaling_policy.0.load_balancing_utilization"); ok {
 		if d.Get(prefix+"load_balancing_utilization.0.target").(float64) != 0 {
-			policyCounter++
 			lbuCount := d.Get(prefix + "load_balancing_utilization.#").(int)
 			if lbuCount != 1 {
 				return nil, fmt.Errorf("The autoscaling_policy must have exactly one load_balancing_utilization, found %d.", lbuCount)
@@ -194,10 +188,6 @@ func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
 				UtilizationTarget: d.Get(prefix + "load_balancing_utilization.0.target").(float64),
 			}
 		}
-	}
-
-	if policyCounter != 1 {
-		return nil, fmt.Errorf("One policy must be defined for an autoscaler.")
 	}
 
 	return scaler, nil
@@ -271,6 +261,8 @@ func flattenAutoscalingPolicy(policy *compute.AutoscalingPolicy) []map[string]in
 		for _, customMetricUtilization := range policy.CustomMetricUtilizations {
 			metricUtil := make(map[string]interface{})
 			metricUtil["target"] = customMetricUtilization.UtilizationTarget
+			metricUtil["name"] = customMetricUtilization.Metric
+			metricUtil["type"] = customMetricUtilization.UtilizationTargetType
 			metricUtils = append(metricUtils, metricUtil)
 		}
 		policyMap["metric"] = metricUtils

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -176,7 +176,7 @@ func testAccCheckComputeAutoscalerMultifunction(n string) resource.TestCheckFunc
 		if found.AutoscalingPolicy.CpuUtilization.UtilizationTarget == 0.5 && found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget == 0.5 {
 			return nil
 		}
-		return fmt.Errorf("Util target for CPU: %d, for LB: %d - should have been 0.5 for each.",
+		return fmt.Errorf("Util target for CPU: %f, for LB: %f - should have been 0.5 for each.",
 			found.AutoscalingPolicy.CpuUtilization.UtilizationTarget,
 			found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget)
 

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -77,6 +77,32 @@ func TestAccComputeAutoscaler_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeAutoscaler_multicondition(t *testing.T) {
+	t.Parallel()
+
+	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var tp_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var igm_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var autoscaler_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeAutoscalerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeAutoscaler_multicondition(it_name, tp_name, igm_name, autoscaler_name),
+				Check:  testAccCheckComputeAutoscalerMultifunction("google_compute_autoscaler.foobar"),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_autoscaler.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeAutoscalerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -124,6 +150,39 @@ func testAccCheckComputeAutoscalerExists(n string, ascaler *compute.Autoscaler) 
 	}
 }
 
+func testAccCheckComputeAutoscalerMultifunction(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.Autoscalers.Get(
+			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Autoscaler not found")
+		}
+
+		if found.AutoscalingPolicy.CpuUtilization.UtilizationTarget == 0.5 && found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget == 0.5 {
+			return nil
+		}
+		return fmt.Errorf("Util target for CPU: %d, for LB: %d - should have been 0.5 for each.",
+			found.AutoscalingPolicy.CpuUtilization.UtilizationTarget,
+			found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget)
+
+	}
+}
+
 func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -151,7 +210,7 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 	}
 }
 
-func testAccComputeAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
@@ -192,7 +251,12 @@ resource "google_compute_instance_group_manager" "foobar" {
 	base_instance_name = "foobar"
 	zone = "us-central1-a"
 }
+`, it_name, tp_name, igm_name)
 
+}
+
+func testAccComputeAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	name = "%s"
@@ -208,51 +272,11 @@ resource "google_compute_autoscaler" "foobar" {
 	}
 
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
 }
 
 func testAccComputeAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance_template" "foobar" {
-	name = "%s"
-	machine_type = "n1-standard-1"
-	can_ip_forward = false
-	tags = ["foo", "bar"]
-
-	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
-		auto_delete = true
-		boot = true
-	}
-
-	network_interface {
-		network = "default"
-	}
-
-	metadata {
-		foo = "bar"
-	}
-
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
-}
-
-resource "google_compute_target_pool" "foobar" {
-	description = "Resource created for Terraform acceptance testing"
-	name = "%s"
-	session_affinity = "CLIENT_IP_PROTO"
-}
-
-resource "google_compute_instance_group_manager" "foobar" {
-	description = "Terraform test instance group manager"
-	name = "%s"
-	instance_template = "${google_compute_instance_template.foobar.self_link}"
-	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
-	base_instance_name = "foobar"
-	zone = "us-central1-a"
-}
-
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	name = "%s"
@@ -268,5 +292,38 @@ resource "google_compute_autoscaler" "foobar" {
 	}
 
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
+}
+
+func testAccComputeAutoscaler_multicondition(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
+resource "google_compute_autoscaler" "foobar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "%s"
+	zone = "us-central1-a"
+	target = "${google_compute_instance_group_manager.foobar.self_link}"
+	autoscaling_policy = {
+		max_replicas = 10
+		min_replicas = 1
+		cooldown_period = 60
+		cpu_utilization = {
+			target = 0.5
+		}
+		load_balancing_utilization = {
+			target = 0.5
+		}
+		metric {
+			name = "compute.googleapis.com/instance/network/received_bytes_count"
+			target = 75
+			type = "GAUGE"
+		}
+		metric {
+			name = "compute.googleapis.com/instance/network/sent_bytes_count"
+			target = 50
+			type = "GAUGE"
+		}
+	}
+
+}
+`, autoscaler_name)
 }

--- a/google/resource_google_project_service_test.go
+++ b/google/resource_google_project_service_test.go
@@ -33,6 +33,20 @@ func TestAccGoogleProjectService_basic(t *testing.T) {
 					testAccCheckProjectService(services, pid, false),
 				),
 			},
+			// Create services with disabling turned off.
+			resource.TestStep{
+				Config: testAccGoogleProjectService_noDisable(services, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectService(services, pid, true),
+				),
+			},
+			// Check that services are still enabled even after the resources are deleted.
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectService(services, pid, true),
+				),
+			},
 		},
 	})
 }
@@ -81,6 +95,28 @@ resource "google_project_service" "test" {
 resource "google_project_service" "test2" {
   project = "${google_project.acceptance.project_id}"
   service = "%s"
+}
+`, pid, name, org, services[0], services[1])
+}
+
+func testAccGoogleProjectService_noDisable(services []string, pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+}
+
+resource "google_project_service" "test" {
+  project = "${google_project.acceptance.project_id}"
+  service = "%s"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "test2" {
+  project = "${google_project.acceptance.project_id}"
+  service = "%s"
+  disable_on_destroy = false
 }
 `, pid, name, org, services[0], services[1])
 }

--- a/vendor/google.golang.org/api/cloudiot/v1/cloudiot-api.json
+++ b/vendor/google.golang.org/api/cloudiot/v1/cloudiot-api.json
@@ -1,0 +1,1311 @@
+{
+  "fullyEncodeReservedExpansion": true,
+  "title": "Google Cloud IoT API",
+  "ownerName": "Google",
+  "resources": {
+    "projects": {
+      "resources": {
+        "locations": {
+          "resources": {
+            "registries": {
+              "methods": {
+                "getIamPolicy": {
+                  "request": {
+                    "$ref": "GetIamPolicyRequest"
+                  },
+                  "description": "Gets the access control policy for a resource.\nReturns an empty policy if the resource exists and does not have a policy\nset.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being requested.\nSee the operation documentation for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:getIamPolicy",
+                  "id": "cloudiot.projects.locations.registries.getIamPolicy",
+                  "path": "v1/{+resource}:getIamPolicy"
+                },
+                "get": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+                  "path": "v1/{+name}",
+                  "id": "cloudiot.projects.locations.registries.get",
+                  "description": "Gets a device registry configuration.",
+                  "response": {
+                    "$ref": "DeviceRegistry"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "name": {
+                      "description": "The name of the device registry. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+                      "location": "path"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ]
+                },
+                "patch": {
+                  "httpMethod": "PATCH",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "DeviceRegistry"
+                  },
+                  "parameters": {
+                    "updateMask": {
+                      "description": "Only updates the `device_registry` fields indicated by this mask.\nThe field mask must not be empty, and it must not contain fields that\nare immutable or only set by the server.\nMutable top-level fields: `event_notification_config`, `http_config`,\n`mqtt_config`, and `state_notification_config`.",
+                      "format": "google-fieldmask",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "name": {
+                      "location": "path",
+                      "description": "The resource path name. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+                  "id": "cloudiot.projects.locations.registries.patch",
+                  "path": "v1/{+name}",
+                  "request": {
+                    "$ref": "DeviceRegistry"
+                  },
+                  "description": "Updates a device registry configuration."
+                },
+                "testIamPermissions": {
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "description": "Returns permissions that a caller has on the specified resource.\nIf the resource does not exist, this will return an empty set of\npermissions, not a NOT_FOUND error.",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested.\nSee the operation documentation for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:testIamPermissions",
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "id": "cloudiot.projects.locations.registries.testIamPermissions"
+                },
+                "delete": {
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "DELETE",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "description": "The name of the device registry. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+                  "path": "v1/{+name}",
+                  "id": "cloudiot.projects.locations.registries.delete",
+                  "description": "Deletes a device registry configuration."
+                },
+                "list": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries",
+                  "path": "v1/{+parent}/registries",
+                  "id": "cloudiot.projects.locations.registries.list",
+                  "description": "Lists device registries.",
+                  "response": {
+                    "$ref": "ListDeviceRegistriesResponse"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "httpMethod": "GET",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "parameters": {
+                    "pageSize": {
+                      "description": "The maximum number of registries to return in the response. If this value\nis zero, the service will select a default size. A call may return fewer\nobjects than requested, but if there is a non-empty `page_token`, it\nindicates that more entries are available.",
+                      "format": "int32",
+                      "type": "integer",
+                      "location": "query"
+                    },
+                    "parent": {
+                      "description": "The project and cloud region path. For example,\n`projects/example-project/locations/us-central1`.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "location": "path"
+                    },
+                    "pageToken": {
+                      "location": "query",
+                      "description": "The value returned by the last `ListDeviceRegistriesResponse`; indicates\nthat this is a continuation of a prior `ListDeviceRegistries` call, and\nthat the system should return the next page of data.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "create": {
+                  "request": {
+                    "$ref": "DeviceRegistry"
+                  },
+                  "description": "Creates a device registry that contains devices.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "response": {
+                    "$ref": "DeviceRegistry"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "location": "path",
+                      "description": "The project and cloud region where this device registry must be created.\nFor example, `projects/example-project/locations/us-central1`.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries",
+                  "id": "cloudiot.projects.locations.registries.create",
+                  "path": "v1/{+parent}/registries"
+                },
+                "setIamPolicy": {
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/cloudiot"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being specified.\nSee the operation documentation for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "id": "cloudiot.projects.locations.registries.setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any\nexisting policy.",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  }
+                }
+              },
+              "resources": {
+                "devices": {
+                  "methods": {
+                    "delete": {
+                      "description": "Deletes a device.",
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "DELETE",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+                      "path": "v1/{+name}",
+                      "id": "cloudiot.projects.locations.registries.devices.delete"
+                    },
+                    "list": {
+                      "description": "List devices in a device registry.",
+                      "response": {
+                        "$ref": "ListDevicesResponse"
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "httpMethod": "GET",
+                      "parameters": {
+                        "pageToken": {
+                          "location": "query",
+                          "description": "The value returned by the last `ListDevicesResponse`; indicates\nthat this is a continuation of a prior `ListDevices` call, and\nthat the system should return the next page of data.",
+                          "type": "string"
+                        },
+                        "fieldMask": {
+                          "description": "The fields of the `Device` resource to be returned in the response. The\nfields `id`, and `num_id` are always returned by default, along with any\nother fields specified.",
+                          "format": "google-fieldmask",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "pageSize": {
+                          "description": "The maximum number of devices to return in the response. If this value\nis zero, the service will select a default size. A call may return fewer\nobjects than requested, but if there is a non-empty `page_token`, it\nindicates that more entries are available.",
+                          "format": "int32",
+                          "type": "integer",
+                          "location": "query"
+                        },
+                        "deviceIds": {
+                          "description": "A list of device string identifiers. If empty, it will ignore this field.\nFor example, `['device0', 'device12']`. This field cannot hold more than\n10,000 entries.",
+                          "type": "string",
+                          "repeated": true,
+                          "location": "query"
+                        },
+                        "parent": {
+                          "description": "The device registry path. Required. For example,\n`projects/my-project/locations/us-central1/registries/my-registry`.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+                          "location": "path"
+                        },
+                        "deviceNumIds": {
+                          "description": "A list of device numerical ids. If empty, it will ignore this field. This\nfield cannot hold more than 10,000 entries.",
+                          "format": "uint64",
+                          "type": "string",
+                          "repeated": true,
+                          "location": "query"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices",
+                      "path": "v1/{+parent}/devices",
+                      "id": "cloudiot.projects.locations.registries.devices.list"
+                    },
+                    "create": {
+                      "response": {
+                        "$ref": "Device"
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "parent": {
+                          "description": "The name of the device registry where this device should be created.\nFor example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices",
+                      "path": "v1/{+parent}/devices",
+                      "id": "cloudiot.projects.locations.registries.devices.create",
+                      "request": {
+                        "$ref": "Device"
+                      },
+                      "description": "Creates a device in a device registry."
+                    },
+                    "modifyCloudToDeviceConfig": {
+                      "request": {
+                        "$ref": "ModifyCloudToDeviceConfigRequest"
+                      },
+                      "description": "Modifies the configuration for the device, which is eventually sent from\nthe Cloud IoT Core servers. Returns the modified configuration version and\nits metadata.",
+                      "response": {
+                        "$ref": "DeviceConfig"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "name": {
+                          "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}:modifyCloudToDeviceConfig",
+                      "path": "v1/{+name}:modifyCloudToDeviceConfig",
+                      "id": "cloudiot.projects.locations.registries.devices.modifyCloudToDeviceConfig"
+                    },
+                    "patch": {
+                      "description": "Updates a device.",
+                      "request": {
+                        "$ref": "Device"
+                      },
+                      "response": {
+                        "$ref": "Device"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "PATCH",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "parameters": {
+                        "updateMask": {
+                          "description": "Only updates the `device` fields indicated by this mask.\nThe field mask must not be empty, and it must not contain fields that\nare immutable or only set by the server.\nMutable top-level fields: `credentials`, `enabled_state`, and `metadata`",
+                          "format": "google-fieldmask",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "name": {
+                          "description": "The resource path name. For example,\n`projects/p1/locations/us-central1/registries/registry0/devices/dev0` or\n`projects/p1/locations/us-central1/registries/registry0/devices/{num_id}`.\nWhen `name` is populated as a response from the service, it always ends\nin the device numeric ID.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+                      "path": "v1/{+name}",
+                      "id": "cloudiot.projects.locations.registries.devices.patch"
+                    },
+                    "get": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+                      "path": "v1/{+name}",
+                      "id": "cloudiot.projects.locations.registries.devices.get",
+                      "description": "Gets details about a device.",
+                      "response": {
+                        "$ref": "Device"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/cloudiot"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$"
+                        },
+                        "fieldMask": {
+                          "description": "The fields of the `Device` resource to be returned in the response. If the\nfield mask is unset or empty, all fields are returned.",
+                          "format": "google-fieldmask",
+                          "type": "string",
+                          "location": "query"
+                        }
+                      }
+                    }
+                  },
+                  "resources": {
+                    "configVersions": {
+                      "methods": {
+                        "list": {
+                          "description": "Lists the last few versions of the device configuration in descending\norder (i.e.: newest first).",
+                          "response": {
+                            "$ref": "ListDeviceConfigVersionsResponse"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform",
+                            "https://www.googleapis.com/auth/cloudiot"
+                          ],
+                          "parameters": {
+                            "numVersions": {
+                              "description": "The number of versions to list. Versions are listed in decreasing order of\nthe version number. The maximum number of versions retained is 10. If this\nvalue is zero, it will return all the versions available.",
+                              "format": "int32",
+                              "type": "integer",
+                              "location": "query"
+                            },
+                            "name": {
+                              "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+                              "required": true,
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+                              "location": "path"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}/configVersions",
+                          "path": "v1/{+name}/configVersions",
+                          "id": "cloudiot.projects.locations.registries.devices.configVersions.list"
+                        }
+                      }
+                    },
+                    "states": {
+                      "methods": {
+                        "list": {
+                          "response": {
+                            "$ref": "ListDeviceStatesResponse"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform",
+                            "https://www.googleapis.com/auth/cloudiot"
+                          ],
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+                              "required": true,
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$"
+                            },
+                            "numStates": {
+                              "description": "The number of states to list. States are listed in descending order of\nupdate time. The maximum number of states retained is 10. If this\nvalue is zero, it will return all the states available.",
+                              "format": "int32",
+                              "type": "integer",
+                              "location": "query"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}/states",
+                          "path": "v1/{+name}/states",
+                          "id": "cloudiot.projects.locations.registries.devices.states.list",
+                          "description": "Lists the last few versions of the device state in descending order (i.e.:\nnewest first)."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query",
+      "enum": [
+        "1",
+        "2"
+      ]
+    },
+    "callback": {
+      "description": "JSONP",
+      "type": "string",
+      "location": "query"
+    },
+    "alt": {
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "description": "Data format for response.",
+      "default": "json",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string"
+    },
+    "key": {
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string"
+    },
+    "access_token": {
+      "description": "OAuth access token.",
+      "type": "string",
+      "location": "query"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string",
+      "location": "query"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "type": "boolean",
+      "default": "true",
+      "location": "query"
+    },
+    "oauth_token": {
+      "location": "query",
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string"
+    },
+    "bearer_token": {
+      "description": "OAuth bearer token.",
+      "type": "string",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean",
+      "default": "true"
+    }
+  },
+  "version": "v1",
+  "baseUrl": "https://cloudiot.googleapis.com/",
+  "kind": "discovery#restDescription",
+  "description": "Registers and manages IoT (Internet of Things) devices that connect to the Google Cloud Platform.\n",
+  "servicePath": "",
+  "basePath": "",
+  "revision": "20180103",
+  "documentationLink": "https://cloud.google.com/iot",
+  "id": "cloudiot:v1",
+  "discoveryVersion": "v1",
+  "version_module": true,
+  "schemas": {
+    "TestIamPermissionsResponse": {
+      "description": "Response message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is\nallowed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "TestIamPermissionsResponse"
+    },
+    "GetIamPolicyRequest": {
+      "description": "Request message for `GetIamPolicy` method.",
+      "type": "object",
+      "properties": {},
+      "id": "GetIamPolicyRequest"
+    },
+    "Device": {
+      "description": "The device resource.",
+      "type": "object",
+      "properties": {
+        "blocked": {
+          "description": "If a device is blocked, connections or requests from this device will fail.\nCan be used to temporarily prevent the device from connecting if, for\nexample, the sensor is generating bad data and needs maintenance.",
+          "type": "boolean"
+        },
+        "lastHeartbeatTime": {
+          "description": "[Output only] The last time a heartbeat was received. Timestamps are\nperiodically collected and written to storage; they may be stale by a few\nminutes. This field is only for devices connecting through MQTT.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "lastEventTime": {
+          "description": "[Output only] The last time a telemetry event was received. Timestamps are\nperiodically collected and written to storage; they may be stale by a few\nminutes.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "lastConfigSendTime": {
+          "description": "[Output only] The last time a cloud-to-device config version was sent to\nthe device.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "lastErrorStatus": {
+          "description": "[Output only] The error message of the most recent error, such as a failure\nto publish to Cloud Pub/Sub. 'last_error_time' is the timestamp of this\nfield. If no errors have occurred, this field has an empty message\nand the status code 0 == OK. Otherwise, this field is expected to have a\nstatus code other than OK.",
+          "$ref": "Status"
+        },
+        "lastStateTime": {
+          "description": "[Output only] The last time a state event was received. Timestamps are\nperiodically collected and written to storage; they may be stale by a few\nminutes.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "state": {
+          "$ref": "DeviceState",
+          "description": "[Output only] The state most recently received from the device. If no state\nhas been reported, this field is not present."
+        },
+        "config": {
+          "description": "The most recent device configuration, which is eventually sent from\nCloud IoT Core to the device. If not present on creation, the\nconfiguration will be initialized with an empty payload and version value\nof `1`. To update this field after creation, use the\n`DeviceManager.ModifyCloudToDeviceConfig` method.",
+          "$ref": "DeviceConfig"
+        },
+        "credentials": {
+          "description": "The credentials used to authenticate this device. To allow credential\nrotation without interruption, multiple device credentials can be bound to\nthis device. No more than 3 credentials can be bound to a single device at\na time. When new credentials are added to a device, they are verified\nagainst the registry credentials. For details, see the description of the\n`DeviceRegistry.credentials` field.",
+          "type": "array",
+          "items": {
+            "$ref": "DeviceCredential"
+          }
+        },
+        "name": {
+          "description": "The resource path name. For example,\n`projects/p1/locations/us-central1/registries/registry0/devices/dev0` or\n`projects/p1/locations/us-central1/registries/registry0/devices/{num_id}`.\nWhen `name` is populated as a response from the service, it always ends\nin the device numeric ID.",
+          "type": "string"
+        },
+        "lastErrorTime": {
+          "description": "[Output only] The time the most recent error occurred, such as a failure to\npublish to Cloud Pub/Sub. This field is the timestamp of\n'last_error_status'.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "metadata": {
+          "description": "The metadata key-value pairs assigned to the device. This metadata is not\ninterpreted or indexed by Cloud IoT Core. It can be used to add contextual\ninformation for the device.\n\nKeys must conform to the regular expression [a-zA-Z0-9-_]+ and be less than\n128 bytes in length.\n\nValues are free-form strings. Each value must be less than or equal to 32\nKB in size.\n\nThe total size of all keys and values must be less than 256 KB, and the\nmaximum number of key-value pairs is 500.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The user-defined device identifier. The device ID must be unique\nwithin a device registry.",
+          "type": "string"
+        },
+        "lastConfigAckTime": {
+          "description": "[Output only] The last time a cloud-to-device config version acknowledgment\nwas received from the device. This field is only for configurations\nsent through MQTT.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "numId": {
+          "description": "[Output only] A server-defined unique numeric ID for the device. This is a\nmore compact way to identify devices, and it is globally unique.",
+          "format": "uint64",
+          "type": "string"
+        }
+      },
+      "id": "Device"
+    },
+    "ListDeviceConfigVersionsResponse": {
+      "description": "Response for `ListDeviceConfigVersions`.",
+      "type": "object",
+      "properties": {
+        "deviceConfigs": {
+          "description": "The device configuration for the last few versions. Versions are listed\nin decreasing order, starting from the most recent one.",
+          "type": "array",
+          "items": {
+            "$ref": "DeviceConfig"
+          }
+        }
+      },
+      "id": "ListDeviceConfigVersionsResponse"
+    },
+    "X509CertificateDetails": {
+      "description": "Details of an X.509 certificate. For informational purposes only.",
+      "type": "object",
+      "properties": {
+        "signatureAlgorithm": {
+          "description": "The algorithm used to sign the certificate.",
+          "type": "string"
+        },
+        "expiryTime": {
+          "description": "The time the certificate becomes invalid.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "startTime": {
+          "description": "The time the certificate becomes valid.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "subject": {
+          "description": "The entity the certificate and public key belong to.",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "The entity that signed the certificate.",
+          "type": "string"
+        },
+        "publicKeyType": {
+          "description": "The type of public key in the certificate.",
+          "type": "string"
+        }
+      },
+      "id": "X509CertificateDetails"
+    },
+    "SetIamPolicyRequest": {
+      "description": "Request message for `SetIamPolicy` method.",
+      "type": "object",
+      "properties": {
+        "updateMask": {
+          "description": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only\nthe fields in the mask will be modified. If no mask is provided, the\nfollowing default mask is used:\npaths: \"bindings, etag\"\nThis field is only used by Cloud IAM.",
+          "format": "google-fieldmask",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "Policy",
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of\nthe policy is limited to a few 10s of KB. An empty policy is a\nvalid policy but certain Cloud Platform services (such as Projects)\nmight reject them."
+        }
+      },
+      "id": "SetIamPolicyRequest"
+    },
+    "EventNotificationConfig": {
+      "description": "The configuration to forward telemetry events.",
+      "type": "object",
+      "properties": {
+        "pubsubTopicName": {
+          "description": "A Cloud Pub/Sub topic name. For example,\n`projects/myProject/topics/deviceEvents`.",
+          "type": "string"
+        }
+      },
+      "id": "EventNotificationConfig"
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }\n\nThe JSON representation for `Empty` is empty JSON object `{}`.",
+      "type": "object",
+      "properties": {},
+      "id": "Empty"
+    },
+    "PublicKeyCredential": {
+      "description": "A public key format and data.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The key data.",
+          "type": "string"
+        },
+        "format": {
+          "description": "The format of the key.",
+          "type": "string",
+          "enumDescriptions": [
+            "The format has not been specified. This is an invalid default value and\nmust not be used.",
+            "An RSA public key encoded in base64, and wrapped by\n`-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----`. This can be\nused to verify `RS256` signatures in JWT tokens ([RFC7518](\nhttps://www.ietf.org/rfc/rfc7518.txt)).",
+            "As RSA_PEM, but wrapped in an X.509v3 certificate ([RFC5280](\nhttps://www.ietf.org/rfc/rfc5280.txt)), encoded in base64, and wrapped by\n`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.",
+            "Public key for the ECDSA algorithm using P-256 and SHA-256, encoded in\nbase64, and wrapped by `-----BEGIN PUBLIC KEY-----` and `-----END\nPUBLIC KEY-----`. This can be used to verify JWT tokens with the `ES256`\nalgorithm ([RFC7518](https://www.ietf.org/rfc/rfc7518.txt)). This curve is\ndefined in [OpenSSL](https://www.openssl.org/) as the `prime256v1` curve.",
+            "As ES256_PEM, but wrapped in an X.509v3 certificate ([RFC5280](\nhttps://www.ietf.org/rfc/rfc5280.txt)), encoded in base64, and wrapped by\n`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`."
+          ],
+          "enum": [
+            "UNSPECIFIED_PUBLIC_KEY_FORMAT",
+            "RSA_PEM",
+            "RSA_X509_PEM",
+            "ES256_PEM",
+            "ES256_X509_PEM"
+          ]
+        }
+      },
+      "id": "PublicKeyCredential"
+    },
+    "PublicKeyCertificate": {
+      "description": "A public key certificate format and data.",
+      "type": "object",
+      "properties": {
+        "x509Details": {
+          "description": "[Output only] The certificate details. Used only for X.509 certificates.",
+          "$ref": "X509CertificateDetails"
+        },
+        "format": {
+          "description": "The certificate format.",
+          "type": "string",
+          "enumDescriptions": [
+            "The format has not been specified. This is an invalid default value and\nmust not be used.",
+            "An X.509v3 certificate ([RFC5280](https://www.ietf.org/rfc/rfc5280.txt)),\nencoded in base64, and wrapped by `-----BEGIN CERTIFICATE-----` and\n`-----END CERTIFICATE-----`."
+          ],
+          "enum": [
+            "UNSPECIFIED_PUBLIC_KEY_CERTIFICATE_FORMAT",
+            "X509_CERTIFICATE_PEM"
+          ]
+        },
+        "certificate": {
+          "description": "The certificate data.",
+          "type": "string"
+        }
+      },
+      "id": "PublicKeyCertificate"
+    },
+    "DeviceState": {
+      "description": "The device state, as reported by the device.",
+      "type": "object",
+      "properties": {
+        "updateTime": {
+          "description": "[Output only] The time at which this state version was updated in Cloud\nIoT Core.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "binaryData": {
+          "description": "The device state data.",
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "id": "DeviceState"
+    },
+    "AuditLogConfig": {
+      "description": "Provides the configuration for logging a type of permissions.\nExample:\n\n    {\n      \"audit_log_configs\": [\n        {\n          \"log_type\": \"DATA_READ\",\n          \"exempted_members\": [\n            \"user:foo@gmail.com\"\n          ]\n        },\n        {\n          \"log_type\": \"DATA_WRITE\",\n        }\n      ]\n    }\n\nThis enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting\nfoo@gmail.com from DATA_READ logging.",
+      "type": "object",
+      "properties": {
+        "logType": {
+          "description": "The log type that this config enables.",
+          "type": "string",
+          "enumDescriptions": [
+            "Default case. Should never be this.",
+            "Admin reads. Example: CloudIAM getIamPolicy",
+            "Data writes. Example: CloudSQL Users create",
+            "Data reads. Example: CloudSQL Users list"
+          ],
+          "enum": [
+            "LOG_TYPE_UNSPECIFIED",
+            "ADMIN_READ",
+            "DATA_WRITE",
+            "DATA_READ"
+          ]
+        },
+        "exemptedMembers": {
+          "description": "Specifies the identities that do not cause logging for this type of\npermission.\nFollows the same format of Binding.members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "AuditLogConfig"
+    },
+    "TestIamPermissionsRequest": {
+      "description": "Request message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with\nwildcards (such as '*' or 'storage.*') are not allowed. For more\ninformation see\n[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "TestIamPermissionsRequest"
+    },
+    "StateNotificationConfig": {
+      "description": "The configuration for notification of new states received from the device.",
+      "type": "object",
+      "properties": {
+        "pubsubTopicName": {
+          "description": "A Cloud Pub/Sub topic name. For example,\n`projects/myProject/topics/deviceEvents`.",
+          "type": "string"
+        }
+      },
+      "id": "StateNotificationConfig"
+    },
+    "Policy": {
+      "description": "Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `Binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\",\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam/docs).",
+      "type": "object",
+      "properties": {
+        "etag": {
+          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly.",
+          "format": "byte",
+          "type": "string"
+        },
+        "version": {
+          "description": "Deprecated.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "auditConfigs": {
+          "description": "Specifies cloud audit logging configuration for this policy.",
+          "type": "array",
+          "items": {
+            "$ref": "AuditConfig"
+          }
+        },
+        "bindings": {
+          "description": "Associates a list of `members` to a `role`.\n`bindings` with no members will result in an error.",
+          "type": "array",
+          "items": {
+            "$ref": "Binding"
+          }
+        },
+        "iamOwned": {
+          "type": "boolean"
+        }
+      },
+      "id": "Policy"
+    },
+    "RegistryCredential": {
+      "description": "A server-stored registry credential used to validate device credentials.",
+      "type": "object",
+      "properties": {
+        "publicKeyCertificate": {
+          "$ref": "PublicKeyCertificate",
+          "description": "A public key certificate used to verify the device credentials."
+        }
+      },
+      "id": "RegistryCredential"
+    },
+    "ListDeviceRegistriesResponse": {
+      "description": "Response for `ListDeviceRegistries`.",
+      "type": "object",
+      "properties": {
+        "deviceRegistries": {
+          "description": "The registries that matched the query.",
+          "type": "array",
+          "items": {
+            "$ref": "DeviceRegistry"
+          }
+        },
+        "nextPageToken": {
+          "description": "If not empty, indicates that there may be more registries that match the\nrequest; this value should be passed in a new\n`ListDeviceRegistriesRequest`.",
+          "type": "string"
+        }
+      },
+      "id": "ListDeviceRegistriesResponse"
+    },
+    "DeviceRegistry": {
+      "description": "A container for a group of devices.",
+      "type": "object",
+      "properties": {
+        "eventNotificationConfigs": {
+          "description": "The configuration for notification of telemetry events received from the\ndevice. All telemetry events that were successfully published by the\ndevice and acknowledged by Cloud IoT Core are guaranteed to be\ndelivered to Cloud Pub/Sub. Only the first configuration is used. If you\ntry to publish a device telemetry event using MQTT without specifying a\nCloud Pub/Sub topic for the device's registry, the connection closes\nautomatically. If you try to do so using an HTTP connection, an error\nis returned.",
+          "type": "array",
+          "items": {
+            "$ref": "EventNotificationConfig"
+          }
+        },
+        "httpConfig": {
+          "$ref": "HttpConfig",
+          "description": "The DeviceService (HTTP) configuration for this device registry."
+        },
+        "id": {
+          "description": "The identifier of this device registry. For example, `myRegistry`.",
+          "type": "string"
+        },
+        "mqttConfig": {
+          "$ref": "MqttConfig",
+          "description": "The MQTT configuration for this device registry."
+        },
+        "stateNotificationConfig": {
+          "description": "The configuration for notification of new states received from the device.\nState updates are guaranteed to be stored in the state history, but\nnotifications to Cloud Pub/Sub are not guaranteed. For example, if\npermissions are misconfigured or the specified topic doesn't exist, no\nnotification will be published but the state will still be stored in Cloud\nIoT Core.",
+          "$ref": "StateNotificationConfig"
+        },
+        "credentials": {
+          "description": "The credentials used to verify the device credentials. No more than 10\ncredentials can be bound to a single registry at a time. The verification\nprocess occurs at the time of device creation or update. If this field is\nempty, no verification is performed. Otherwise, the credentials of a newly\ncreated device or added credentials of an updated device should be signed\nwith one of these registry credentials.\n\nNote, however, that existing devices will never be affected by\nmodifications to this list of credentials: after a device has been\nsuccessfully created in a registry, it should be able to connect even if\nits registry credentials are revoked, deleted, or modified.",
+          "type": "array",
+          "items": {
+            "$ref": "RegistryCredential"
+          }
+        },
+        "name": {
+          "description": "The resource path name. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+          "type": "string"
+        }
+      },
+      "id": "DeviceRegistry"
+    },
+    "ListDevicesResponse": {
+      "description": "Response for `ListDevices`.",
+      "type": "object",
+      "properties": {
+        "devices": {
+          "description": "The devices that match the request.",
+          "type": "array",
+          "items": {
+            "$ref": "Device"
+          }
+        },
+        "nextPageToken": {
+          "description": "If not empty, indicates that there may be more devices that match the\nrequest; this value should be passed in a new `ListDevicesRequest`.",
+          "type": "string"
+        }
+      },
+      "id": "ListDevicesResponse"
+    },
+    "HttpConfig": {
+      "description": "The configuration of the HTTP bridge for a device registry.",
+      "type": "object",
+      "properties": {
+        "httpEnabledState": {
+          "enumDescriptions": [
+            "No HTTP state specified. If not specified, DeviceService will be\nenabled by default.",
+            "Enables DeviceService (HTTP) service for the registry.",
+            "Disables DeviceService (HTTP) service for the registry."
+          ],
+          "enum": [
+            "HTTP_STATE_UNSPECIFIED",
+            "HTTP_ENABLED",
+            "HTTP_DISABLED"
+          ],
+          "description": "If enabled, allows devices to use DeviceService via the HTTP protocol.\nOtherwise, any requests to DeviceService will fail for this registry.",
+          "type": "string"
+        }
+      },
+      "id": "HttpConfig"
+    },
+    "AuditConfig": {
+      "description": "Specifies the audit configuration for a service.\nThe configuration determines which permission types are logged, and what\nidentities, if any, are exempted from logging.\nAn AuditConfig must have one or more AuditLogConfigs.\n\nIf there are AuditConfigs for both `allServices` and a specific service,\nthe union of the two AuditConfigs is used for that service: the log_types\nspecified in each AuditConfig are enabled, and the exempted_members in each\nAuditConfig are exempted.\n\nExample Policy with multiple AuditConfigs:\n\n    {\n      \"audit_configs\": [\n        {\n          \"service\": \"allServices\"\n          \"audit_log_configs\": [\n            {\n              \"log_type\": \"DATA_READ\",\n              \"exempted_members\": [\n                \"user:foo@gmail.com\"\n              ]\n            },\n            {\n              \"log_type\": \"DATA_WRITE\",\n            },\n            {\n              \"log_type\": \"ADMIN_READ\",\n            }\n          ]\n        },\n        {\n          \"service\": \"fooservice.googleapis.com\"\n          \"audit_log_configs\": [\n            {\n              \"log_type\": \"DATA_READ\",\n            },\n            {\n              \"log_type\": \"DATA_WRITE\",\n              \"exempted_members\": [\n                \"user:bar@gmail.com\"\n              ]\n            }\n          ]\n        }\n      ]\n    }\n\nFor fooservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ\nlogging. It also exempts foo@gmail.com from DATA_READ logging, and\nbar@gmail.com from DATA_WRITE logging.",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "Specifies a service that will be enabled for audit logging.\nFor example, `storage.googleapis.com`, `cloudsql.googleapis.com`.\n`allServices` is a special value that covers all services.",
+          "type": "string"
+        },
+        "auditLogConfigs": {
+          "description": "The configuration for logging of each type of permission.\nNext ID: 4",
+          "type": "array",
+          "items": {
+            "$ref": "AuditLogConfig"
+          }
+        },
+        "exemptedMembers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "AuditConfig"
+    },
+    "DeviceCredential": {
+      "description": "A server-stored device credential used for authentication.",
+      "type": "object",
+      "properties": {
+        "expirationTime": {
+          "description": "[Optional] The time at which this credential becomes invalid. This\ncredential will be ignored for new client authentication requests after\nthis timestamp; however, it will not be automatically deleted.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "publicKey": {
+          "$ref": "PublicKeyCredential",
+          "description": "A public key used to verify the signature of JSON Web Tokens (JWTs).\nWhen adding a new device credential, either via device creation or via\nmodifications, this public key credential may be required to be signed by\none of the registry level certificates. More specifically, if the\nregistry contains at least one certificate, any new device credential\nmust be signed by one of the registry certificates. As a result,\nwhen the registry contains certificates, only X.509 certificates are\naccepted as device credentials. However, if the registry does\nnot contain a certificate, self-signed certificates and public keys will\nbe accepted. New device credentials must be different from every\nregistry-level certificate."
+        }
+      },
+      "id": "DeviceCredential"
+    },
+    "DeviceConfig": {
+      "description": "The device configuration. Eventually delivered to devices.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "[Output only] The version of this update. The version number is assigned by\nthe server, and is always greater than 0 after device creation. The\nversion must be 0 on the `CreateDevice` request if a `config` is\nspecified; the response of `CreateDevice` will always have a value of 1.",
+          "format": "int64",
+          "type": "string"
+        },
+        "cloudUpdateTime": {
+          "description": "[Output only] The time at which this configuration version was updated in\nCloud IoT Core. This timestamp is set by the server.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "deviceAckTime": {
+          "description": "[Output only] The time at which Cloud IoT Core received the\nacknowledgment from the device, indicating that the device has received\nthis configuration version. If this field is not present, the device has\nnot yet acknowledged that it received this version. Note that when\nthe config was sent to the device, many config versions may have been\navailable in Cloud IoT Core while the device was disconnected, and on\nconnection, only the latest version is sent to the device. Some\nversions may never be sent to the device, and therefore are never\nacknowledged. This timestamp is set by Cloud IoT Core.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "binaryData": {
+          "description": "The device configuration data.",
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "id": "DeviceConfig"
+    },
+    "MqttConfig": {
+      "description": "The configuration of MQTT for a device registry.",
+      "type": "object",
+      "properties": {
+        "mqttEnabledState": {
+          "description": "If enabled, allows connections using the MQTT protocol. Otherwise, MQTT\nconnections to this registry will fail.",
+          "type": "string",
+          "enumDescriptions": [
+            "No MQTT state specified. If not specified, MQTT will be enabled by default.",
+            "Enables a MQTT connection.",
+            "Disables a MQTT connection."
+          ],
+          "enum": [
+            "MQTT_STATE_UNSPECIFIED",
+            "MQTT_ENABLED",
+            "MQTT_DISABLED"
+          ]
+        }
+      },
+      "id": "MqttConfig"
+    },
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. It is used by\n[gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error message,\nand error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` that can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "type": "object",
+      "properties": {
+        "details": {
+          "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            }
+          }
+        },
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "id": "Status"
+    },
+    "Binding": {
+      "description": "Associates `members` with a `role`.",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "The condition that is associated with this binding.\nNOTE: an unsatisfied condition will not allow user access via current\nbinding. Different bindings, including their conditions, are examined\nindependently.\nThis field is GOOGLE_INTERNAL.",
+          "$ref": "Expr"
+        },
+        "members": {
+          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` or `joe@example.com`.\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: A Google Apps domain name that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "role": {
+          "description": "Role that is assigned to `members`.\nFor example, `roles/viewer`, `roles/editor`, or `roles/owner`.\nRequired",
+          "type": "string"
+        }
+      },
+      "id": "Binding"
+    },
+    "Expr": {
+      "description": "Represents an expression text. Example:\n\n    title: \"User account presence\"\n    description: \"Determines whether the request has a user account\"\n    expression: \"size(request.user) \u003e 0\"",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "An optional description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
+          "type": "string"
+        },
+        "expression": {
+          "description": "Textual representation of an expression in\nCommon Expression Language syntax.\n\nThe application context of the containing message determines which\nwell-known feature set of CEL is supported.",
+          "type": "string"
+        },
+        "title": {
+          "description": "An optional title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
+          "type": "string"
+        },
+        "location": {
+          "description": "An optional string indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
+          "type": "string"
+        }
+      },
+      "id": "Expr"
+    },
+    "ModifyCloudToDeviceConfigRequest": {
+      "description": "Request for `ModifyCloudToDeviceConfig`.",
+      "type": "object",
+      "properties": {
+        "versionToUpdate": {
+          "description": "The version number to update. If this value is zero, it will not check the\nversion number of the server and will always update the current version;\notherwise, this update will fail if the version number found on the server\ndoes not match this version number. This is used to support multiple\nsimultaneous updates without losing data.",
+          "format": "int64",
+          "type": "string"
+        },
+        "binaryData": {
+          "description": "The configuration data for the device.",
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "id": "ModifyCloudToDeviceConfigRequest"
+    },
+    "ListDeviceStatesResponse": {
+      "description": "Response for `ListDeviceStates`.",
+      "type": "object",
+      "properties": {
+        "deviceStates": {
+          "description": "The last few device states. States are listed in descending order of server\nupdate time, starting from the most recent one.",
+          "type": "array",
+          "items": {
+            "$ref": "DeviceState"
+          }
+        }
+      },
+      "id": "ListDeviceStatesResponse"
+    }
+  },
+  "protocol": "rest",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "canonicalName": "Cloud Iot",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/cloudiot": {
+          "description": "Register and manage devices in the Google Cloud IoT service"
+        }
+      }
+    }
+  },
+  "rootUrl": "https://cloudiot.googleapis.com/",
+  "ownerDomain": "google.com",
+  "name": "cloudiot",
+  "batchPath": "batch"
+}

--- a/vendor/google.golang.org/api/cloudiot/v1/cloudiot-gen.go
+++ b/vendor/google.golang.org/api/cloudiot/v1/cloudiot-gen.go
@@ -1,0 +1,4143 @@
+// Package cloudiot provides access to the Google Cloud IoT API.
+//
+// See https://cloud.google.com/iot
+//
+// Usage example:
+//
+//   import "google.golang.org/api/cloudiot/v1"
+//   ...
+//   cloudiotService, err := cloudiot.New(oauthHttpClient)
+package cloudiot // import "google.golang.org/api/cloudiot/v1"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "cloudiot:v1"
+const apiName = "cloudiot"
+const apiVersion = "v1"
+const basePath = "https://cloudiot.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// Register and manage devices in the Google Cloud IoT service
+	CloudiotScope = "https://www.googleapis.com/auth/cloudiot"
+)
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.Projects = NewProjectsService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Projects *ProjectsService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewProjectsService(s *Service) *ProjectsService {
+	rs := &ProjectsService{s: s}
+	rs.Locations = NewProjectsLocationsService(s)
+	return rs
+}
+
+type ProjectsService struct {
+	s *Service
+
+	Locations *ProjectsLocationsService
+}
+
+func NewProjectsLocationsService(s *Service) *ProjectsLocationsService {
+	rs := &ProjectsLocationsService{s: s}
+	rs.Registries = NewProjectsLocationsRegistriesService(s)
+	return rs
+}
+
+type ProjectsLocationsService struct {
+	s *Service
+
+	Registries *ProjectsLocationsRegistriesService
+}
+
+func NewProjectsLocationsRegistriesService(s *Service) *ProjectsLocationsRegistriesService {
+	rs := &ProjectsLocationsRegistriesService{s: s}
+	rs.Devices = NewProjectsLocationsRegistriesDevicesService(s)
+	return rs
+}
+
+type ProjectsLocationsRegistriesService struct {
+	s *Service
+
+	Devices *ProjectsLocationsRegistriesDevicesService
+}
+
+func NewProjectsLocationsRegistriesDevicesService(s *Service) *ProjectsLocationsRegistriesDevicesService {
+	rs := &ProjectsLocationsRegistriesDevicesService{s: s}
+	rs.ConfigVersions = NewProjectsLocationsRegistriesDevicesConfigVersionsService(s)
+	rs.States = NewProjectsLocationsRegistriesDevicesStatesService(s)
+	return rs
+}
+
+type ProjectsLocationsRegistriesDevicesService struct {
+	s *Service
+
+	ConfigVersions *ProjectsLocationsRegistriesDevicesConfigVersionsService
+
+	States *ProjectsLocationsRegistriesDevicesStatesService
+}
+
+func NewProjectsLocationsRegistriesDevicesConfigVersionsService(s *Service) *ProjectsLocationsRegistriesDevicesConfigVersionsService {
+	rs := &ProjectsLocationsRegistriesDevicesConfigVersionsService{s: s}
+	return rs
+}
+
+type ProjectsLocationsRegistriesDevicesConfigVersionsService struct {
+	s *Service
+}
+
+func NewProjectsLocationsRegistriesDevicesStatesService(s *Service) *ProjectsLocationsRegistriesDevicesStatesService {
+	rs := &ProjectsLocationsRegistriesDevicesStatesService{s: s}
+	return rs
+}
+
+type ProjectsLocationsRegistriesDevicesStatesService struct {
+	s *Service
+}
+
+// AuditConfig: Specifies the audit configuration for a service.
+// The configuration determines which permission types are logged, and
+// what
+// identities, if any, are exempted from logging.
+// An AuditConfig must have one or more AuditLogConfigs.
+//
+// If there are AuditConfigs for both `allServices` and a specific
+// service,
+// the union of the two AuditConfigs is used for that service: the
+// log_types
+// specified in each AuditConfig are enabled, and the exempted_members
+// in each
+// AuditConfig are exempted.
+//
+// Example Policy with multiple AuditConfigs:
+//
+//     {
+//       "audit_configs": [
+//         {
+//           "service": "allServices"
+//           "audit_log_configs": [
+//             {
+//               "log_type": "DATA_READ",
+//               "exempted_members": [
+//                 "user:foo@gmail.com"
+//               ]
+//             },
+//             {
+//               "log_type": "DATA_WRITE",
+//             },
+//             {
+//               "log_type": "ADMIN_READ",
+//             }
+//           ]
+//         },
+//         {
+//           "service": "fooservice.googleapis.com"
+//           "audit_log_configs": [
+//             {
+//               "log_type": "DATA_READ",
+//             },
+//             {
+//               "log_type": "DATA_WRITE",
+//               "exempted_members": [
+//                 "user:bar@gmail.com"
+//               ]
+//             }
+//           ]
+//         }
+//       ]
+//     }
+//
+// For fooservice, this policy enables DATA_READ, DATA_WRITE and
+// ADMIN_READ
+// logging. It also exempts foo@gmail.com from DATA_READ logging,
+// and
+// bar@gmail.com from DATA_WRITE logging.
+type AuditConfig struct {
+	// AuditLogConfigs: The configuration for logging of each type of
+	// permission.
+	// Next ID: 4
+	AuditLogConfigs []*AuditLogConfig `json:"auditLogConfigs,omitempty"`
+
+	ExemptedMembers []string `json:"exemptedMembers,omitempty"`
+
+	// Service: Specifies a service that will be enabled for audit
+	// logging.
+	// For example, `storage.googleapis.com`,
+	// `cloudsql.googleapis.com`.
+	// `allServices` is a special value that covers all services.
+	Service string `json:"service,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AuditLogConfigs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AuditLogConfigs") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuditConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod AuditConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuditLogConfig: Provides the configuration for logging a type of
+// permissions.
+// Example:
+//
+//     {
+//       "audit_log_configs": [
+//         {
+//           "log_type": "DATA_READ",
+//           "exempted_members": [
+//             "user:foo@gmail.com"
+//           ]
+//         },
+//         {
+//           "log_type": "DATA_WRITE",
+//         }
+//       ]
+//     }
+//
+// This enables 'DATA_READ' and 'DATA_WRITE' logging, while
+// exempting
+// foo@gmail.com from DATA_READ logging.
+type AuditLogConfig struct {
+	// ExemptedMembers: Specifies the identities that do not cause logging
+	// for this type of
+	// permission.
+	// Follows the same format of Binding.members.
+	ExemptedMembers []string `json:"exemptedMembers,omitempty"`
+
+	// LogType: The log type that this config enables.
+	//
+	// Possible values:
+	//   "LOG_TYPE_UNSPECIFIED" - Default case. Should never be this.
+	//   "ADMIN_READ" - Admin reads. Example: CloudIAM getIamPolicy
+	//   "DATA_WRITE" - Data writes. Example: CloudSQL Users create
+	//   "DATA_READ" - Data reads. Example: CloudSQL Users list
+	LogType string `json:"logType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ExemptedMembers") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ExemptedMembers") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuditLogConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod AuditLogConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Binding: Associates `members` with a `role`.
+type Binding struct {
+	// Condition: The condition that is associated with this binding.
+	// NOTE: an unsatisfied condition will not allow user access via
+	// current
+	// binding. Different bindings, including their conditions, are
+	// examined
+	// independently.
+	// This field is GOOGLE_INTERNAL.
+	Condition *Expr `json:"condition,omitempty"`
+
+	// Members: Specifies the identities requesting access for a Cloud
+	// Platform resource.
+	// `members` can have the following values:
+	//
+	// * `allUsers`: A special identifier that represents anyone who is
+	//    on the internet; with or without a Google account.
+	//
+	// * `allAuthenticatedUsers`: A special identifier that represents
+	// anyone
+	//    who is authenticated with a Google account or a service
+	// account.
+	//
+	// * `user:{emailid}`: An email address that represents a specific
+	// Google
+	//    account. For example, `alice@gmail.com` or `joe@example.com`.
+	//
+	//
+	// * `serviceAccount:{emailid}`: An email address that represents a
+	// service
+	//    account. For example,
+	// `my-other-app@appspot.gserviceaccount.com`.
+	//
+	// * `group:{emailid}`: An email address that represents a Google
+	// group.
+	//    For example, `admins@example.com`.
+	//
+	//
+	// * `domain:{domain}`: A Google Apps domain name that represents all
+	// the
+	//    users of that domain. For example, `google.com` or
+	// `example.com`.
+	//
+	//
+	Members []string `json:"members,omitempty"`
+
+	// Role: Role that is assigned to `members`.
+	// For example, `roles/viewer`, `roles/editor`, or
+	// `roles/owner`.
+	// Required
+	Role string `json:"role,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Condition") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Condition") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Binding) MarshalJSON() ([]byte, error) {
+	type NoMethod Binding
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Device: The device resource.
+type Device struct {
+	// Blocked: If a device is blocked, connections or requests from this
+	// device will fail.
+	// Can be used to temporarily prevent the device from connecting if,
+	// for
+	// example, the sensor is generating bad data and needs maintenance.
+	Blocked bool `json:"blocked,omitempty"`
+
+	// Config: The most recent device configuration, which is eventually
+	// sent from
+	// Cloud IoT Core to the device. If not present on creation,
+	// the
+	// configuration will be initialized with an empty payload and version
+	// value
+	// of `1`. To update this field after creation, use
+	// the
+	// `DeviceManager.ModifyCloudToDeviceConfig` method.
+	Config *DeviceConfig `json:"config,omitempty"`
+
+	// Credentials: The credentials used to authenticate this device. To
+	// allow credential
+	// rotation without interruption, multiple device credentials can be
+	// bound to
+	// this device. No more than 3 credentials can be bound to a single
+	// device at
+	// a time. When new credentials are added to a device, they are
+	// verified
+	// against the registry credentials. For details, see the description of
+	// the
+	// `DeviceRegistry.credentials` field.
+	Credentials []*DeviceCredential `json:"credentials,omitempty"`
+
+	// Id: The user-defined device identifier. The device ID must be
+	// unique
+	// within a device registry.
+	Id string `json:"id,omitempty"`
+
+	// LastConfigAckTime: [Output only] The last time a cloud-to-device
+	// config version acknowledgment
+	// was received from the device. This field is only for
+	// configurations
+	// sent through MQTT.
+	LastConfigAckTime string `json:"lastConfigAckTime,omitempty"`
+
+	// LastConfigSendTime: [Output only] The last time a cloud-to-device
+	// config version was sent to
+	// the device.
+	LastConfigSendTime string `json:"lastConfigSendTime,omitempty"`
+
+	// LastErrorStatus: [Output only] The error message of the most recent
+	// error, such as a failure
+	// to publish to Cloud Pub/Sub. 'last_error_time' is the timestamp of
+	// this
+	// field. If no errors have occurred, this field has an empty
+	// message
+	// and the status code 0 == OK. Otherwise, this field is expected to
+	// have a
+	// status code other than OK.
+	LastErrorStatus *Status `json:"lastErrorStatus,omitempty"`
+
+	// LastErrorTime: [Output only] The time the most recent error occurred,
+	// such as a failure to
+	// publish to Cloud Pub/Sub. This field is the timestamp
+	// of
+	// 'last_error_status'.
+	LastErrorTime string `json:"lastErrorTime,omitempty"`
+
+	// LastEventTime: [Output only] The last time a telemetry event was
+	// received. Timestamps are
+	// periodically collected and written to storage; they may be stale by a
+	// few
+	// minutes.
+	LastEventTime string `json:"lastEventTime,omitempty"`
+
+	// LastHeartbeatTime: [Output only] The last time a heartbeat was
+	// received. Timestamps are
+	// periodically collected and written to storage; they may be stale by a
+	// few
+	// minutes. This field is only for devices connecting through MQTT.
+	LastHeartbeatTime string `json:"lastHeartbeatTime,omitempty"`
+
+	// LastStateTime: [Output only] The last time a state event was
+	// received. Timestamps are
+	// periodically collected and written to storage; they may be stale by a
+	// few
+	// minutes.
+	LastStateTime string `json:"lastStateTime,omitempty"`
+
+	// Metadata: The metadata key-value pairs assigned to the device. This
+	// metadata is not
+	// interpreted or indexed by Cloud IoT Core. It can be used to add
+	// contextual
+	// information for the device.
+	//
+	// Keys must conform to the regular expression [a-zA-Z0-9-_]+ and be
+	// less than
+	// 128 bytes in length.
+	//
+	// Values are free-form strings. Each value must be less than or equal
+	// to 32
+	// KB in size.
+	//
+	// The total size of all keys and values must be less than 256 KB, and
+	// the
+	// maximum number of key-value pairs is 500.
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Name: The resource path name. For
+	// example,
+	// `projects/p1/locations/us-central1/registries/registry0/devic
+	// es/dev0`
+	// or
+	// `projects/p1/locations/us-central1/registries/registry0/devices/{nu
+	// m_id}`.
+	// When `name` is populated as a response from the service, it always
+	// ends
+	// in the device numeric ID.
+	Name string `json:"name,omitempty"`
+
+	// NumId: [Output only] A server-defined unique numeric ID for the
+	// device. This is a
+	// more compact way to identify devices, and it is globally unique.
+	NumId uint64 `json:"numId,omitempty,string"`
+
+	// State: [Output only] The state most recently received from the
+	// device. If no state
+	// has been reported, this field is not present.
+	State *DeviceState `json:"state,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Blocked") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Blocked") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Device) MarshalJSON() ([]byte, error) {
+	type NoMethod Device
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DeviceConfig: The device configuration. Eventually delivered to
+// devices.
+type DeviceConfig struct {
+	// BinaryData: The device configuration data.
+	BinaryData string `json:"binaryData,omitempty"`
+
+	// CloudUpdateTime: [Output only] The time at which this configuration
+	// version was updated in
+	// Cloud IoT Core. This timestamp is set by the server.
+	CloudUpdateTime string `json:"cloudUpdateTime,omitempty"`
+
+	// DeviceAckTime: [Output only] The time at which Cloud IoT Core
+	// received the
+	// acknowledgment from the device, indicating that the device has
+	// received
+	// this configuration version. If this field is not present, the device
+	// has
+	// not yet acknowledged that it received this version. Note that
+	// when
+	// the config was sent to the device, many config versions may have
+	// been
+	// available in Cloud IoT Core while the device was disconnected, and
+	// on
+	// connection, only the latest version is sent to the device.
+	// Some
+	// versions may never be sent to the device, and therefore are
+	// never
+	// acknowledged. This timestamp is set by Cloud IoT Core.
+	DeviceAckTime string `json:"deviceAckTime,omitempty"`
+
+	// Version: [Output only] The version of this update. The version number
+	// is assigned by
+	// the server, and is always greater than 0 after device creation.
+	// The
+	// version must be 0 on the `CreateDevice` request if a `config`
+	// is
+	// specified; the response of `CreateDevice` will always have a value of
+	// 1.
+	Version int64 `json:"version,omitempty,string"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "BinaryData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BinaryData") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DeviceConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod DeviceConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DeviceCredential: A server-stored device credential used for
+// authentication.
+type DeviceCredential struct {
+	// ExpirationTime: [Optional] The time at which this credential becomes
+	// invalid. This
+	// credential will be ignored for new client authentication requests
+	// after
+	// this timestamp; however, it will not be automatically deleted.
+	ExpirationTime string `json:"expirationTime,omitempty"`
+
+	// PublicKey: A public key used to verify the signature of JSON Web
+	// Tokens (JWTs).
+	// When adding a new device credential, either via device creation or
+	// via
+	// modifications, this public key credential may be required to be
+	// signed by
+	// one of the registry level certificates. More specifically, if
+	// the
+	// registry contains at least one certificate, any new device
+	// credential
+	// must be signed by one of the registry certificates. As a result,
+	// when the registry contains certificates, only X.509 certificates
+	// are
+	// accepted as device credentials. However, if the registry does
+	// not contain a certificate, self-signed certificates and public keys
+	// will
+	// be accepted. New device credentials must be different from
+	// every
+	// registry-level certificate.
+	PublicKey *PublicKeyCredential `json:"publicKey,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ExpirationTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ExpirationTime") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DeviceCredential) MarshalJSON() ([]byte, error) {
+	type NoMethod DeviceCredential
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DeviceRegistry: A container for a group of devices.
+type DeviceRegistry struct {
+	// Credentials: The credentials used to verify the device credentials.
+	// No more than 10
+	// credentials can be bound to a single registry at a time. The
+	// verification
+	// process occurs at the time of device creation or update. If this
+	// field is
+	// empty, no verification is performed. Otherwise, the credentials of a
+	// newly
+	// created device or added credentials of an updated device should be
+	// signed
+	// with one of these registry credentials.
+	//
+	// Note, however, that existing devices will never be affected
+	// by
+	// modifications to this list of credentials: after a device has
+	// been
+	// successfully created in a registry, it should be able to connect even
+	// if
+	// its registry credentials are revoked, deleted, or modified.
+	Credentials []*RegistryCredential `json:"credentials,omitempty"`
+
+	// EventNotificationConfigs: The configuration for notification of
+	// telemetry events received from the
+	// device. All telemetry events that were successfully published by
+	// the
+	// device and acknowledged by Cloud IoT Core are guaranteed to
+	// be
+	// delivered to Cloud Pub/Sub. Only the first configuration is used. If
+	// you
+	// try to publish a device telemetry event using MQTT without specifying
+	// a
+	// Cloud Pub/Sub topic for the device's registry, the connection
+	// closes
+	// automatically. If you try to do so using an HTTP connection, an
+	// error
+	// is returned.
+	EventNotificationConfigs []*EventNotificationConfig `json:"eventNotificationConfigs,omitempty"`
+
+	// HttpConfig: The DeviceService (HTTP) configuration for this device
+	// registry.
+	HttpConfig *HttpConfig `json:"httpConfig,omitempty"`
+
+	// Id: The identifier of this device registry. For example,
+	// `myRegistry`.
+	Id string `json:"id,omitempty"`
+
+	// MqttConfig: The MQTT configuration for this device registry.
+	MqttConfig *MqttConfig `json:"mqttConfig,omitempty"`
+
+	// Name: The resource path name. For
+	// example,
+	// `projects/example-project/locations/us-central1/registries/my
+	// -registry`.
+	Name string `json:"name,omitempty"`
+
+	// StateNotificationConfig: The configuration for notification of new
+	// states received from the device.
+	// State updates are guaranteed to be stored in the state history,
+	// but
+	// notifications to Cloud Pub/Sub are not guaranteed. For example,
+	// if
+	// permissions are misconfigured or the specified topic doesn't exist,
+	// no
+	// notification will be published but the state will still be stored in
+	// Cloud
+	// IoT Core.
+	StateNotificationConfig *StateNotificationConfig `json:"stateNotificationConfig,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Credentials") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Credentials") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DeviceRegistry) MarshalJSON() ([]byte, error) {
+	type NoMethod DeviceRegistry
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DeviceState: The device state, as reported by the device.
+type DeviceState struct {
+	// BinaryData: The device state data.
+	BinaryData string `json:"binaryData,omitempty"`
+
+	// UpdateTime: [Output only] The time at which this state version was
+	// updated in Cloud
+	// IoT Core.
+	UpdateTime string `json:"updateTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "BinaryData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BinaryData") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DeviceState) MarshalJSON() ([]byte, error) {
+	type NoMethod DeviceState
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Empty: A generic empty message that you can re-use to avoid defining
+// duplicated
+// empty messages in your APIs. A typical example is to use it as the
+// request
+// or the response type of an API method. For instance:
+//
+//     service Foo {
+//       rpc Bar(google.protobuf.Empty) returns
+// (google.protobuf.Empty);
+//     }
+//
+// The JSON representation for `Empty` is empty JSON object `{}`.
+type Empty struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+}
+
+// EventNotificationConfig: The configuration to forward telemetry
+// events.
+type EventNotificationConfig struct {
+	// PubsubTopicName: A Cloud Pub/Sub topic name. For
+	// example,
+	// `projects/myProject/topics/deviceEvents`.
+	PubsubTopicName string `json:"pubsubTopicName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "PubsubTopicName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "PubsubTopicName") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *EventNotificationConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod EventNotificationConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Expr: Represents an expression text. Example:
+//
+//     title: "User account presence"
+//     description: "Determines whether the request has a user account"
+//     expression: "size(request.user) > 0"
+type Expr struct {
+	// Description: An optional description of the expression. This is a
+	// longer text which
+	// describes the expression, e.g. when hovered over it in a UI.
+	Description string `json:"description,omitempty"`
+
+	// Expression: Textual representation of an expression in
+	// Common Expression Language syntax.
+	//
+	// The application context of the containing message determines
+	// which
+	// well-known feature set of CEL is supported.
+	Expression string `json:"expression,omitempty"`
+
+	// Location: An optional string indicating the location of the
+	// expression for error
+	// reporting, e.g. a file name and a position in the file.
+	Location string `json:"location,omitempty"`
+
+	// Title: An optional title for the expression, i.e. a short string
+	// describing
+	// its purpose. This can be used e.g. in UIs which allow to enter
+	// the
+	// expression.
+	Title string `json:"title,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Expr) MarshalJSON() ([]byte, error) {
+	type NoMethod Expr
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// GetIamPolicyRequest: Request message for `GetIamPolicy` method.
+type GetIamPolicyRequest struct {
+}
+
+// HttpConfig: The configuration of the HTTP bridge for a device
+// registry.
+type HttpConfig struct {
+	// HttpEnabledState: If enabled, allows devices to use DeviceService via
+	// the HTTP protocol.
+	// Otherwise, any requests to DeviceService will fail for this registry.
+	//
+	// Possible values:
+	//   "HTTP_STATE_UNSPECIFIED" - No HTTP state specified. If not
+	// specified, DeviceService will be
+	// enabled by default.
+	//   "HTTP_ENABLED" - Enables DeviceService (HTTP) service for the
+	// registry.
+	//   "HTTP_DISABLED" - Disables DeviceService (HTTP) service for the
+	// registry.
+	HttpEnabledState string `json:"httpEnabledState,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HttpEnabledState") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HttpEnabledState") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *HttpConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod HttpConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListDeviceConfigVersionsResponse: Response for
+// `ListDeviceConfigVersions`.
+type ListDeviceConfigVersionsResponse struct {
+	// DeviceConfigs: The device configuration for the last few versions.
+	// Versions are listed
+	// in decreasing order, starting from the most recent one.
+	DeviceConfigs []*DeviceConfig `json:"deviceConfigs,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "DeviceConfigs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DeviceConfigs") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListDeviceConfigVersionsResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod ListDeviceConfigVersionsResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListDeviceRegistriesResponse: Response for `ListDeviceRegistries`.
+type ListDeviceRegistriesResponse struct {
+	// DeviceRegistries: The registries that matched the query.
+	DeviceRegistries []*DeviceRegistry `json:"deviceRegistries,omitempty"`
+
+	// NextPageToken: If not empty, indicates that there may be more
+	// registries that match the
+	// request; this value should be passed in a
+	// new
+	// `ListDeviceRegistriesRequest`.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "DeviceRegistries") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DeviceRegistries") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListDeviceRegistriesResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod ListDeviceRegistriesResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListDeviceStatesResponse: Response for `ListDeviceStates`.
+type ListDeviceStatesResponse struct {
+	// DeviceStates: The last few device states. States are listed in
+	// descending order of server
+	// update time, starting from the most recent one.
+	DeviceStates []*DeviceState `json:"deviceStates,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "DeviceStates") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DeviceStates") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListDeviceStatesResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod ListDeviceStatesResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListDevicesResponse: Response for `ListDevices`.
+type ListDevicesResponse struct {
+	// Devices: The devices that match the request.
+	Devices []*Device `json:"devices,omitempty"`
+
+	// NextPageToken: If not empty, indicates that there may be more devices
+	// that match the
+	// request; this value should be passed in a new `ListDevicesRequest`.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Devices") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Devices") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListDevicesResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod ListDevicesResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ModifyCloudToDeviceConfigRequest: Request for
+// `ModifyCloudToDeviceConfig`.
+type ModifyCloudToDeviceConfigRequest struct {
+	// BinaryData: The configuration data for the device.
+	BinaryData string `json:"binaryData,omitempty"`
+
+	// VersionToUpdate: The version number to update. If this value is zero,
+	// it will not check the
+	// version number of the server and will always update the current
+	// version;
+	// otherwise, this update will fail if the version number found on the
+	// server
+	// does not match this version number. This is used to support
+	// multiple
+	// simultaneous updates without losing data.
+	VersionToUpdate int64 `json:"versionToUpdate,omitempty,string"`
+
+	// ForceSendFields is a list of field names (e.g. "BinaryData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BinaryData") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ModifyCloudToDeviceConfigRequest) MarshalJSON() ([]byte, error) {
+	type NoMethod ModifyCloudToDeviceConfigRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MqttConfig: The configuration of MQTT for a device registry.
+type MqttConfig struct {
+	// MqttEnabledState: If enabled, allows connections using the MQTT
+	// protocol. Otherwise, MQTT
+	// connections to this registry will fail.
+	//
+	// Possible values:
+	//   "MQTT_STATE_UNSPECIFIED" - No MQTT state specified. If not
+	// specified, MQTT will be enabled by default.
+	//   "MQTT_ENABLED" - Enables a MQTT connection.
+	//   "MQTT_DISABLED" - Disables a MQTT connection.
+	MqttEnabledState string `json:"mqttEnabledState,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "MqttEnabledState") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "MqttEnabledState") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MqttConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod MqttConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Policy: Defines an Identity and Access Management (IAM) policy. It is
+// used to
+// specify access control policies for Cloud Platform resources.
+//
+//
+// A `Policy` consists of a list of `bindings`. A `Binding` binds a list
+// of
+// `members` to a `role`, where the members can be user accounts, Google
+// groups,
+// Google domains, and service accounts. A `role` is a named list of
+// permissions
+// defined by IAM.
+//
+// **Example**
+//
+//     {
+//       "bindings": [
+//         {
+//           "role": "roles/owner",
+//           "members": [
+//             "user:mike@example.com",
+//             "group:admins@example.com",
+//             "domain:google.com",
+//
+// "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+//           ]
+//         },
+//         {
+//           "role": "roles/viewer",
+//           "members": ["user:sean@example.com"]
+//         }
+//       ]
+//     }
+//
+// For a description of IAM and its features, see the
+// [IAM developer's guide](https://cloud.google.com/iam/docs).
+type Policy struct {
+	// AuditConfigs: Specifies cloud audit logging configuration for this
+	// policy.
+	AuditConfigs []*AuditConfig `json:"auditConfigs,omitempty"`
+
+	// Bindings: Associates a list of `members` to a `role`.
+	// `bindings` with no members will result in an error.
+	Bindings []*Binding `json:"bindings,omitempty"`
+
+	// Etag: `etag` is used for optimistic concurrency control as a way to
+	// help
+	// prevent simultaneous updates of a policy from overwriting each
+	// other.
+	// It is strongly suggested that systems make use of the `etag` in
+	// the
+	// read-modify-write cycle to perform policy updates in order to avoid
+	// race
+	// conditions: An `etag` is returned in the response to `getIamPolicy`,
+	// and
+	// systems are expected to put that etag in the request to
+	// `setIamPolicy` to
+	// ensure that their change will be applied to the same version of the
+	// policy.
+	//
+	// If no `etag` is provided in the call to `setIamPolicy`, then the
+	// existing
+	// policy is overwritten blindly.
+	Etag string `json:"etag,omitempty"`
+
+	IamOwned bool `json:"iamOwned,omitempty"`
+
+	// Version: Deprecated.
+	Version int64 `json:"version,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "AuditConfigs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AuditConfigs") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Policy) MarshalJSON() ([]byte, error) {
+	type NoMethod Policy
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// PublicKeyCertificate: A public key certificate format and data.
+type PublicKeyCertificate struct {
+	// Certificate: The certificate data.
+	Certificate string `json:"certificate,omitempty"`
+
+	// Format: The certificate format.
+	//
+	// Possible values:
+	//   "UNSPECIFIED_PUBLIC_KEY_CERTIFICATE_FORMAT" - The format has not
+	// been specified. This is an invalid default value and
+	// must not be used.
+	//   "X509_CERTIFICATE_PEM" - An X.509v3 certificate
+	// ([RFC5280](https://www.ietf.org/rfc/rfc5280.txt)),
+	// encoded in base64, and wrapped by `-----BEGIN CERTIFICATE-----`
+	// and
+	// `-----END CERTIFICATE-----`.
+	Format string `json:"format,omitempty"`
+
+	// X509Details: [Output only] The certificate details. Used only for
+	// X.509 certificates.
+	X509Details *X509CertificateDetails `json:"x509Details,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Certificate") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Certificate") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *PublicKeyCertificate) MarshalJSON() ([]byte, error) {
+	type NoMethod PublicKeyCertificate
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// PublicKeyCredential: A public key format and data.
+type PublicKeyCredential struct {
+	// Format: The format of the key.
+	//
+	// Possible values:
+	//   "UNSPECIFIED_PUBLIC_KEY_FORMAT" - The format has not been
+	// specified. This is an invalid default value and
+	// must not be used.
+	//   "RSA_PEM" - An RSA public key encoded in base64, and wrapped
+	// by
+	// `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----`. This can
+	// be
+	// used to verify `RS256` signatures in JWT tokens
+	// ([RFC7518](
+	// https://www.ietf.org/rfc/rfc7518.txt)).
+	//   "RSA_X509_PEM" - As RSA_PEM, but wrapped in an X.509v3 certificate
+	// ([RFC5280](
+	// https://www.ietf.org/rfc/rfc5280.txt)), encoded in base64, and
+	// wrapped by
+	// `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
+	//   "ES256_PEM" - Public key for the ECDSA algorithm using P-256 and
+	// SHA-256, encoded in
+	// base64, and wrapped by `-----BEGIN PUBLIC KEY-----` and
+	// `-----END
+	// PUBLIC KEY-----`. This can be used to verify JWT tokens with the
+	// `ES256`
+	// algorithm ([RFC7518](https://www.ietf.org/rfc/rfc7518.txt)). This
+	// curve is
+	// defined in [OpenSSL](https://www.openssl.org/) as the `prime256v1`
+	// curve.
+	//   "ES256_X509_PEM" - As ES256_PEM, but wrapped in an X.509v3
+	// certificate ([RFC5280](
+	// https://www.ietf.org/rfc/rfc5280.txt)), encoded in base64, and
+	// wrapped by
+	// `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
+	Format string `json:"format,omitempty"`
+
+	// Key: The key data.
+	Key string `json:"key,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Format") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Format") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *PublicKeyCredential) MarshalJSON() ([]byte, error) {
+	type NoMethod PublicKeyCredential
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// RegistryCredential: A server-stored registry credential used to
+// validate device credentials.
+type RegistryCredential struct {
+	// PublicKeyCertificate: A public key certificate used to verify the
+	// device credentials.
+	PublicKeyCertificate *PublicKeyCertificate `json:"publicKeyCertificate,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "PublicKeyCertificate") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "PublicKeyCertificate") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RegistryCredential) MarshalJSON() ([]byte, error) {
+	type NoMethod RegistryCredential
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SetIamPolicyRequest: Request message for `SetIamPolicy` method.
+type SetIamPolicyRequest struct {
+	// Policy: REQUIRED: The complete policy to be applied to the
+	// `resource`. The size of
+	// the policy is limited to a few 10s of KB. An empty policy is a
+	// valid policy but certain Cloud Platform services (such as
+	// Projects)
+	// might reject them.
+	Policy *Policy `json:"policy,omitempty"`
+
+	// UpdateMask: OPTIONAL: A FieldMask specifying which fields of the
+	// policy to modify. Only
+	// the fields in the mask will be modified. If no mask is provided,
+	// the
+	// following default mask is used:
+	// paths: "bindings, etag"
+	// This field is only used by Cloud IAM.
+	UpdateMask string `json:"updateMask,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Policy") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Policy") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SetIamPolicyRequest) MarshalJSON() ([]byte, error) {
+	type NoMethod SetIamPolicyRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StateNotificationConfig: The configuration for notification of new
+// states received from the device.
+type StateNotificationConfig struct {
+	// PubsubTopicName: A Cloud Pub/Sub topic name. For
+	// example,
+	// `projects/myProject/topics/deviceEvents`.
+	PubsubTopicName string `json:"pubsubTopicName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "PubsubTopicName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "PubsubTopicName") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StateNotificationConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod StateNotificationConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Status: The `Status` type defines a logical error model that is
+// suitable for different
+// programming environments, including REST APIs and RPC APIs. It is
+// used by
+// [gRPC](https://github.com/grpc). The error model is designed to
+// be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error
+// message,
+// and error details. The error code should be an enum value
+// of
+// google.rpc.Code, but it may accept additional error codes if needed.
+// The
+// error message should be a developer-facing English message that
+// helps
+// developers *understand* and *resolve* the error. If a localized
+// user-facing
+// error message is needed, put the localized message in the error
+// details or
+// localize it in the client. The optional error details may contain
+// arbitrary
+// information about the error. There is a predefined set of error
+// detail types
+// in the package `google.rpc` that can be used for common error
+// conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error
+// model, but it
+// is not necessarily the actual wire format. When the `Status` message
+// is
+// exposed in different client libraries and different wire protocols,
+// it can be
+// mapped differently. For example, it will likely be mapped to some
+// exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety
+// of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different
+// environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the
+// client,
+//     it may embed the `Status` in the normal response to indicate the
+// partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step
+// may
+//     have a `Status` message for error reporting.
+//
+// - Batch operations. If a client uses batch request and batch
+// response, the
+//     `Status` message should be used directly inside batch response,
+// one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous
+// operation
+//     results in its response, the status of those operations should
+// be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message
+// `Status` could
+//     be used directly after any stripping needed for security/privacy
+// reasons.
+type Status struct {
+	// Code: The status code, which should be an enum value of
+	// google.rpc.Code.
+	Code int64 `json:"code,omitempty"`
+
+	// Details: A list of messages that carry the error details.  There is a
+	// common set of
+	// message types for APIs to use.
+	Details []googleapi.RawMessage `json:"details,omitempty"`
+
+	// Message: A developer-facing error message, which should be in
+	// English. Any
+	// user-facing error message should be localized and sent in
+	// the
+	// google.rpc.Status.details field, or localized by the client.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Code") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Status) MarshalJSON() ([]byte, error) {
+	type NoMethod Status
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TestIamPermissionsRequest: Request message for `TestIamPermissions`
+// method.
+type TestIamPermissionsRequest struct {
+	// Permissions: The set of permissions to check for the `resource`.
+	// Permissions with
+	// wildcards (such as '*' or 'storage.*') are not allowed. For
+	// more
+	// information see
+	// [IAM
+	// Overview](https://cloud.google.com/iam/docs/overview#permissions).
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Permissions") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsRequest) MarshalJSON() ([]byte, error) {
+	type NoMethod TestIamPermissionsRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TestIamPermissionsResponse: Response message for `TestIamPermissions`
+// method.
+type TestIamPermissionsResponse struct {
+	// Permissions: A subset of `TestPermissionsRequest.permissions` that
+	// the caller is
+	// allowed.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Permissions") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod TestIamPermissionsResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// X509CertificateDetails: Details of an X.509 certificate. For
+// informational purposes only.
+type X509CertificateDetails struct {
+	// ExpiryTime: The time the certificate becomes invalid.
+	ExpiryTime string `json:"expiryTime,omitempty"`
+
+	// Issuer: The entity that signed the certificate.
+	Issuer string `json:"issuer,omitempty"`
+
+	// PublicKeyType: The type of public key in the certificate.
+	PublicKeyType string `json:"publicKeyType,omitempty"`
+
+	// SignatureAlgorithm: The algorithm used to sign the certificate.
+	SignatureAlgorithm string `json:"signatureAlgorithm,omitempty"`
+
+	// StartTime: The time the certificate becomes valid.
+	StartTime string `json:"startTime,omitempty"`
+
+	// Subject: The entity the certificate and public key belong to.
+	Subject string `json:"subject,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ExpiryTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ExpiryTime") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *X509CertificateDetails) MarshalJSON() ([]byte, error) {
+	type NoMethod X509CertificateDetails
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// method id "cloudiot.projects.locations.registries.create":
+
+type ProjectsLocationsRegistriesCreateCall struct {
+	s              *Service
+	parent         string
+	deviceregistry *DeviceRegistry
+	urlParams_     gensupport.URLParams
+	ctx_           context.Context
+	header_        http.Header
+}
+
+// Create: Creates a device registry that contains devices.
+func (r *ProjectsLocationsRegistriesService) Create(parent string, deviceregistry *DeviceRegistry) *ProjectsLocationsRegistriesCreateCall {
+	c := &ProjectsLocationsRegistriesCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	c.deviceregistry = deviceregistry
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesCreateCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesCreateCall) Context(ctx context.Context) *ProjectsLocationsRegistriesCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.deviceregistry)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/registries")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.create" call.
+// Exactly one of *DeviceRegistry or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *DeviceRegistry.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesCreateCall) Do(opts ...googleapi.CallOption) (*DeviceRegistry, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &DeviceRegistry{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a device registry that contains devices.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.create",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "parent": {
+	//       "description": "The project and cloud region where this device registry must be created.\nFor example, `projects/example-project/locations/us-central1`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+parent}/registries",
+	//   "request": {
+	//     "$ref": "DeviceRegistry"
+	//   },
+	//   "response": {
+	//     "$ref": "DeviceRegistry"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.delete":
+
+type ProjectsLocationsRegistriesDeleteCall struct {
+	s          *Service
+	name       string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Delete: Deletes a device registry configuration.
+func (r *ProjectsLocationsRegistriesService) Delete(name string) *ProjectsLocationsRegistriesDeleteCall {
+	c := &ProjectsLocationsRegistriesDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDeleteCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDeleteCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDeleteCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDeleteCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.delete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesDeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes a device registry configuration.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+	//   "httpMethod": "DELETE",
+	//   "id": "cloudiot.projects.locations.registries.delete",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device registry. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.get":
+
+type ProjectsLocationsRegistriesGetCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets a device registry configuration.
+func (r *ProjectsLocationsRegistriesService) Get(name string) *ProjectsLocationsRegistriesGetCall {
+	c := &ProjectsLocationsRegistriesGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesGetCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesGetCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesGetCall) Context(ctx context.Context) *ProjectsLocationsRegistriesGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.get" call.
+// Exactly one of *DeviceRegistry or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *DeviceRegistry.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesGetCall) Do(opts ...googleapi.CallOption) (*DeviceRegistry, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &DeviceRegistry{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a device registry configuration.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device registry. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "DeviceRegistry"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.getIamPolicy":
+
+type ProjectsLocationsRegistriesGetIamPolicyCall struct {
+	s                   *Service
+	resource            string
+	getiampolicyrequest *GetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+	header_             http.Header
+}
+
+// GetIamPolicy: Gets the access control policy for a resource.
+// Returns an empty policy if the resource exists and does not have a
+// policy
+// set.
+func (r *ProjectsLocationsRegistriesService) GetIamPolicy(resource string, getiampolicyrequest *GetIamPolicyRequest) *ProjectsLocationsRegistriesGetIamPolicyCall {
+	c := &ProjectsLocationsRegistriesGetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.getiampolicyrequest = getiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesGetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesGetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesGetIamPolicyCall) Context(ctx context.Context) *ProjectsLocationsRegistriesGetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesGetIamPolicyCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesGetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.getiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:getIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.getIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesGetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the access control policy for a resource.\nReturns an empty policy if the resource exists and does not have a policy\nset.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:getIamPolicy",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.getIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being requested.\nSee the operation documentation for the appropriate value for this field.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:getIamPolicy",
+	//   "request": {
+	//     "$ref": "GetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.list":
+
+type ProjectsLocationsRegistriesListCall struct {
+	s            *Service
+	parent       string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists device registries.
+func (r *ProjectsLocationsRegistriesService) List(parent string) *ProjectsLocationsRegistriesListCall {
+	c := &ProjectsLocationsRegistriesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": The maximum number
+// of registries to return in the response. If this value
+// is zero, the service will select a default size. A call may return
+// fewer
+// objects than requested, but if there is a non-empty `page_token`,
+// it
+// indicates that more entries are available.
+func (c *ProjectsLocationsRegistriesListCall) PageSize(pageSize int64) *ProjectsLocationsRegistriesListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": The value returned
+// by the last `ListDeviceRegistriesResponse`; indicates
+// that this is a continuation of a prior `ListDeviceRegistries` call,
+// and
+// that the system should return the next page of data.
+func (c *ProjectsLocationsRegistriesListCall) PageToken(pageToken string) *ProjectsLocationsRegistriesListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesListCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesListCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesListCall) Context(ctx context.Context) *ProjectsLocationsRegistriesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/registries")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.list" call.
+// Exactly one of *ListDeviceRegistriesResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *ListDeviceRegistriesResponse.ServerResponse.Header or (if a
+// response was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesListCall) Do(opts ...googleapi.CallOption) (*ListDeviceRegistriesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListDeviceRegistriesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists device registries.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.list",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "pageSize": {
+	//       "description": "The maximum number of registries to return in the response. If this value\nis zero, the service will select a default size. A call may return fewer\nobjects than requested, but if there is a non-empty `page_token`, it\nindicates that more entries are available.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "The value returned by the last `ListDeviceRegistriesResponse`; indicates\nthat this is a continuation of a prior `ListDeviceRegistries` call, and\nthat the system should return the next page of data.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "parent": {
+	//       "description": "The project and cloud region path. For example,\n`projects/example-project/locations/us-central1`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+parent}/registries",
+	//   "response": {
+	//     "$ref": "ListDeviceRegistriesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsLocationsRegistriesListCall) Pages(ctx context.Context, f func(*ListDeviceRegistriesResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "cloudiot.projects.locations.registries.patch":
+
+type ProjectsLocationsRegistriesPatchCall struct {
+	s              *Service
+	name           string
+	deviceregistry *DeviceRegistry
+	urlParams_     gensupport.URLParams
+	ctx_           context.Context
+	header_        http.Header
+}
+
+// Patch: Updates a device registry configuration.
+func (r *ProjectsLocationsRegistriesService) Patch(name string, deviceregistry *DeviceRegistry) *ProjectsLocationsRegistriesPatchCall {
+	c := &ProjectsLocationsRegistriesPatchCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.deviceregistry = deviceregistry
+	return c
+}
+
+// UpdateMask sets the optional parameter "updateMask": Only updates the
+// `device_registry` fields indicated by this mask.
+// The field mask must not be empty, and it must not contain fields
+// that
+// are immutable or only set by the server.
+// Mutable top-level fields: `event_notification_config`,
+// `http_config`,
+// `mqtt_config`, and `state_notification_config`.
+func (c *ProjectsLocationsRegistriesPatchCall) UpdateMask(updateMask string) *ProjectsLocationsRegistriesPatchCall {
+	c.urlParams_.Set("updateMask", updateMask)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesPatchCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesPatchCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesPatchCall) Context(ctx context.Context) *ProjectsLocationsRegistriesPatchCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesPatchCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesPatchCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.deviceregistry)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.patch" call.
+// Exactly one of *DeviceRegistry or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *DeviceRegistry.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesPatchCall) Do(opts ...googleapi.CallOption) (*DeviceRegistry, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &DeviceRegistry{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a device registry configuration.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}",
+	//   "httpMethod": "PATCH",
+	//   "id": "cloudiot.projects.locations.registries.patch",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource path name. For example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "updateMask": {
+	//       "description": "Only updates the `device_registry` fields indicated by this mask.\nThe field mask must not be empty, and it must not contain fields that\nare immutable or only set by the server.\nMutable top-level fields: `event_notification_config`, `http_config`,\n`mqtt_config`, and `state_notification_config`.",
+	//       "format": "google-fieldmask",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "request": {
+	//     "$ref": "DeviceRegistry"
+	//   },
+	//   "response": {
+	//     "$ref": "DeviceRegistry"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.setIamPolicy":
+
+type ProjectsLocationsRegistriesSetIamPolicyCall struct {
+	s                   *Service
+	resource            string
+	setiampolicyrequest *SetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+	header_             http.Header
+}
+
+// SetIamPolicy: Sets the access control policy on the specified
+// resource. Replaces any
+// existing policy.
+func (r *ProjectsLocationsRegistriesService) SetIamPolicy(resource string, setiampolicyrequest *SetIamPolicyRequest) *ProjectsLocationsRegistriesSetIamPolicyCall {
+	c := &ProjectsLocationsRegistriesSetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.setiampolicyrequest = setiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesSetIamPolicyCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesSetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesSetIamPolicyCall) Context(ctx context.Context) *ProjectsLocationsRegistriesSetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesSetIamPolicyCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesSetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:setIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.setIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesSetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the access control policy on the specified resource. Replaces any\nexisting policy.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:setIamPolicy",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.setIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being specified.\nSee the operation documentation for the appropriate value for this field.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:setIamPolicy",
+	//   "request": {
+	//     "$ref": "SetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.testIamPermissions":
+
+type ProjectsLocationsRegistriesTestIamPermissionsCall struct {
+	s                         *Service
+	resource                  string
+	testiampermissionsrequest *TestIamPermissionsRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+	header_                   http.Header
+}
+
+// TestIamPermissions: Returns permissions that a caller has on the
+// specified resource.
+// If the resource does not exist, this will return an empty set
+// of
+// permissions, not a NOT_FOUND error.
+func (r *ProjectsLocationsRegistriesService) TestIamPermissions(resource string, testiampermissionsrequest *TestIamPermissionsRequest) *ProjectsLocationsRegistriesTestIamPermissionsCall {
+	c := &ProjectsLocationsRegistriesTestIamPermissionsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.testiampermissionsrequest = testiampermissionsrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesTestIamPermissionsCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesTestIamPermissionsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesTestIamPermissionsCall) Context(ctx context.Context) *ProjectsLocationsRegistriesTestIamPermissionsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesTestIamPermissionsCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesTestIamPermissionsCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.testiampermissionsrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:testIamPermissions")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.testIamPermissions" call.
+// Exactly one of *TestIamPermissionsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *TestIamPermissionsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesTestIamPermissionsCall) Do(opts ...googleapi.CallOption) (*TestIamPermissionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &TestIamPermissionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns permissions that a caller has on the specified resource.\nIf the resource does not exist, this will return an empty set of\npermissions, not a NOT_FOUND error.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}:testIamPermissions",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.testIamPermissions",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy detail is being requested.\nSee the operation documentation for the appropriate value for this field.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:testIamPermissions",
+	//   "request": {
+	//     "$ref": "TestIamPermissionsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "TestIamPermissionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.create":
+
+type ProjectsLocationsRegistriesDevicesCreateCall struct {
+	s          *Service
+	parent     string
+	device     *Device
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Create: Creates a device in a device registry.
+func (r *ProjectsLocationsRegistriesDevicesService) Create(parent string, device *Device) *ProjectsLocationsRegistriesDevicesCreateCall {
+	c := &ProjectsLocationsRegistriesDevicesCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	c.device = device
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesCreateCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesCreateCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.device)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/devices")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.create" call.
+// Exactly one of *Device or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Device.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesDevicesCreateCall) Do(opts ...googleapi.CallOption) (*Device, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Device{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a device in a device registry.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.devices.create",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "parent": {
+	//       "description": "The name of the device registry where this device should be created.\nFor example,\n`projects/example-project/locations/us-central1/registries/my-registry`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+parent}/devices",
+	//   "request": {
+	//     "$ref": "Device"
+	//   },
+	//   "response": {
+	//     "$ref": "Device"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.delete":
+
+type ProjectsLocationsRegistriesDevicesDeleteCall struct {
+	s          *Service
+	name       string
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Delete: Deletes a device.
+func (r *ProjectsLocationsRegistriesDevicesService) Delete(name string) *ProjectsLocationsRegistriesDevicesDeleteCall {
+	c := &ProjectsLocationsRegistriesDevicesDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesDeleteCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesDeleteCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesDeleteCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesDeleteCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.delete" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesDevicesDeleteCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes a device.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+	//   "httpMethod": "DELETE",
+	//   "id": "cloudiot.projects.locations.registries.devices.delete",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.get":
+
+type ProjectsLocationsRegistriesDevicesGetCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets details about a device.
+func (r *ProjectsLocationsRegistriesDevicesService) Get(name string) *ProjectsLocationsRegistriesDevicesGetCall {
+	c := &ProjectsLocationsRegistriesDevicesGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// FieldMask sets the optional parameter "fieldMask": The fields of the
+// `Device` resource to be returned in the response. If the
+// field mask is unset or empty, all fields are returned.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) FieldMask(fieldMask string) *ProjectsLocationsRegistriesDevicesGetCall {
+	c.urlParams_.Set("fieldMask", fieldMask)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesDevicesGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.get" call.
+// Exactly one of *Device or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Device.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesDevicesGetCall) Do(opts ...googleapi.CallOption) (*Device, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Device{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets details about a device.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.devices.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "fieldMask": {
+	//       "description": "The fields of the `Device` resource to be returned in the response. If the\nfield mask is unset or empty, all fields are returned.",
+	//       "format": "google-fieldmask",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "name": {
+	//       "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Device"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.list":
+
+type ProjectsLocationsRegistriesDevicesListCall struct {
+	s            *Service
+	parent       string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: List devices in a device registry.
+func (r *ProjectsLocationsRegistriesDevicesService) List(parent string) *ProjectsLocationsRegistriesDevicesListCall {
+	c := &ProjectsLocationsRegistriesDevicesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	return c
+}
+
+// DeviceIds sets the optional parameter "deviceIds": A list of device
+// string identifiers. If empty, it will ignore this field.
+// For example, `['device0', 'device12']`. This field cannot hold more
+// than
+// 10,000 entries.
+func (c *ProjectsLocationsRegistriesDevicesListCall) DeviceIds(deviceIds ...string) *ProjectsLocationsRegistriesDevicesListCall {
+	c.urlParams_.SetMulti("deviceIds", append([]string{}, deviceIds...))
+	return c
+}
+
+// DeviceNumIds sets the optional parameter "deviceNumIds": A list of
+// device numerical ids. If empty, it will ignore this field. This
+// field cannot hold more than 10,000 entries.
+func (c *ProjectsLocationsRegistriesDevicesListCall) DeviceNumIds(deviceNumIds ...uint64) *ProjectsLocationsRegistriesDevicesListCall {
+	var deviceNumIds_ []string
+	for _, v := range deviceNumIds {
+		deviceNumIds_ = append(deviceNumIds_, fmt.Sprint(v))
+	}
+	c.urlParams_.SetMulti("deviceNumIds", deviceNumIds_)
+	return c
+}
+
+// FieldMask sets the optional parameter "fieldMask": The fields of the
+// `Device` resource to be returned in the response. The
+// fields `id`, and `num_id` are always returned by default, along with
+// any
+// other fields specified.
+func (c *ProjectsLocationsRegistriesDevicesListCall) FieldMask(fieldMask string) *ProjectsLocationsRegistriesDevicesListCall {
+	c.urlParams_.Set("fieldMask", fieldMask)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": The maximum number
+// of devices to return in the response. If this value
+// is zero, the service will select a default size. A call may return
+// fewer
+// objects than requested, but if there is a non-empty `page_token`,
+// it
+// indicates that more entries are available.
+func (c *ProjectsLocationsRegistriesDevicesListCall) PageSize(pageSize int64) *ProjectsLocationsRegistriesDevicesListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": The value returned
+// by the last `ListDevicesResponse`; indicates
+// that this is a continuation of a prior `ListDevices` call, and
+// that the system should return the next page of data.
+func (c *ProjectsLocationsRegistriesDevicesListCall) PageToken(pageToken string) *ProjectsLocationsRegistriesDevicesListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesListCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesDevicesListCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesDevicesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesListCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/devices")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.list" call.
+// Exactly one of *ListDevicesResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListDevicesResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesDevicesListCall) Do(opts ...googleapi.CallOption) (*ListDevicesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListDevicesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "List devices in a device registry.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.devices.list",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "deviceIds": {
+	//       "description": "A list of device string identifiers. If empty, it will ignore this field.\nFor example, `['device0', 'device12']`. This field cannot hold more than\n10,000 entries.",
+	//       "location": "query",
+	//       "repeated": true,
+	//       "type": "string"
+	//     },
+	//     "deviceNumIds": {
+	//       "description": "A list of device numerical ids. If empty, it will ignore this field. This\nfield cannot hold more than 10,000 entries.",
+	//       "format": "uint64",
+	//       "location": "query",
+	//       "repeated": true,
+	//       "type": "string"
+	//     },
+	//     "fieldMask": {
+	//       "description": "The fields of the `Device` resource to be returned in the response. The\nfields `id`, and `num_id` are always returned by default, along with any\nother fields specified.",
+	//       "format": "google-fieldmask",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "The maximum number of devices to return in the response. If this value\nis zero, the service will select a default size. A call may return fewer\nobjects than requested, but if there is a non-empty `page_token`, it\nindicates that more entries are available.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "The value returned by the last `ListDevicesResponse`; indicates\nthat this is a continuation of a prior `ListDevices` call, and\nthat the system should return the next page of data.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "parent": {
+	//       "description": "The device registry path. Required. For example,\n`projects/my-project/locations/us-central1/registries/my-registry`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+parent}/devices",
+	//   "response": {
+	//     "$ref": "ListDevicesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsLocationsRegistriesDevicesListCall) Pages(ctx context.Context, f func(*ListDevicesResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "cloudiot.projects.locations.registries.devices.modifyCloudToDeviceConfig":
+
+type ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall struct {
+	s                                *Service
+	name                             string
+	modifycloudtodeviceconfigrequest *ModifyCloudToDeviceConfigRequest
+	urlParams_                       gensupport.URLParams
+	ctx_                             context.Context
+	header_                          http.Header
+}
+
+// ModifyCloudToDeviceConfig: Modifies the configuration for the device,
+// which is eventually sent from
+// the Cloud IoT Core servers. Returns the modified configuration
+// version and
+// its metadata.
+func (r *ProjectsLocationsRegistriesDevicesService) ModifyCloudToDeviceConfig(name string, modifycloudtodeviceconfigrequest *ModifyCloudToDeviceConfigRequest) *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall {
+	c := &ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.modifycloudtodeviceconfigrequest = modifycloudtodeviceconfigrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.modifycloudtodeviceconfigrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:modifyCloudToDeviceConfig")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.modifyCloudToDeviceConfig" call.
+// Exactly one of *DeviceConfig or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *DeviceConfig.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesDevicesModifyCloudToDeviceConfigCall) Do(opts ...googleapi.CallOption) (*DeviceConfig, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &DeviceConfig{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Modifies the configuration for the device, which is eventually sent from\nthe Cloud IoT Core servers. Returns the modified configuration version and\nits metadata.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}:modifyCloudToDeviceConfig",
+	//   "httpMethod": "POST",
+	//   "id": "cloudiot.projects.locations.registries.devices.modifyCloudToDeviceConfig",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}:modifyCloudToDeviceConfig",
+	//   "request": {
+	//     "$ref": "ModifyCloudToDeviceConfigRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "DeviceConfig"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.patch":
+
+type ProjectsLocationsRegistriesDevicesPatchCall struct {
+	s          *Service
+	name       string
+	device     *Device
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Patch: Updates a device.
+func (r *ProjectsLocationsRegistriesDevicesService) Patch(name string, device *Device) *ProjectsLocationsRegistriesDevicesPatchCall {
+	c := &ProjectsLocationsRegistriesDevicesPatchCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	c.device = device
+	return c
+}
+
+// UpdateMask sets the optional parameter "updateMask": Only updates the
+// `device` fields indicated by this mask.
+// The field mask must not be empty, and it must not contain fields
+// that
+// are immutable or only set by the server.
+// Mutable top-level fields: `credentials`, `enabled_state`, and
+// `metadata`
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) UpdateMask(updateMask string) *ProjectsLocationsRegistriesDevicesPatchCall {
+	c.urlParams_.Set("updateMask", updateMask)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesPatchCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesPatchCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.device)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.patch" call.
+// Exactly one of *Device or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Device.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsLocationsRegistriesDevicesPatchCall) Do(opts ...googleapi.CallOption) (*Device, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Device{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a device.",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}",
+	//   "httpMethod": "PATCH",
+	//   "id": "cloudiot.projects.locations.registries.devices.patch",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The resource path name. For example,\n`projects/p1/locations/us-central1/registries/registry0/devices/dev0` or\n`projects/p1/locations/us-central1/registries/registry0/devices/{num_id}`.\nWhen `name` is populated as a response from the service, it always ends\nin the device numeric ID.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "updateMask": {
+	//       "description": "Only updates the `device` fields indicated by this mask.\nThe field mask must not be empty, and it must not contain fields that\nare immutable or only set by the server.\nMutable top-level fields: `credentials`, `enabled_state`, and `metadata`",
+	//       "format": "google-fieldmask",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "request": {
+	//     "$ref": "Device"
+	//   },
+	//   "response": {
+	//     "$ref": "Device"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.configVersions.list":
+
+type ProjectsLocationsRegistriesDevicesConfigVersionsListCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists the last few versions of the device configuration in
+// descending
+// order (i.e.: newest first).
+func (r *ProjectsLocationsRegistriesDevicesConfigVersionsService) List(name string) *ProjectsLocationsRegistriesDevicesConfigVersionsListCall {
+	c := &ProjectsLocationsRegistriesDevicesConfigVersionsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// NumVersions sets the optional parameter "numVersions": The number of
+// versions to list. Versions are listed in decreasing order of
+// the version number. The maximum number of versions retained is 10. If
+// this
+// value is zero, it will return all the versions available.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) NumVersions(numVersions int64) *ProjectsLocationsRegistriesDevicesConfigVersionsListCall {
+	c.urlParams_.Set("numVersions", fmt.Sprint(numVersions))
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesConfigVersionsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesDevicesConfigVersionsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesConfigVersionsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/configVersions")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.configVersions.list" call.
+// Exactly one of *ListDeviceConfigVersionsResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *ListDeviceConfigVersionsResponse.ServerResponse.Header or (if
+// a response was returned at all) in error.(*googleapi.Error).Header.
+// Use googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesDevicesConfigVersionsListCall) Do(opts ...googleapi.CallOption) (*ListDeviceConfigVersionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListDeviceConfigVersionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists the last few versions of the device configuration in descending\norder (i.e.: newest first).",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}/configVersions",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.devices.configVersions.list",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "numVersions": {
+	//       "description": "The number of versions to list. Versions are listed in decreasing order of\nthe version number. The maximum number of versions retained is 10. If this\nvalue is zero, it will return all the versions available.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/configVersions",
+	//   "response": {
+	//     "$ref": "ListDeviceConfigVersionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}
+
+// method id "cloudiot.projects.locations.registries.devices.states.list":
+
+type ProjectsLocationsRegistriesDevicesStatesListCall struct {
+	s            *Service
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists the last few versions of the device state in descending
+// order (i.e.:
+// newest first).
+func (r *ProjectsLocationsRegistriesDevicesStatesService) List(name string) *ProjectsLocationsRegistriesDevicesStatesListCall {
+	c := &ProjectsLocationsRegistriesDevicesStatesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// NumStates sets the optional parameter "numStates": The number of
+// states to list. States are listed in descending order of
+// update time. The maximum number of states retained is 10. If
+// this
+// value is zero, it will return all the states available.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) NumStates(numStates int64) *ProjectsLocationsRegistriesDevicesStatesListCall {
+	c.urlParams_.Set("numStates", fmt.Sprint(numStates))
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) Fields(s ...googleapi.Field) *ProjectsLocationsRegistriesDevicesStatesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) IfNoneMatch(entityTag string) *ProjectsLocationsRegistriesDevicesStatesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) Context(ctx context.Context) *ProjectsLocationsRegistriesDevicesStatesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/states")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "cloudiot.projects.locations.registries.devices.states.list" call.
+// Exactly one of *ListDeviceStatesResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *ListDeviceStatesResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsRegistriesDevicesStatesListCall) Do(opts ...googleapi.CallOption) (*ListDeviceStatesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListDeviceStatesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists the last few versions of the device state in descending order (i.e.:\nnewest first).",
+	//   "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/registries/{registriesId}/devices/{devicesId}/states",
+	//   "httpMethod": "GET",
+	//   "id": "cloudiot.projects.locations.registries.devices.states.list",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the device. For example,\n`projects/p0/locations/us-central1/registries/registry0/devices/device0` or\n`projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.",
+	//       "location": "path",
+	//       "pattern": "^projects/[^/]+/locations/[^/]+/registries/[^/]+/devices/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "numStates": {
+	//       "description": "The number of states to list. States are listed in descending order of\nupdate time. The maximum number of states retained is 10. If this\nvalue is zero, it will return all the states available.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     }
+	//   },
+	//   "path": "v1/{+name}/states",
+	//   "response": {
+	//     "$ref": "ListDeviceStatesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloudiot"
+	//   ]
+	// }
+
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1242,6 +1242,12 @@
 			"revisionTime": "2017-12-15T00:04:04Z"
 		},
 		{
+			"checksumSHA1": "uLifIDdJHnoBlTG0G4T6DGSB9l4=",
+			"path": "google.golang.org/api/cloudiot/v1",
+			"revision": "37df4fabefb044819e927f44b8487d4cd926d06c",
+			"revisionTime": "2018-01-12T00:03:42Z"
+		},
+		{
 			"checksumSHA1": "/cYz9AiKwLEO61OdoLnKi2uiOeQ=",
 			"path": "google.golang.org/api/cloudkms/v1",
 			"revision": "654f863362977d69086620b5f72f13e911da2410",

--- a/website/docs/r/cloudiot_registry.html.markdown
+++ b/website/docs/r/cloudiot_registry.html.markdown
@@ -70,14 +70,13 @@ The following arguments are supported:
 
 - - -
 
-* `project` - (Optional) The project in which the resource belongs. If it
-    is not provided, the provider project is used.
+* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
 
 * `region` - (Optional) The Region in which the created address should reside. If it is not provided, the provider region is used.
 
-* `event_notification_configs` - (Optional) List of pubsub topics to publish device events. Structure is documented below.
+* `event_notification_configs` - (Optional) List of PubSub topics to publish device events. Structure is documented below.
 
-* `state_notification_config` - (Optional) A pubsub topic to publish device state updates. Structure is documented below.
+* `state_notification_config` - (Optional) A PubSub topic to publish device state updates. Structure is documented below.
 
 * `mqtt_config` - (Optional) Activate or deactivate MQTT. Structure is documented below.
 * `http_config` - (Optional) Activate or deactivate HTTP. Structure is documented below.
@@ -87,11 +86,11 @@ The following arguments are supported:
 
 The `event_notification_configs` block supports:
 
-* `pubsub_topic_name` - (Required) Pubsub topic name to publish device events.
+* `pubsub_topic_name` - (Required) PubSub topic name to publish device events.
 
 The `state_notification_config` block supports:
 
-* `pubsub_topic_name` - (Required) Pubsub topic name to publish device state updates.
+* `pubsub_topic_name` - (Required) PubSub topic name to publish device state updates.
 
 The `mqtt_config` block supports:
 
@@ -110,8 +109,9 @@ The `credentials` block supports:
 The `x509_details` block supports:
 * `issuer` - (Required) Identifies the entity that has signed and issued the certificate.
 * `subject` - (Required) The person or system the certificate belongs to.
-* `start_time` - (Required) The date on which the certificate validity period begins.
-* `expiry_time` - (Required) The date on which the certificate validity period ends.
+* `start_time` - (Required) The date on which the certificate validity period begins. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: 
+`2016-10-09T12:33:37.578138407Z`.
+* `expiry_time` - (Required) The date on which the certificate validity period ends. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: `2016-10-09T12:33:37.578138407Z`.
 * `signature_algorithm` - (Required) Identifier for the cryptographic algorithm used to sign this certificate.
 * `public_key_type` - (Required) The type of public key in the certificate.
 

--- a/website/docs/r/cloudiot_registry.html.markdown
+++ b/website/docs/r/cloudiot_registry.html.markdown
@@ -1,0 +1,128 @@
+---
+layout: "google"
+page_title: "Google: google_cloudiot_registry"
+sidebar_current: "docs-google-cloudiot-registry-x"
+description: |-
+  Creates a device registry in Google's Cloud IoT Core platform
+---
+
+# google\cloudiot\_registry
+
+ Creates a device registry in Google's Cloud IoT Core platform. For more information see
+[the official documentation](https://cloud.google.com/iot/docs/) and
+[API](https://cloud.google.com/iot/docs/reference/rest/v1/projects.locations.registries).
+
+
+## Example Usage
+
+```hcl
+resource "google_pubsub_topic" "default-devicestatus" {
+  name = "default-devicestatus"
+}
+
+resource "google_pubsub_topic" "default-telemetry" {
+  name = "default-telemetry"
+}
+
+resource "google_cloudiot_registry" "default-registry" {
+  name = "default-registry"
+
+  event_notification_configs = [{
+    pubsub_topic_name = "${google_pubsub_topic.default-devicestatus.id}"
+  }]
+
+  state_notification_config = {
+    pubsub_topic_name = "${google_pubsub_topic.default-telemetry.id}"
+  }
+
+  http_config = {
+    http_enabled_state = "HTTP_ENABLED"
+  }
+
+  mqtt_config = {
+    mqtt_enabled_state = "MQTT_ENABLED"
+  }
+
+  credentials = [
+    {
+      format      = "X509_CERTIFICATE_PEM"
+      certificate = "<CERTIFICATE>"
+
+      x509_details = {
+        issuer              = "CN=unused"
+        subject             = "CN=unused"
+        start_time          = "2018-01-12T20:13:43Z"
+        expiry_time         = "2023-01-11T20:13:43Z"
+        signature_algorithm = "sha256WithRSAEncryption"
+        public_key_type     = "PK_RSA"
+      }
+    },
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by device registry.
+    Changing this forces a new resource to be created.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The Region in which the created address should reside. If it is not provided, the provider region is used.
+
+* `event_notification_configs` - (Optional) List of pubsub topics to publish device events. Structure is documented below.
+
+* `state_notification_config` - (Optional) A pubsub topic to publish device state updates. Structure is documented below.
+
+* `mqtt_config` - (Optional) Activate or deactivate MQTT. Structure is documented below.
+* `http_config` - (Optional) Activate or deactivate HTTP. Structure is documented below.
+
+* `credentials` - (Optional) List of public key certificates to authenticate devices. Structure is documented below. 
+
+
+The `event_notification_configs` block supports:
+
+* `pubsub_topic_name` - (Required) Pubsub topic name to publish device events.
+
+The `state_notification_config` block supports:
+
+* `pubsub_topic_name` - (Required) Pubsub topic name to publish device state updates.
+
+The `mqtt_config` block supports:
+
+* `mqtt_enabled_state` - (Required) The field allows `MQTT_STATE_UNSPECIFIED`, `MQTT_ENABLED` or `MQTT_DISABLED`.
+
+The `http_config` block supports:
+
+* `http_enabled_state` - (Required) The field allows `HTTP_STATE_UNSPECIFIED`, `HTTP_ENABLED` or `HTTP_DISABLED`.
+
+The `credentials` block supports:
+
+* `format` - (Required) The field allows `UNSPECIFIED_PUBLIC_KEY_CERTIFICATE_FORMAT` or `X509_CERTIFICATE_PEM`.
+* `certificate` - (Required) The certificate data.
+* `x509_details` - (Required) The certificate details. The structure is described below.
+
+The `x509_details` block supports:
+* `issuer` - (Required) Identifies the entity that has signed and issued the certificate.
+* `subject` - (Required) The person or system the certificate belongs to.
+* `start_time` - (Required) The date on which the certificate validity period begins.
+* `expiry_time` - (Required) The date on which the certificate validity period ends.
+* `signature_algorithm` - (Required) Identifier for the cryptographic algorithm used to sign this certificate.
+* `public_key_type` - (Required) The type of public key in the certificate.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.
+
+## Import
+
+A device registry can be imported using the `name`, e.g.
+
+```
+$ terraform import google_cloudiot_registry.myregistry myregistry
+```

--- a/website/docs/r/cloudiot_registry.html.markdown
+++ b/website/docs/r/cloudiot_registry.html.markdown
@@ -45,16 +45,9 @@ resource "google_cloudiot_registry" "default-registry" {
 
   credentials = [
     {
-      format      = "X509_CERTIFICATE_PEM"
-      certificate = "<CERTIFICATE>"
-
-      x509_details = {
-        issuer              = "CN=unused"
-        subject             = "CN=unused"
-        start_time          = "2018-01-12T20:13:43Z"
-        expiry_time         = "2023-01-11T20:13:43Z"
-        signature_algorithm = "sha256WithRSAEncryption"
-        public_key_type     = "PK_RSA"
+      public_key_certificate = {
+        format      = "X509_CERTIFICATE_PEM"
+        certificate = "<CERTIFICATE>"
       }
     },
   ]
@@ -102,18 +95,13 @@ The `http_config` block supports:
 
 The `credentials` block supports:
 
+* `public_key_certificate` - (Required) The certificate format and data.
+
+The `public_key_certificate` block supports:
+
 * `format` - (Required) The field allows `UNSPECIFIED_PUBLIC_KEY_CERTIFICATE_FORMAT` or `X509_CERTIFICATE_PEM`.
 * `certificate` - (Required) The certificate data.
-* `x509_details` - (Required) The certificate details. The structure is described below.
 
-The `x509_details` block supports:
-* `issuer` - (Required) Identifies the entity that has signed and issued the certificate.
-* `subject` - (Required) The person or system the certificate belongs to.
-* `start_time` - (Required) The date on which the certificate validity period begins. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: 
-`2016-10-09T12:33:37.578138407Z`.
-* `expiry_time` - (Required) The date on which the certificate validity period ends. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: `2016-10-09T12:33:37.578138407Z`.
-* `signature_algorithm` - (Required) Identifier for the cryptographic algorithm used to sign this certificate.
-* `public_key_type` - (Required) The type of public key in the certificate.
 
 ## Attributes Reference
 

--- a/website/docs/r/google_project_service.html.markdown
+++ b/website/docs/r/google_project_service.html.markdown
@@ -32,3 +32,5 @@ The following arguments are supported:
 * `service` - (Required) The service to enable.
 
 * `project` - (Optional) The project ID. If not provided, the provider project is used.
+
+* `disable_on_destroy` - (Optional) If true, disable the service when the terraform resource is destroyed.  Defaults to true.  May be useful in the event that a project is long-lived but the infrastructure running in that project changes frequently.

--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -27,7 +27,7 @@ resource "google_pubsub_subscription" "default" {
   ack_deadline_seconds = 20
 
   push_config {
-    endpoint = "https://example.com/push"
+    push_endpoint = "https://example.com/push"
 
     attributes {
       x-goog-version = "v1"

--- a/website/google.erb
+++ b/website/google.erb
@@ -528,6 +528,15 @@
     </ul>
     </li>
 
+    <li<%= sidebar_current("docs-google-cloudiot") %>>
+      <a href="#">Google Cloud IoT Core</a>
+      <ul class="nav nav-visible">
+        <li<%= sidebar_current("docs-google-cloudiot-registry-x") %>>
+          <a href="/docs/providers/google/r/cloudiot_registry.html">google_cloudiot_registry</a>
+        </li>
+      </ul>
+    </li>
+
   </ul>
 </div>
   <% end %>


### PR DESCRIPTION
This pull request adds support for the Google Cloud IoT Core registry. I have tried to be as closes to the data structure of [registry API](https://cloud.google.com/iot/docs/reference/rest/v1/projects.locations.registries) as possible. The downside is a lot of nesting in the config. But hopefully it allows a easy extension if the API evolves.