### PR TITLE
Correct usage of 'folders' for 'google_folder_organization_policy' resource

### DIFF
--- a/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/website/docs/r/google_folder_organization_policy.html.markdown
@@ -19,7 +19,7 @@ To set policy with a [boolean constraint](https://cloud.google.com/resource-mana
 
 ```hcl
 resource "google_folder_organization_policy" "serial_port_policy" {
-  folder     = "123456789"
+  folder     = "folders/123456789"
   constraint = "compute.disableSerialPortAccess"
 
   boolean_policy {
@@ -33,7 +33,7 @@ To set a policy with a [list contraint](https://cloud.google.com/resource-manage
 
 ```hcl
 resource "google_folder_organization_policy" "services_policy" {
-  folder     = "123456789"
+  folder     = "folders/123456789"
   constraint = "serviceuser.services"
 
   list_policy {
@@ -49,7 +49,7 @@ Or to deny some services, use the following instead:
 
 ```hcl
 resource "google_folder_organization_policy" "services_policy" {
-  folder     = "123456789"
+  folder     = "folders/123456789"
   constraint = "serviceuser.services"
 
   list_policy {
@@ -66,7 +66,7 @@ resource "google_folder_organization_policy" "services_policy" {
 
 The following arguments are supported:
 
-* `folder` - (Required) The numeric ID of the organization to set the policy for.
+* `folder` - (Required) The resource name of the folder to set the policy for. Its format is folders/{folder_id}.
 
 * `constraint` - (Required) The name of the Constraint the Policy is configuring, for example, `serviceuser.services`. Check out the [complete list of available constraints](https://cloud.google.com/resource-manager/docs/organization-policy/understanding-constraints#available_constraints).
 


### PR DESCRIPTION
The `folders` argument to the `google_folder_organization_policy` resource has to be the folder's resource name in the format **folders/**_{folder_id}_.
Correct the documentation.