### PR TITLE
Fix autoscaler - was unnecessarily forcing to a single metric

### DIFF
--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -177,7 +177,6 @@ func buildAutoscaler(d *schema.ResourceData) (*compute.Autoscaler, error) {
 			}
 		}
 	}
-	fmt.Printf("customMetrics: %s\n", customMetrics)
 	scaler.AutoscalingPolicy.CustomMetricUtilizations = customMetrics
 	if _, ok := d.GetOk("autoscaling_policy.0.load_balancing_utilization"); ok {
 		if d.Get(prefix+"load_balancing_utilization.0.target").(float64) != 0 {

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -77,6 +77,32 @@ func TestAccComputeAutoscaler_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeAutoscaler_multicondition(t *testing.T) {
+	t.Parallel()
+
+	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var tp_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var igm_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var autoscaler_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeAutoscalerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeAutoscaler_multicondition(it_name, tp_name, igm_name, autoscaler_name),
+				Check:  testAccCheckComputeAutoscalerMultifunction("google_compute_autoscaler.foobar"),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_autoscaler.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeAutoscalerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -124,6 +150,39 @@ func testAccCheckComputeAutoscalerExists(n string, ascaler *compute.Autoscaler) 
 	}
 }
 
+func testAccCheckComputeAutoscalerMultifunction(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.Autoscalers.Get(
+			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Autoscaler not found")
+		}
+
+		if found.AutoscalingPolicy.CpuUtilization.UtilizationTarget == 0.5 && found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget == 0.5 {
+			return nil
+		}
+		return fmt.Errorf("Util target for CPU: %d, for LB: %d - should have been 0.5 for each.",
+			found.AutoscalingPolicy.CpuUtilization.UtilizationTarget,
+			found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget)
+
+	}
+}
+
 func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -151,7 +210,7 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 	}
 }
 
-func testAccComputeAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
@@ -192,7 +251,12 @@ resource "google_compute_instance_group_manager" "foobar" {
 	base_instance_name = "foobar"
 	zone = "us-central1-a"
 }
+`, it_name, tp_name, igm_name)
 
+}
+
+func testAccComputeAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	name = "%s"
@@ -208,51 +272,11 @@ resource "google_compute_autoscaler" "foobar" {
 	}
 
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
 }
 
 func testAccComputeAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance_template" "foobar" {
-	name = "%s"
-	machine_type = "n1-standard-1"
-	can_ip_forward = false
-	tags = ["foo", "bar"]
-
-	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
-		auto_delete = true
-		boot = true
-	}
-
-	network_interface {
-		network = "default"
-	}
-
-	metadata {
-		foo = "bar"
-	}
-
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
-}
-
-resource "google_compute_target_pool" "foobar" {
-	description = "Resource created for Terraform acceptance testing"
-	name = "%s"
-	session_affinity = "CLIENT_IP_PROTO"
-}
-
-resource "google_compute_instance_group_manager" "foobar" {
-	description = "Terraform test instance group manager"
-	name = "%s"
-	instance_template = "${google_compute_instance_template.foobar.self_link}"
-	target_pools = ["${google_compute_target_pool.foobar.self_link}"]
-	base_instance_name = "foobar"
-	zone = "us-central1-a"
-}
-
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
 	description = "Resource created for Terraform acceptance testing"
 	name = "%s"
@@ -268,5 +292,38 @@ resource "google_compute_autoscaler" "foobar" {
 	}
 
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
+}
+
+func testAccComputeAutoscaler_multicondition(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
+resource "google_compute_autoscaler" "foobar" {
+	description = "Resource created for Terraform acceptance testing"
+	name = "%s"
+	zone = "us-central1-a"
+	target = "${google_compute_instance_group_manager.foobar.self_link}"
+	autoscaling_policy = {
+		max_replicas = 10
+		min_replicas = 1
+		cooldown_period = 60
+		cpu_utilization = {
+			target = 0.5
+		}
+		load_balancing_utilization = {
+			target = 0.5
+		}
+		metric {
+			name = "compute.googleapis.com/instance/network/received_bytes_count"
+			target = 75
+			type = "GAUGE"
+		}
+		metric {
+			name = "compute.googleapis.com/instance/network/sent_bytes_count"
+			target = 50
+			type = "GAUGE"
+		}
+	}
+
+}
+`, autoscaler_name)
 }


### PR DESCRIPTION
Multiple metrics are supported, as the new test proves.  Also, we weren't successfully storing the right information about custom metrics on read... you can imagine why we didn't catch that since it's a little-used feature.

This fixes #38.