### PR TITLE
Update docs to show disabling basic auth in new container cluster.

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -210,6 +210,8 @@ The `master_auth` block supports:
 * `username` - (Required) The username to use for HTTP basic authentication when accessing
     the Kubernetes master endpoint
 
+If this block is provided and both username and password are empty, basic auth will be disabled.
+
 The `master_authorized_networks_config` block supports:
 
 * `cidr_blocks` - (Optional) Defines up to 10 external networks that can access

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -210,7 +210,7 @@ The `master_auth` block supports:
 * `username` - (Required) The username to use for HTTP basic authentication when accessing
     the Kubernetes master endpoint
 
-If this block is provided and both username and password are empty, basic auth will be disabled.
+If this block is provided and both `username` and `password` are empty, basic authentication will be disabled.
 
 The `master_authorized_networks_config` block supports:
 


### PR DESCRIPTION
This docs-only change will close #510.