### PR TITLE
Fix 'go vet' error - 'arg found.AutoscalingPolicy.CpuUtilization.UtilizationTarget for printf verb %d of wrong type: float64'

### DIFF
--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -176,7 +176,7 @@ func testAccCheckComputeAutoscalerMultifunction(n string) resource.TestCheckFunc
 		if found.AutoscalingPolicy.CpuUtilization.UtilizationTarget == 0.5 && found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget == 0.5 {
 			return nil
 		}
-		return fmt.Errorf("Util target for CPU: %d, for LB: %d - should have been 0.5 for each.",
+		return fmt.Errorf("Util target for CPU: %f, for LB: %f - should have been 0.5 for each.",
 			found.AutoscalingPolicy.CpuUtilization.UtilizationTarget,
 			found.AutoscalingPolicy.LoadBalancingUtilization.UtilizationTarget)
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/968.