### PR TITLE
Fix canonical image

### DIFF
--- a/google/resource_compute_instance_migrate.go
+++ b/google/resource_compute_instance_migrate.go
@@ -442,7 +442,8 @@ func getDiskFromAutoDeleteAndImage(config *Config, instance *compute.Instance, a
 	if err != nil {
 		return nil, err
 	}
-	canonicalImage := GetResourceNameFromSelfLink(img)
+	imgParts := strings.Split(img, "/projects/")
+	canonicalImage := imgParts[len(imgParts)-1]
 
 	for i, disk := range instance.Disks {
 		if disk.Boot == true || disk.Type == "SCRATCH" {


### PR DESCRIPTION
Fix test failures for instance migration introduced in:
https://github.com/terraform-providers/terraform-provider-google/commit/d0f5fec463da5caca97fa35ad91e20b353c0f44f

Tests are now passing:
```sh
--- PASS: TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage (47.92s)
--- PASS: TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage (51.74s)
```