### PR TITLE
Added tfvars to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.exe
 .DS_Store
 example.tf
+terraform.tfvars
 terraform.tfplan
 terraform.tfstate
 bin/


### PR DESCRIPTION
This is just for my convenience - I needed to make a tfvars file because you can't seem to pass vars on the command line when you're doing imports.