### PR TITLE
Add update support for machine type, min cpu platform, and service accounts

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -54,6 +54,10 @@ func ParseAcceleratorFieldValue(accelerator string, d TerraformResourceData, con
 	return parseZonalFieldValue("acceleratorTypes", accelerator, "project", "zone", d, config, false)
 }
 
+func ParseMachineTypesFieldValue(machineType string, d TerraformResourceData, config *Config) (*ZonalFieldValue, error) {
+	return parseZonalFieldValue("machineTypes", machineType, "project", "zone", d, config, false)
+}
+
 // ------------------------------------------------------------
 // Base helpers used to create helpers for specific fields.
 // ------------------------------------------------------------

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -518,6 +518,60 @@ func TestAccComputeInstance_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_stopInstanceToUpdate(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			// Set fields that require stopping the instance
+			resource.TestStep{
+				Config: testAccComputeInstance_stopInstanceToUpdate(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+				),
+			},
+			resource.TestStep{
+				ResourceName:  "google_compute_instance.foobar",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), "us-central1-a", instanceName),
+			},
+			// Check that updating them works
+			resource.TestStep{
+				Config: testAccComputeInstance_stopInstanceToUpdate2(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+				),
+			},
+			resource.TestStep{
+				ResourceName:  "google_compute_instance.foobar",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), "us-central1-a", instanceName),
+			},
+			// Check that removing them works
+			resource.TestStep{
+				Config: testAccComputeInstance_stopInstanceToUpdate3(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						"google_compute_instance.foobar", &instance),
+				),
+			},
+			resource.TestStep{
+				ResourceName:  "google_compute_instance.foobar",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), "us-central1-a", instanceName),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_service_account(t *testing.T) {
 	t.Parallel()
 
@@ -2423,4 +2477,84 @@ resource "google_compute_instance" "foobar" {
     }
   }
 }`, acctest.RandString(10), acctest.RandString(10), instance)
+}
+
+// Set fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
+func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foobar" {
+	name           = "%s"
+	machine_type   = "n1-standard-1"
+	zone           = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	min_cpu_platform = "Intel Broadwell"
+	service_account {
+		scopes = [
+			"userinfo-email",
+			"compute-ro",
+			"storage-ro",
+		]
+	}
+}
+`, instance)
+}
+
+// Update fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
+func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foobar" {
+	name           = "%s"
+	machine_type   = "n1-standard-2"
+	zone           = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	min_cpu_platform = "Intel Skylake"
+	service_account {
+		scopes = [
+			"userinfo-email",
+			"compute-ro",
+		]
+	}
+}
+`, instance)
+}
+
+// Remove fields that require stopping the instance: min_cpu_platform and service_account (machine_type is Required)
+func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foobar" {
+	name           = "%s"
+	machine_type   = "n1-standard-2"
+	zone           = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "debian-8-jessie-v20160803"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, instance)
 }

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -2505,6 +2505,8 @@ resource "google_compute_instance" "foobar" {
 			"storage-ro",
 		]
 	}
+
+	allow_stopping_for_update = true
 }
 `, instance)
 }
@@ -2534,6 +2536,8 @@ resource "google_compute_instance" "foobar" {
 			"compute-ro",
 		]
 	}
+
+	allow_stopping_for_update = true
 }
 `, instance)
 }
@@ -2555,6 +2559,8 @@ resource "google_compute_instance" "foobar" {
 	network_interface {
 		network = "default"
 	}
+
+	allow_stopping_for_update = true
 }
 `, instance)
 }

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -64,8 +64,7 @@ The following arguments are supported:
 * `machine_type` - (Required) The machine type to create. To create a custom
     machine type, value should be set as specified
     [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType).
-    **Warning**: Terraform will stop the instance while updating this field. Make sure this
-    is acceptable for your instance before changing this value.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
@@ -76,6 +75,9 @@ The following arguments are supported:
     be specified multiple times. Structure is documented below.
 
 - - -
+
+* `allow_stopping_for_update` - (Optional) If true, allows Terraform to stop the instance to update its properties.
+  If you try to update a property that requires stopping the instance without setting this field, the update will fail.
 
 * `attached_disk` - (Optional) List of disks to attach to the instance. Structure is documented below.
 
@@ -103,8 +105,7 @@ The following arguments are supported:
 
 * `min_cpu_platform` - (Optional) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
 `Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
-    **Warning**: Terraform will stop the instance while updating this field. Make sure this
-    is acceptable for your instance before changing this value.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -117,8 +118,7 @@ The following arguments are supported:
 
 * `service_account` - (Optional) Service account to attach to the instance.
     Structure is documented below.
-    **Warning**: Terraform will stop the instance while updating this field. Make sure this
-    is acceptable for your instance before changing this value.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
 
 * `tags` - (Optional) A list of tags to attach to the instance.
 
@@ -226,14 +226,12 @@ The `service_account` block supports:
 
 * `email` - (Optional) The service account e-mail address. If not given, the
     default Google Compute Engine service account is used.
-    **Warning**: Terraform will stop the instance while updating this field. Make sure this
-    is acceptable for your instance before changing this value.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
 
 * `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
     short names are supported. To allow full access to all Cloud APIs, use the
     `cloud-platform` scope. See a complete list of scopes [here](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes).
-    **Warning**: Terraform will stop the instance while updating this field. Make sure this
-    is acceptable for your instance before changing this value.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
 
 The `scheduling` block supports:
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -63,7 +63,9 @@ The following arguments are supported:
 
 * `machine_type` - (Required) The machine type to create. To create a custom
     machine type, value should be set as specified
-    [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType)
+    [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType).
+    **Warning**: Terraform will stop the instance while updating this field. Make sure this
+    is acceptable for your instance before changing this value.
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
@@ -86,6 +88,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A brief description of this resource.
 
+* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
+
 * `labels` - (Optional) A set of key/value label pairs to assign to the instance.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
@@ -96,6 +100,11 @@ The following arguments are supported:
     recreated (thus re-running the script) if it is changed. This replaces the
     startup-script metadata key on the created instance and thus the two
     mechanisms are not allowed to be used simultaneously.
+
+* `min_cpu_platform` - (Optional) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
+`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+    **Warning**: Terraform will stop the instance while updating this field. Make sure this
+    is acceptable for your instance before changing this value.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -108,6 +117,8 @@ The following arguments are supported:
 
 * `service_account` - (Optional) Service account to attach to the instance.
     Structure is documented below.
+    **Warning**: Terraform will stop the instance while updating this field. Make sure this
+    is acceptable for your instance before changing this value.
 
 * `tags` - (Optional) A list of tags to attach to the instance.
 
@@ -215,10 +226,14 @@ The `service_account` block supports:
 
 * `email` - (Optional) The service account e-mail address. If not given, the
     default Google Compute Engine service account is used.
+    **Warning**: Terraform will stop the instance while updating this field. Make sure this
+    is acceptable for your instance before changing this value.
 
 * `scopes` - (Required) A list of service scopes. Both OAuth2 URLs and gcloud
     short names are supported. To allow full access to all Cloud APIs, use the
     `cloud-platform` scope. See a complete list of scopes [here](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes).
+    **Warning**: Terraform will stop the instance while updating this field. Make sure this
+    is acceptable for your instance before changing this value.
 
 The `scheduling` block supports:
 
@@ -230,13 +245,6 @@ The `scheduling` block supports:
 
 * `automatic_restart` - (Optional) Specifies if the instance should be
     restarted if it was terminated by Compute Engine (not a user).
-
----
-
-* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
-
-* `min_cpu_platform` - (Optional) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
-`Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
 
 The `guest_accelerator` block supports:
 


### PR DESCRIPTION
All three of these require the machine to be stopped before updating. I also added a warning in the docs for each of these fields.

Following the example of https://github.com/hashicorp/terraform/pull/11998 of just going ahead and doing the stopping.

Fixes #728.