### PR TITLE
Deprecate name_prefix

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -51,6 +51,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 					}
 					return
 				},
+				Deprecated: "Use the random provider instead",
 			},
 
 			"disk": &schema.Schema{

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -40,6 +40,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://cloud.google.com/compute/docs/reference/latest/instanceTemplates#resource
@@ -51,7 +52,8 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 					}
 					return
 				},
-				Deprecated: "Use the random provider instead",
+				Deprecated: "Use the random provider instead. See migration instructions at " +
+					"https://github.com/terraform-providers/terraform-provider-google/issues/1054#issuecomment-377390209",
 			},
 
 			"disk": &schema.Schema{

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -39,6 +39,7 @@ func resourceComputeSslCertificate() *schema.Resource {
 			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://cloud.google.com/compute/docs/reference/latest/sslCertificates#resource
@@ -50,7 +51,8 @@ func resourceComputeSslCertificate() *schema.Resource {
 					}
 					return
 				},
-				Deprecated: "Use the random provider instead",
+				Deprecated: "Use the random provider instead. See migration instructions at " +
+					"https://github.com/terraform-providers/terraform-provider-google/issues/1054#issuecomment-377390209",
 			},
 
 			"private_key": &schema.Schema{

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -50,6 +50,7 @@ func resourceComputeSslCertificate() *schema.Resource {
 					}
 					return
 				},
+				Deprecated: "Use the random provider instead",
 			},
 
 			"private_key": &schema.Schema{

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -117,10 +117,12 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"name_prefix": &schema.Schema{
-		Type:       schema.TypeString,
-		Optional:   true,
-		ForceNew:   true,
-		Deprecated: "Use the random provider instead",
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+		Deprecated: "Use the random provider instead. See migration instructions at " +
+			"https://github.com/terraform-providers/terraform-provider-google/issues/1054#issuecomment-377390209",
 	},
 
 	"node_config": schemaNodeConfig,

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -117,9 +117,10 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"name_prefix": &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		ForceNew: true,
+		Type:       schema.TypeString,
+		Optional:   true,
+		ForceNew:   true,
+		Deprecated: "Use the random provider instead",
 	},
 
 	"node_config": schemaNodeConfig,

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the instance template. If you leave
   this blank, Terraform will auto-generate a unique name.
 
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+* `name_prefix` - (Deprecated, Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.
 
 * `can_ip_forward` - (Optional) Whether to allow sending and receiving of

--- a/website/docs/r/compute_ssl_certificate.html.markdown
+++ b/website/docs/r/compute_ssl_certificate.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `name` - (Optional) A unique name for the SSL certificate. If you leave
   this blank, Terraform will auto-generate a unique name.
 
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+* `name_prefix` - (Deprecated, Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.
 
 * `description` - (Optional) An optional description of this resource.

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -69,7 +69,7 @@ resource "google_container_cluster" "primary" {
 * `name` - (Optional) The name of the node pool. If left blank, Terraform will
     auto-generate a unique name.
 
-* `name_prefix` - (Optional) Creates a unique name for the node pool beginning
+* `name_prefix` - (Deprecated, Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
 
 * `node_config` - (Optional) The node configuration of the pool. See


### PR DESCRIPTION
Since you can generate prefixes with the random provider, there's no need for `name_prefix` anywhere anymore and it only makes things more complicated.

Related: #780.