### PR TITLE
deprecate compute_image.custom_timeout

### DIFF
--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
@@ -17,7 +18,13 @@ func resourceComputeImage() *schema.Resource {
 		Update: resourceComputeImageUpdate,
 		Delete: resourceComputeImageDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceComputeImageImportState,
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(computeImageCreateTimeoutDefault * time.Minute),
+			Update: schema.DefaultTimeout(computeImageCreateTimeoutDefault * time.Minute),
+			Delete: schema.DefaultTimeout(computeImageCreateTimeoutDefault * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -87,9 +94,9 @@ func resourceComputeImage() *schema.Resource {
 			},
 
 			"create_timeout": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  computeImageCreateTimeoutDefault,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: "Use timeouts block instead. See https://www.terraform.io/docs/configuration/resources.html#timeouts.",
 			},
 
 			"labels": &schema.Schema{
@@ -155,6 +162,8 @@ func resourceComputeImageCreate(d *schema.ResourceData, meta interface{}) error 
 	var createTimeout int
 	if v, ok := d.GetOk("create_timeout"); ok {
 		createTimeout = v.(int)
+	} else {
+		createTimeout = int(d.Timeout(schema.TimeoutCreate).Minutes())
 	}
 
 	// Insert the image
@@ -237,7 +246,7 @@ func resourceComputeImageUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		d.SetPartial("labels")
 
-		err = computeOperationWaitTime(config.clientCompute, op, project, "Setting labels", 4)
+		err = computeOperationWaitTime(config.clientCompute, op, project, "Setting labels", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if err != nil {
 			return err
 		}
@@ -270,21 +279,11 @@ func resourceComputeImageDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting image: %s", err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Deleting image")
+	err = computeOperationWaitTime(config.clientCompute, op, project, "Deleting image", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
 	}
 
 	d.SetId("")
 	return nil
-}
-
-func resourceComputeImageImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	// `create_timeout` field is specific to this Terraform resource implementation. Thus, this value cannot be
-	// imported from the Google Cloud REST API.
-	// Setting to default value otherwise Terraform requires a ForceNew to change the resource to match the
-	// default `create_timeout`.
-	d.Set("create_timeout", computeImageCreateTimeoutDefault)
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/compute_image.html.markdown
+++ b/website/docs/r/compute_image.html.markdown
@@ -49,15 +49,25 @@ The following arguments are supported: (Note that one of either source_disk or
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 
-* `source_disk` - The URL of a disk that will be used as the source of the
+- - -
+
+* `description` - (Optional) The description of the image to be created
+
+* `family` - (Optional) The name of the image family to which this image belongs.
+
+* `labels` - (Optional) A set of key/value label pairs to assign to the image.
+
+* `source_disk` - (Optional) The URL of a disk that will be used as the source of the
     image. Changing this forces a new resource to be created.
 
-* `raw_disk` - The raw disk that will be used as the source of the image.
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `raw_disk` - (Optional) The raw disk that will be used as the source of the image.
     Changing this forces a new resource to be created. Structure is documented
     below.
 
-* `create_timeout` - Configurable timeout in minutes for creating images. Default is 4 minutes.
-    Changing this forces a new resource to be created.
+* `create_timeout` - (Deprecated) Configurable timeout in minutes for creating images. Default is 4 minutes.
 
 The `raw_disk` block supports:
 
@@ -70,16 +80,6 @@ The `raw_disk` block supports:
 * `container_type` - (Optional) The format used to encode and transmit the
     block device. TAR is the only supported type and is the default.
 
-- - -
-
-* `project` - (Optional) The project in which the resource belongs. If it
-    is not provided, the provider project is used.
-
-* `description` - (Optional) The description of the image to be created
-
-* `family` - (Optional) The name of the image family to which this image belongs.
-
-* `labels` - (Optional) A set of key/value label pairs to assign to the image.
 
 ## Attributes Reference
 
@@ -89,6 +89,15 @@ exported:
 * `self_link` - The URI of the created resource.
 
 * `label_fingerprint` - The fingerprint of the assigned labels.
+
+## Timeouts
+
+`google_compute_image` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - Default `4 minutes`
+- `update` - Default `4 minutes`
+- `delete` - Default `4 minutes`
 
 ## Import
 


### PR DESCRIPTION
No need for a separate attribute when we already have language support for custom timeouts.