### PR TITLE
Add example usage and better description of private_key attribute of …

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -25,6 +25,26 @@ resource "google_service_account_key" "acceptance" {
 }
 ```
 
+## Example Usage, save key in Kubernetes secret
+
+```hcl
+resource "google_service_account" "myaccount" {
+  account_id   = "myaccount"
+  display_name = "My Service Account"
+}
+resource "google_service_account_key" "mykey" {
+  service_account_id = "${google_service_account.myaccount.id}"
+}
+resource "kubernetes_secret" "google-application-credentials" {
+  metadata {
+    name = "google-application-credentials"
+  }
+  data {
+    credentials.json = "${base64decode(google_service_account_key.mykey.private_key)}"
+  }
+}
+```
+
 ## Create new Key Pair, encrypting the private key with a PGP Key
 
 ```hcl
@@ -71,8 +91,9 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `public_key` - The public key, base64 encoded
 
-* `private_key` - The private key, base64 encoded. This is only populated
-when creating a new key, and when no `pgp_key` is provided
+* `private_key` - The private key in JSON format, base64 encoded. This is what you normally get as a file when creating
+service account keys through the CLI or web console. This is only populated when creating a new key, and when no 
+`pgp_key` is provided.
 
 * `private_key_encrypted` – The private key material, base 64 encoded and
 encrypted with the given `pgp_key`. This is only populated when creating a new


### PR DESCRIPTION
…google_service_account_key.

This should fix my complaints about the documentation not being clear in #400 ;)
I've added a specific example of how to put a Service Account credentials file into a Kubernetes secret, which seems to be what a lot of people want to do, and I've added a sentence or two to the description of the private_key attribute, to make it clear that the content of this attribute is what you normally download when creating keys through the web console.