### PR TITLE
Remove master_auth from test that don't need it

### DIFF
--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -1283,11 +1283,6 @@ resource "google_container_cluster" "with_net_ref_by_name" {
 	zone = "us-central1-a"
 	initial_node_count = 1
 
-	master_auth {
-		username = "mr.yoda"
-		password = "adoy.rm"
-	}
-
 	network = "${google_compute_network.container_network.name}"
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 }


### PR DESCRIPTION
Fix failling test.

```sh
--- PASS: TestAccContainerCluster_network (796.77s)
```