### PR TITLE
Fix org/folder policy tests

### DIFF
--- a/google/resource_google_folder_organization_policy_test.go
+++ b/google/resource_google_folder_organization_policy_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -194,6 +195,8 @@ func testAccCheckGoogleFolderOrganizationListPolicyAllowedValues(n string, value
 			return err
 		}
 
+		sort.Strings(policy.ListPolicy.AllowedValues)
+		sort.Strings(values)
 		if !reflect.DeepEqual(policy.ListPolicy.AllowedValues, values) {
 			return fmt.Errorf("Expected the list policy to allow '%s', instead allowed '%s'", values, policy.ListPolicy.AllowedValues)
 		}
@@ -209,6 +212,8 @@ func testAccCheckGoogleFolderOrganizationListPolicyDeniedValues(n string, values
 			return err
 		}
 
+		sort.Strings(policy.ListPolicy.DeniedValues)
+		sort.Strings(values)
 		if !reflect.DeepEqual(policy.ListPolicy.DeniedValues, values) {
 			return fmt.Errorf("Expected the list policy to deny '%s', instead denied '%s'", values, policy.ListPolicy.DeniedValues)
 		}
@@ -303,14 +308,14 @@ resource "google_folder" "orgpolicy" {
 }
 
 resource "google_folder_organization_policy" "list" {
-	folder     = "${google_folder.orgpolicy.name}"
+  folder     = "${google_folder.orgpolicy.name}"
   constraint = "serviceuser.services"
 
   list_policy {
     deny {
       values = [
-        "maps-ios-backend.googleapis.com",
-        "placesios.googleapis.com",
+        "doubleclicksearch.googleapis.com",
+        "replicapoolupdater.googleapis.com",
       ]
     }
   }


### PR DESCRIPTION
* Change "deny" services to be ones that are allowed by the api (https://cloud.google.com/resource-manager/docs/organization-policy/understanding-constraints#available_constraints)
* Sort values returned so we're comparing correctly
* Run org tests serially so they don't conflict with each other (I don't think this will affect how they're run in CI but it's at least a start)

```
$ make testacc TEST=./google TESTARGS='-run=OrganizationPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=OrganizationPolicy -timeout 120m
=== RUN   TestAccGoogleFolderOrganizationPolicy_boolean
=== RUN   TestAccGoogleFolderOrganizationPolicy_list_allowAll
=== RUN   TestAccGoogleFolderOrganizationPolicy_list_allowSome
=== RUN   TestAccGoogleFolderOrganizationPolicy_list_denySome
=== RUN   TestAccGoogleFolderOrganizationPolicy_list_update
=== RUN   TestAccGoogleOrganizationPolicy_boolean
--- PASS: TestAccGoogleOrganizationPolicy_boolean (6.71s)
=== RUN   TestAccGoogleOrganizationPolicy_list_allowAll
--- PASS: TestAccGoogleOrganizationPolicy_list_allowAll (1.80s)
=== RUN   TestAccGoogleOrganizationPolicy_list_allowSome
--- PASS: TestAccGoogleOrganizationPolicy_list_allowSome (2.10s)
=== RUN   TestAccGoogleOrganizationPolicy_list_denySome
--- PASS: TestAccGoogleOrganizationPolicy_list_denySome (1.90s)
=== RUN   TestAccGoogleOrganizationPolicy_list_update
--- PASS: TestAccGoogleOrganizationPolicy_list_update (2.90s)
--- PASS: TestAccGoogleFolderOrganizationPolicy_list_allowSome (13.89s)
--- PASS: TestAccGoogleFolderOrganizationPolicy_list_denySome (14.69s)
--- PASS: TestAccGoogleFolderOrganizationPolicy_list_update (16.29s)
--- PASS: TestAccGoogleFolderOrganizationPolicy_list_allowAll (14.60s)
--- PASS: TestAccGoogleFolderOrganizationPolicy_boolean (32.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	47.710s
```