### PR TITLE
Mark subnetwork field in container cluster as computed

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -340,7 +340,9 @@ func resourceContainerCluster() *schema.Resource {
 			"subnetwork": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"endpoint": {

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -338,10 +338,10 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"subnetwork": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
 				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 


### PR DESCRIPTION
Fixes failing tests: `TestAccContainerCluster_withNodeConfig` and `TestAccContainerCluster_withNodeConfigScopeAlias`

If the subnetwork was not specified in the config, it would create a perpetual diff.

```sh
subnetwork: "default" => "" (forces new resource)
```