### PR TITLE
Fix TestAccContainerCluster_withIPAllocationPolicy test

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -379,6 +379,12 @@ func resourceContainerCluster() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"use_ip_aliases": {
+							Type: schema.TypeBool,
+							Optional: true,
+							Default: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -1095,9 +1101,10 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 
 func expandIPAllocationPolicy(configured interface{}) (*container.IPAllocationPolicy, error) {
 	ap := &container.IPAllocationPolicy{}
-	if len(configured.([]interface{})) > 0 {
-		if config, ok := configured.([]interface{})[0].(map[string]interface{}); ok {
-			ap.UseIpAliases = true
+	l := configured.([]interface{})
+	if len(l) > 0 {
+		if config, ok := l[0].(map[string]interface{}); ok {
+			ap.UseIpAliases = config["use_ip_aliases"].(bool)
 			if v, ok := config["cluster_secondary_range_name"]; ok {
 				ap.ClusterSecondaryRangeName = v.(string)
 			}
@@ -1222,6 +1229,7 @@ func flattenIPAllocationPolicy(c *container.IPAllocationPolicy) []map[string]int
 		{
 			"cluster_secondary_range_name":  c.ClusterSecondaryRangeName,
 			"services_secondary_range_name": c.ServicesSecondaryRangeName,
+			"use_ip_aliases": c.UseIpAliases,
 		},
 	}
 }

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -380,9 +380,9 @@ func resourceContainerCluster() *schema.Resource {
 							ForceNew: true,
 						},
 						"use_ip_aliases": {
-							Type: schema.TypeBool,
+							Type:     schema.TypeBool,
 							Optional: true,
-							Default: true,
+							Default:  true,
 							ForceNew: true,
 						},
 					},
@@ -1229,7 +1229,7 @@ func flattenIPAllocationPolicy(c *container.IPAllocationPolicy) []map[string]int
 		{
 			"cluster_secondary_range_name":  c.ClusterSecondaryRangeName,
 			"services_secondary_range_name": c.ServicesSecondaryRangeName,
-			"use_ip_aliases": c.UseIpAliases,
+			"use_ip_aliases":                c.UseIpAliases,
 		},
 	}
 }

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -379,12 +379,6 @@ func resourceContainerCluster() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
-						"use_ip_aliases": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-							ForceNew: true,
-						},
 					},
 				},
 			},
@@ -1104,7 +1098,7 @@ func expandIPAllocationPolicy(configured interface{}) (*container.IPAllocationPo
 	l := configured.([]interface{})
 	if len(l) > 0 {
 		if config, ok := l[0].(map[string]interface{}); ok {
-			ap.UseIpAliases = config["use_ip_aliases"].(bool)
+			ap.UseIpAliases = true
 			if v, ok := config["cluster_secondary_range_name"]; ok {
 				ap.ClusterSecondaryRangeName = v.(string)
 			}
@@ -1112,12 +1106,8 @@ func expandIPAllocationPolicy(configured interface{}) (*container.IPAllocationPo
 			if v, ok := config["services_secondary_range_name"]; ok {
 				ap.ServicesSecondaryRangeName = v.(string)
 			}
-
-			if ap.UseIpAliases &&
-				(ap.ClusterSecondaryRangeName == "" || ap.ServicesSecondaryRangeName == "") {
-
-				return nil, fmt.Errorf("clusters using IP aliases must specify secondary ranges.")
-			}
+		} else {
+			return nil, fmt.Errorf("clusters using IP aliases must specify secondary ranges.")
 		}
 	}
 
@@ -1229,7 +1219,6 @@ func flattenIPAllocationPolicy(c *container.IPAllocationPolicy) []map[string]int
 		{
 			"cluster_secondary_range_name":  c.ClusterSecondaryRangeName,
 			"services_secondary_range_name": c.ServicesSecondaryRangeName,
-			"use_ip_aliases":                c.UseIpAliases,
 		},
 	}
 }

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -685,6 +685,17 @@ func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
 				Config: testAccContainerCluster_withIPAllocationPolicy(
 					cluster,
 					map[string]string{
+						"pods":     "10.1.0.0/16",
+						"services": "10.2.0.0/20",
+					},
+					map[string]string{},
+				),
+				ExpectError: regexp.MustCompile("clusters using IP aliases must specify secondary ranges"),
+			},
+			{
+				Config: testAccContainerCluster_withIPAllocationPolicy(
+					cluster,
+					map[string]string{
 						"pods": "10.1.0.0/16",
 					},
 					map[string]string{
@@ -1575,6 +1586,7 @@ resource "google_container_cluster" "with_maintenance_window" {
 }
 
 func testAccContainerCluster_withIPAllocationPolicy(cluster string, ranges, policy map[string]string) string {
+
 	var secondaryRanges bytes.Buffer
 	for rangeName, cidr := range ranges {
 		secondaryRanges.WriteString(fmt.Sprintf(`

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -685,17 +685,6 @@ func TestAccContainerCluster_withIPAllocationPolicy(t *testing.T) {
 				Config: testAccContainerCluster_withIPAllocationPolicy(
 					cluster,
 					map[string]string{
-						"pods":     "10.1.0.0/16",
-						"services": "10.2.0.0/20",
-					},
-					map[string]string{},
-				),
-				ExpectError: regexp.MustCompile("clusters using IP aliases must specify secondary ranges"),
-			},
-			{
-				Config: testAccContainerCluster_withIPAllocationPolicy(
-					cluster,
-					map[string]string{
 						"pods": "10.1.0.0/16",
 					},
 					map[string]string{
@@ -1586,7 +1575,6 @@ resource "google_container_cluster" "with_maintenance_window" {
 }
 
 func testAccContainerCluster_withIPAllocationPolicy(cluster string, ranges, policy map[string]string) string {
-
 	var secondaryRanges bytes.Buffer
 	for rangeName, cidr := range ranges {
 		secondaryRanges.WriteString(fmt.Sprintf(`


### PR DESCRIPTION
Step 2 is failing because an empty `ip_allocation_policy` block doesn't fail.
It fails to cast as a `map[string]interface{}` but this does not return an error. The if throwing the error could not be reached.