### PR TITLE
Don't set metadata_startup_script in some cases.

### DIFF
--- a/google/metadata.go
+++ b/google/metadata.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -151,6 +152,9 @@ func resourceInstanceMetadata(d *schema.ResourceData) (*computeBeta.Metadata, er
 	m := &computeBeta.Metadata{}
 	mdMap := d.Get("metadata").(map[string]interface{})
 	if v, ok := d.GetOk("metadata_startup_script"); ok && v.(string) != "" {
+		if ss, ok := mdMap["startup-script"]; ok && ss != "" {
+			return nil, errors.New("Cannot provide both metadata_startup_script and metadata.startup-script.")
+		}
 		mdMap["startup-script"] = v
 	}
 	if len(mdMap) > 0 {

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -780,6 +780,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	md := flattenMetadataBeta(instance.Metadata)
 	existingMetadata := d.Get("metadata").(map[string]interface{})
 
+	// If the existing config specifies "metadata.startup-script" instead of "metadata_startup_script",
+	// we shouldn't move the remote metadata.startup-script to metadata_startup_script.  Otherwise,
+	// we should.
 	if ss, ok := existingMetadata["startup-script"]; ok && ss != "" {
 		d.Set("metadata_startup_script", md["startup-script"])
 		// Note that here we delete startup-script from our metadata list. This is to prevent storing the startup-script

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -783,7 +783,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	// If the existing config specifies "metadata.startup-script" instead of "metadata_startup_script",
 	// we shouldn't move the remote metadata.startup-script to metadata_startup_script.  Otherwise,
 	// we should.
-	if ss, ok := existingMetadata["startup-script"]; ok && ss != "" {
+	if ss, ok := existingMetadata["startup-script"]; !ok || ss == "" {
 		d.Set("metadata_startup_script", md["startup-script"])
 		// Note that here we delete startup-script from our metadata list. This is to prevent storing the startup-script
 		// as a value in the metadata since the config specifically tracks it under 'metadata_startup_script'

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -778,13 +778,14 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	md := flattenMetadataBeta(instance.Metadata)
-
-	d.Set("metadata_startup_script", md["startup-script"])
-	// Note that here we delete startup-script from our metadata list. This is to prevent storing the startup-script
-	// as a value in the metadata since the config specifically tracks it under 'metadata_startup_script'
-	delete(md, "startup-script")
-
 	existingMetadata := d.Get("metadata").(map[string]interface{})
+
+	if ss, ok := existingMetadata["startup-script"]; ok && ss != "" {
+		d.Set("metadata_startup_script", md["startup-script"])
+		// Note that here we delete startup-script from our metadata list. This is to prevent storing the startup-script
+		// as a value in the metadata since the config specifically tracks it under 'metadata_startup_script'
+		delete(md, "startup-script")
+	}
 
 	// Delete any keys not explicitly set in our config file
 	for k := range md {

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1478,7 +1478,9 @@ resource "google_compute_instance" "foobar" {
 
 	create_timeout = 5
 
-	metadata_startup_script = "echo Hello"
+	metadata {
+		startup-script = "echo Hello"
+	}
 
 	labels {
 		my_key       = "my_value"


### PR DESCRIPTION
If the state contains `metadata.startup-script`, the user likely wants to keep it in there instead of `metadata_startup_script` (which is `ForceNew`, where `metadata.startup-script` is not).  This isn't the standard case - `metadata.startup-script` creates heterogeneous fleets unless managed very carefully, which is why `metadata_startup_script` exists - but it's supported by the API and it's a valid state, so we want it to continue working.

After this PR:
* If you set `metadata_startup_script` and don't set `metadata.startup-script`, you will see no change.
* If you set `metadata.startup-script` and don't set `metadata_startup_script`, you will stop seeing permanent diffs, because `Read` will stop setting `metadata_startup_script`.
* If you set both, your behavior will be strange and you'll probably see permanent diffs - don't set both.
* If you do an import, you'll get `metadata_startup_script`.

If you're affected by something like #1079, this will make sure that you don't have problems going for anything created after this PR goes in, but for your existing instances you'll need to make sure that the `metadata.startup-script` has a non-empty value, probably using the `terraform state` functions.