### PR TITLE
Changes to handle autogeneration.

### DIFF
--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -38,6 +38,7 @@ func Convert(item, out interface{}) error {
 type TerraformResourceData interface {
 	HasChange(string) bool
 	GetOk(string) (interface{}, bool)
+	Set(string, interface{}) error
 }
 
 // Compare the fields set in schema against a list of features and their versions to determine

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -39,6 +39,8 @@ type TerraformResourceData interface {
 	HasChange(string) bool
 	GetOk(string) (interface{}, bool)
 	Set(string, interface{}) error
+	SetId(string)
+	Id() string
 }
 
 // Compare the fields set in schema against a list of features and their versions to determine

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -228,3 +228,8 @@ func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
 
 	return nil, false
 }
+
+func (d *ResourceDataMock) Set(key string, value interface{}) error {
+	d.FieldsInSchema[key] = value
+	return nil
+}

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -206,7 +206,7 @@ func TestComputeApiVersion(t *testing.T) {
 type ResourceDataMock struct {
 	FieldsInSchema      map[string]interface{}
 	FieldsWithHasChange []string
-	id string
+	id                  string
 }
 
 func (d *ResourceDataMock) HasChange(key string) bool {

--- a/google/api_versions_test.go
+++ b/google/api_versions_test.go
@@ -206,6 +206,7 @@ func TestComputeApiVersion(t *testing.T) {
 type ResourceDataMock struct {
 	FieldsInSchema      map[string]interface{}
 	FieldsWithHasChange []string
+	id string
 }
 
 func (d *ResourceDataMock) HasChange(key string) bool {
@@ -232,4 +233,12 @@ func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
 func (d *ResourceDataMock) Set(key string, value interface{}) error {
 	d.FieldsInSchema[key] = value
 	return nil
+}
+
+func (d *ResourceDataMock) SetId(v string) {
+	d.id = v
+}
+
+func (d *ResourceDataMock) Id() string {
+	return d.id
 }

--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -318,7 +318,7 @@ func parseRegionalFieldValue(resourceType, fieldValue, projectSchemaField, regio
 // - region extracted from the provider-level zone
 func getRegionFromSchema(regionSchemaField, zoneSchemaField string, d TerraformResourceData, config *Config) (string, error) {
 	if v, ok := d.GetOk(regionSchemaField); ok && regionSchemaField != "" {
-		return v.(string), nil
+		return GetResourceNameFromSelfLink(v.(string)), nil
 	}
 	if v, ok := d.GetOk(zoneSchemaField); ok && zoneSchemaField != "" {
 		return getRegionFromZone(v.(string)), nil

--- a/google/utils.go
+++ b/google/utils.go
@@ -45,7 +45,7 @@ func getZone(d TerraformResourceData, config *Config) (string, error) {
 		}
 		return "", fmt.Errorf("Cannot determine zone: set in this resource, or set provider-level zone.")
 	}
-	return res.(string), nil
+	return GetResourceNameFromSelfLink(res.(string)), nil
 }
 
 func getRegionFromInstanceState(is *terraform.InstanceState, config *Config) (string, error) {


### PR DESCRIPTION
* Extend ResourceDataMock and TerraformResourceData to also support `Set(...)`, `Id()` and `SetId()` methods.
* When calling `getRegion` or `getZone`, we should only return the region or zone name when the state value contains a self_link (i.e. API returns a self_link for subnetwork region field)