### PR TITLE
Support `distributionPolicy` when creating regional instance group managers.

### DIFF
--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -9,11 +10,15 @@ import (
 	"fmt"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
+	"strings"
 	"time"
 )
 
 var RegionInstanceGroupManagerBaseApiVersion = v1
-var RegionInstanceGroupManagerVersionedFeatures = []Feature{Feature{Version: v0beta, Item: "auto_healing_policies"}}
+var RegionInstanceGroupManagerVersionedFeatures = []Feature{
+	Feature{Version: v0beta, Item: "auto_healing_policies"},
+	Feature{Version: v0beta, Item: "distribution_policy"},
+}
 
 func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 	return &schema.Resource{
@@ -109,7 +114,6 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				},
 				Set: selfLinkRelativePathHash,
 			},
-
 			"target_size": &schema.Schema{
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -145,6 +149,18 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
+
+			"distribution_policy": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Set:      hashZoneFromSelfLinkOrResourceName,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: compareSelfLinkOrResourceName,
+				},
+			},
 		},
 	}
 }
@@ -167,6 +183,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
 		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
+		DistributionPolicy:  expandDistributionPolicy(d.Get("distribution_policy").(*schema.Set)),
 		// Force send TargetSize to allow size of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -212,6 +229,7 @@ func getManager(d *schema.ResourceData, meta interface{}) (*computeBeta.Instance
 
 	region := d.Get("region").(string)
 	manager := &computeBeta.InstanceGroupManager{}
+
 	switch computeApiVersion {
 	case v1:
 		v1Manager := &compute.InstanceGroupManager{}
@@ -227,6 +245,7 @@ func getManager(d *schema.ResourceData, meta interface{}) (*computeBeta.Instance
 
 	if err != nil {
 		handleNotFoundError(err, d, fmt.Sprintf("Region Instance Manager %q", d.Get("name").(string)))
+		return nil, err
 	}
 	return manager, nil
 }
@@ -270,6 +289,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", manager.InstanceGroup)
 	d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies))
+	d.Set("distribution_policy", flattenDistributionPolicy(manager.DistributionPolicy))
 	d.Set("self_link", ConvertSelfLinkToV1(manager.SelfLink))
 
 	if d.Get("wait_for_instances").(bool) {
@@ -508,4 +528,42 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 
 	d.SetId("")
 	return nil
+}
+
+func expandDistributionPolicy(configured *schema.Set) *computeBeta.DistributionPolicy {
+	if configured.Len() == 0 {
+		return nil
+	}
+
+	distributionPolicyZoneConfigs := make([]*computeBeta.DistributionPolicyZoneConfiguration, 0, configured.Len())
+	for _, raw := range configured.List() {
+		data := raw.(string)
+		distributionPolicyZoneConfig := computeBeta.DistributionPolicyZoneConfiguration{
+			Zone: "zones/" + data,
+		}
+
+		distributionPolicyZoneConfigs = append(distributionPolicyZoneConfigs, &distributionPolicyZoneConfig)
+	}
+	return &computeBeta.DistributionPolicy{Zones: distributionPolicyZoneConfigs}
+}
+
+func flattenDistributionPolicy(distributionPolicy *computeBeta.DistributionPolicy) *schema.Set {
+	zones := make([]interface{}, 0)
+
+	if distributionPolicy != nil {
+		for _, zone := range distributionPolicy.Zones {
+			zones = append(zones, zone.Zone)
+		}
+	}
+
+	return schema.NewSet(schema.HashSchema(&schema.Schema{
+		Type: schema.TypeString,
+	}), zones)
+}
+
+func hashZoneFromSelfLinkOrResourceName(value interface{}) int {
+	parts := strings.Split(value.(string), "/")
+	resource := parts[len(parts)-1]
+
+	return hashcode.String(resource)
 }

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -871,15 +871,6 @@ resource "google_compute_http_health_check" "zero" {
 }
 
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
-	policies := make([]string, 0, len(zones))
-	for _, zone := range zones {
-		policy := fmt.Sprintf(`
-			{
-					zone = "%s"
-			}`, zone)
-		policies = append(policies, policy)
-	}
-
 	return fmt.Sprintf(`
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
@@ -906,9 +897,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 	base_instance_name = "igm-basic"
 	region = "us-central1"
 	target_size = 2
-	distribution_policy = [
-%s
-	]
+	distribution_policy_zones = ["%s"]
 }
-	`, template, igm, strings.Join(policies, ",\n"))
+	`, template, igm, strings.Join(zones, "\",\""))
 }

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -871,6 +871,15 @@ resource "google_compute_http_health_check" "zero" {
 }
 
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
+	policies := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		policy := fmt.Sprintf(`
+			{
+					zone = "%s"
+			}`, zone)
+		policies = append(policies, policy)
+	}
+
 	return fmt.Sprintf(`
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
@@ -897,7 +906,9 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 	base_instance_name = "igm-basic"
 	region = "us-central1"
 	target_size = 2
-	distribution_policy = ["%s"]
+	distribution_policy = [
+%s
+	]
 }
-	`, template, igm, strings.Join(zones, "\",\""))
+	`, template, igm, strings.Join(policies, ",\n"))
 }

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -204,6 +204,32 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	})
 }
 
+func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
+	t.Parallel()
+
+	var manager computeBeta.InstanceGroupManager
+
+	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	zones := []string{"us-central1-a", "us-central1-b"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRegionInstanceGroupManagerBetaExists(
+						"google_compute_region_instance_group_manager.igm-basic", &manager),
+					testAccCheckRegionInstanceGroupManagerDistributionPolicy("google_compute_region_instance_group_manager.igm-basic", zones),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRegionInstanceGroupManagerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -397,6 +423,51 @@ func testAccCheckRegionInstanceGroupManagerAutoHealingPolicies(n, hck string, in
 		if autoHealingPolicy.InitialDelaySec != initialDelaySec {
 			return fmt.Errorf("Expected auto healing policy inital delay to be %d, got %d", initialDelaySec, autoHealingPolicy.InitialDelaySec)
 		}
+		return nil
+	}
+}
+
+func testAccCheckRegionInstanceGroupManagerDistributionPolicy(n string, zones []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		manager, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
+			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if manager.DistributionPolicy == nil {
+			return fmt.Errorf("Expected distribution policy to exist")
+		}
+
+		zoneConfigs := manager.DistributionPolicy.Zones
+		if len(zoneConfigs) != len(zones) {
+			return fmt.Errorf("Expected number of zones in distribution policy to match; had %d, expected %d", len(zoneConfigs), len(zones))
+		}
+
+		sort.Strings(zones)
+		sortedExisting := make([]string, 0)
+		for _, zone := range zoneConfigs {
+			sortedExisting = append(sortedExisting, zone.Zone)
+		}
+		sort.Strings(sortedExisting)
+
+		for i := 0; i < len(zones); i++ {
+			if !strings.HasSuffix(sortedExisting[i], zones[i]) {
+				return fmt.Errorf("found mismatched zone configuration: expected entry #%d as '%s', got %s", i, zones[i], sortedExisting[i])
+			}
+		}
+
 		return nil
 	}
 }
@@ -797,4 +868,36 @@ resource "google_compute_http_health_check" "zero" {
 	timeout_sec        = 1
 }
 	`, template, target, igm, hck)
+}
+
+func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance_template" "igm-basic" {
+	name = "%s"
+	machine_type = "n1-standard-1"
+	can_ip_forward = false
+	tags = ["foo", "bar"]
+	disk {
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		auto_delete = true
+		boot = true
+	}
+	network_interface {
+		network = "default"
+	}
+	metadata {
+		foo = "bar"
+	}
+}
+
+resource "google_compute_region_instance_group_manager" "igm-basic" {
+	description = "Terraform test instance group manager"
+	name = "%s"
+	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	base_instance_name = "igm-basic"
+	region = "us-central1"
+	target_size = 2
+	distribution_policy = ["%s"]
+}
+	`, template, igm, strings.Join(zones, "\",\""))
 }

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -34,9 +34,10 @@ resource "google_compute_health_check" "autohealing" {
 resource "google_compute_region_instance_group_manager" "appserver" {
   name = "appserver-igm"
 
-  base_instance_name = "app"
-  instance_template  = "${google_compute_instance_template.appserver.self_link}"
-  region             = "us-central1"
+  base_instance_name  = "app"
+  instance_template   = "${google_compute_instance_template.appserver.self_link}"
+  region              = "us-central1"
+  distribution_policy = ["us-central1-a", "us-central1-f"]
 
   target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2
@@ -98,6 +99,10 @@ The following arguments are supported:
 
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
+
+* `distribution_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The distribution policy for this managed instance
+group. You can specify one or more values. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups#selectingzones).
+
 
 The `named_port` block supports: (Include a `named_port` block for each named-port required).
 

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -37,7 +37,7 @@ resource "google_compute_region_instance_group_manager" "appserver" {
   base_instance_name         = "app"
   instance_template          = "${google_compute_instance_template.appserver.self_link}"
   region                     = "us-central1"
-  distribution_policy_zoneos = ["us-central1-a", "us-central1-f"]
+  distribution_policy_zones  = ["us-central1-a", "us-central1-f"]
 
   target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -34,10 +34,10 @@ resource "google_compute_health_check" "autohealing" {
 resource "google_compute_region_instance_group_manager" "appserver" {
   name = "appserver-igm"
 
-  base_instance_name  = "app"
-  instance_template   = "${google_compute_instance_template.appserver.self_link}"
-  region              = "us-central1"
-  distribution_policy = ["us-central1-a", "us-central1-f"]
+  base_instance_name         = "app"
+  instance_template          = "${google_compute_instance_template.appserver.self_link}"
+  region                     = "us-central1"
+  distribution_policy_zoneos = ["us-central1-a", "us-central1-f"]
 
   target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
 
-* `distribution_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The distribution policy for this managed instance
+* `distribution_policy_zones` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The distribution policy for this managed instance
 group. You can specify one or more values. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups#selectingzones).
 
 


### PR DESCRIPTION
This addresses #549.

This one is sort of a doozy because it's both an un-updatable attribute and beta feature. The format required for the zones to be specified in was also a little tricky. Definitely looking for thoughts on how my approach could be better. I chose what I thought was the best user experience -- users specifying the "naked" zone -- and augmenting it behind-the-scenes.

```
TF_ACC=1 go test ./google -v -run=TestAccRegionInstanceGroupManager -timeout 120m
=== RUN   TestAccRegionInstanceGroupManager_basic
=== RUN   TestAccRegionInstanceGroupManager_targetSizeZero
=== RUN   TestAccRegionInstanceGroupManager_update
=== RUN   TestAccRegionInstanceGroupManager_updateLifecycle
=== RUN   TestAccRegionInstanceGroupManager_separateRegions
=== RUN   TestAccRegionInstanceGroupManager_autoHealingPolicies
=== RUN   TestAccRegionInstanceGroupManager_distributionPolicy
--- PASS: TestAccRegionInstanceGroupManager_targetSizeZero (49.02s)
--- PASS: TestAccRegionInstanceGroupManager_updateLifecycle (218.13s)
--- PASS: TestAccRegionInstanceGroupManager_update (241.82s)
--- PASS: TestAccRegionInstanceGroupManager_distributionPolicy (244.57s)
--- PASS: TestAccRegionInstanceGroupManager_autoHealingPolicies (244.72s)
--- PASS: TestAccRegionInstanceGroupManager_separateRegions (255.48s)
--- PASS: TestAccRegionInstanceGroupManager_basic (306.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	306.793s
```