### PR TITLE
Move method from resource to datasource file

### DIFF
--- a/google/data_source_google_compute_subnetwork.go
+++ b/google/data_source_google_compute_subnetwork.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 
+	"google.golang.org/api/compute/v1"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -104,4 +105,21 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	subnetwork.Region = region
 	d.SetId(createSubnetID(subnetwork))
 	return nil
+}
+
+func flattenSecondaryRanges(secondaryRanges []*compute.SubnetworkSecondaryRange) []map[string]interface{} {
+	secondaryRangesSchema := make([]map[string]interface{}, 0, len(secondaryRanges))
+	for _, secondaryRange := range secondaryRanges {
+		data := map[string]interface{}{
+			"range_name":    secondaryRange.RangeName,
+			"ip_cidr_range": secondaryRange.IpCidrRange,
+		}
+
+		secondaryRangesSchema = append(secondaryRangesSchema, data)
+	}
+	return secondaryRangesSchema
+}
+
+func createSubnetID(s *compute.Subnetwork) string {
+	return fmt.Sprintf("%s/%s", s.Region, s.Name)
 }

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -378,10 +378,6 @@ func resourceComputeSubnetworkImportState(d *schema.ResourceData, meta interface
 	return []*schema.ResourceData{d}, nil
 }
 
-func createSubnetID(s *compute.Subnetwork) string {
-	return fmt.Sprintf("%s/%s", s.Region, s.Name)
-}
-
 func splitSubnetID(id string) (region string, name string) {
 	parts := strings.Split(id, "/")
 	region = parts[0]
@@ -415,19 +411,6 @@ func expandSecondaryRangesV0Beta(configured []interface{}) []*computeBeta.Subnet
 		secondaryRanges = append(secondaryRanges, &secondaryRange)
 	}
 	return secondaryRanges
-}
-
-func flattenSecondaryRanges(secondaryRanges []*compute.SubnetworkSecondaryRange) []map[string]interface{} {
-	secondaryRangesSchema := make([]map[string]interface{}, 0, len(secondaryRanges))
-	for _, secondaryRange := range secondaryRanges {
-		data := map[string]interface{}{
-			"range_name":    secondaryRange.RangeName,
-			"ip_cidr_range": secondaryRange.IpCidrRange,
-		}
-
-		secondaryRangesSchema = append(secondaryRangesSchema, data)
-	}
-	return secondaryRangesSchema
 }
 
 func flattenSecondaryRangesV0Beta(secondaryRanges []*computeBeta.SubnetworkSecondaryRange) []map[string]interface{} {


### PR DESCRIPTION
This way, when we autogenerate the subnetwork resource,  we don't break the subnetwork datasource.

Subnetwork is the only datasource using a flatten method defined in a resource file.