### PR TITLE
add json omitted fields back when converting

### DIFF
--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-
-	// "github.com/davecgh/go-spew/spew"
-	"github.com/fatih/structs"
-	"github.com/mitchellh/mapstructure"
 )
 
 type ApiVersion uint8
@@ -42,15 +38,7 @@ func Convert(item, out interface{}) error {
 	// 	return err
 	// }
 
-	s := structs.Map(item)
-	// fmt.Printf("structs.Map: %#v\n", s)
-	// spew.Dump(s)
-	err := mapstructure.Decode(structs.Map(item), out)
-	if err != nil {
-		return err
-	}
-
-	// setOmittedFields(item, out)
+	setOmittedFields(item, out)
 
 	return nil
 }

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -28,15 +29,15 @@ var OrderedContainerApiVersions = []ApiVersion{
 // between multiple API versions, as they are strict supersets of one another.
 // item and out are pointers to structs
 func Convert(item, out interface{}) error {
-	// bytes, err := json.Marshal(item)
-	// if err != nil {
-	// 	return err
-	// }
+	bytes, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
 
-	// err = json.Unmarshal(bytes, out)
-	// if err != nil {
-	// 	return err
-	// }
+	err = json.Unmarshal(bytes, out)
+	if err != nil {
+		return err
+	}
 
 	setOmittedFields(item, out)
 
@@ -66,9 +67,9 @@ func setOmittedFields(item, out interface{}) {
 
 		// If the field contains a 'json:"="' tag, then it was omitted from the Marshal/Unmarshal
 		// call and needs to be added back in.
-		// if fieldInfo.Tag.Get("json") == "-" {
-		oField.Set(iField)
-		// }
+		if fieldInfo.Tag.Get("json") == "-" {
+			oField.Set(iField)
+		}
 
 		// If this field is a struct, *struct, []struct, or []*struct, recurse.
 		if iField.Kind() == reflect.Struct {

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -3,6 +3,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -26,7 +27,7 @@ var OrderedContainerApiVersions = []ApiVersion{
 
 // Convert between two types by converting to/from JSON. Intended to switch
 // between multiple API versions, as they are strict supersets of one another.
-// Convert loses information about ForceSendFields and NullFields.
+// item and out are pointers to structs
 func Convert(item, out interface{}) error {
 	bytes, err := json.Marshal(item)
 	if err != nil {
@@ -38,7 +39,57 @@ func Convert(item, out interface{}) error {
 		return err
 	}
 
+	setOmittedFields(item, out)
+
 	return nil
+}
+
+func setOmittedFields(item, out interface{}) {
+	// Both inputs must be pointers, see https://blog.golang.org/laws-of-reflection:
+	// "To modify a reflection object, the value must be settable."
+	iVal := reflect.ValueOf(item).Elem()
+	oVal := reflect.ValueOf(out).Elem()
+
+	// Loop through all the fields of the struct to look for omitted fields and nested fields
+	for i := 0; i < iVal.NumField(); i++ {
+		iField := iVal.Field(i)
+		if isEmptyValue(iField) {
+			continue
+		}
+
+		fieldInfo := iVal.Type().Field(i)
+		oField := oVal.FieldByName(fieldInfo.Name)
+
+		// Only look at fields that exist in the output struct
+		if !oField.IsValid() {
+			continue
+		}
+
+		// If the field contains a 'json:"="' tag, then it was omitted from the Marshal/Unmarshal
+		// call and needs to be added back in.
+		if fieldInfo.Tag.Get("json") == "-" {
+			oField.Set(iField)
+		}
+
+		// If this field is a struct, *struct, []struct, or []*struct, recurse.
+		if iField.Kind() == reflect.Struct {
+			setOmittedFields(iField.Addr().Interface(), oField.Addr().Interface())
+		}
+		if iField.Kind() == reflect.Ptr && iField.Type().Elem().Kind() == reflect.Struct {
+			setOmittedFields(iField.Interface(), oField.Interface())
+		}
+		if iField.Kind() == reflect.Slice && iField.Type().Elem().Kind() == reflect.Struct {
+			for j := 0; j < iField.Len(); j++ {
+				setOmittedFields(iField.Index(j).Addr().Interface(), oField.Index(j).Addr().Interface())
+			}
+		}
+		if iField.Kind() == reflect.Slice && iField.Type().Elem().Kind() == reflect.Ptr &&
+			iField.Type().Elem().Elem().Kind() == reflect.Struct {
+			for j := 0; j < iField.Len(); j++ {
+				setOmittedFields(iField.Index(j).Interface(), oField.Index(j).Interface())
+			}
+		}
+	}
 }
 
 type TerraformResourceData interface {

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	// "github.com/davecgh/go-spew/spew"
+	"github.com/fatih/structs"
+	"github.com/mitchellh/mapstructure"
 )
 
 type ApiVersion uint8
@@ -38,7 +42,15 @@ func Convert(item, out interface{}) error {
 	// 	return err
 	// }
 
-	setOmittedFields(item, out)
+	s := structs.Map(item)
+	// fmt.Printf("structs.Map: %#v\n", s)
+	// spew.Dump(s)
+	err := mapstructure.Decode(structs.Map(item), out)
+	if err != nil {
+		return err
+	}
+
+	// setOmittedFields(item, out)
 
 	return nil
 }

--- a/google/api_versions.go
+++ b/google/api_versions.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -29,15 +28,15 @@ var OrderedContainerApiVersions = []ApiVersion{
 // between multiple API versions, as they are strict supersets of one another.
 // item and out are pointers to structs
 func Convert(item, out interface{}) error {
-	bytes, err := json.Marshal(item)
-	if err != nil {
-		return err
-	}
+	// bytes, err := json.Marshal(item)
+	// if err != nil {
+	// 	return err
+	// }
 
-	err = json.Unmarshal(bytes, out)
-	if err != nil {
-		return err
-	}
+	// err = json.Unmarshal(bytes, out)
+	// if err != nil {
+	// 	return err
+	// }
 
 	setOmittedFields(item, out)
 
@@ -67,9 +66,9 @@ func setOmittedFields(item, out interface{}) {
 
 		// If the field contains a 'json:"="' tag, then it was omitted from the Marshal/Unmarshal
 		// call and needs to be added back in.
-		if fieldInfo.Tag.Get("json") == "-" {
-			oField.Set(iField)
-		}
+		// if fieldInfo.Tag.Get("json") == "-" {
+		oField.Set(iField)
+		// }
 
 		// If this field is a struct, *struct, []struct, or []*struct, recurse.
 		if iField.Kind() == reflect.Struct {


### PR DESCRIPTION
Currently when converting between two structs we lose `ForceSendFields` and `NullFields` because they contain the tag `json:"-"`, which cause `json.Marshal` and `json.Unmarshal` to ignore those fields.

Currently we handle this by adding back those fields immediately after we convert the object. The problems with this are twofold:
1. We have to remember to do so for each resource that gets converted this way
2. If the resource contains nested fields, we have to add the omitted fields back for each nested struct at the time we do the conversion, which means maintaining that list and remembering to update it if we add more fields to the schema

This change recursively checks the input struct for omitted fields and sets the output struct to have those values.

Hypothetically if we got rid of the check for the "-" tag from this change then it would do the full conversion without having to call the json functions. For now I'm very slightly leaning against that since (presumably) the json functions do some sort of error checking that this doesn't do, but I could be convinced.