### PR TITLE
s/TestAccGoogle/TestAcc/

### DIFF
--- a/google/data_source_google_compute_zones_test.go
+++ b/google/data_source_google_compute_zones_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleComputeZones_basic(t *testing.T) {
+func TestAccComputeZones_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{

--- a/google/data_source_google_container_cluster_test.go
+++ b/google/data_source_google_container_cluster_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleContainerClusterDatasource_basic(t *testing.T) {
+func TestAccContainerClusterDatasource_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{

--- a/google/data_source_google_container_engine_versions_test.go
+++ b/google/data_source_google_container_engine_versions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleContainerEngineVersions_basic(t *testing.T) {
+func TestAccContainerEngineVersions_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"testing"
 
+	"log"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudkms/v1"
-	"log"
 )
 
-func TestAccGoogleKmsSecret_basic(t *testing.T) {
+func TestAccKmsSecret_basic(t *testing.T) {
 	t.Parallel()
 
 	projectOrg := getTestOrgFromEnv(t)

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -3,9 +3,8 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"testing"
-
 	"log"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/google/data_source_storage_object_signed_url_test.go
+++ b/google/data_source_storage_object_signed_url_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"

--- a/google/data_source_storage_object_signed_url_test.go
+++ b/google/data_source_storage_object_signed_url_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -109,7 +108,7 @@ func TestAccStorageSignedUrl_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testGoogleSignedUrlConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleSignedUrlExists("data.google_storage_object_signed_url.blerg"),
+					testAccSignedUrlExists("data.google_storage_object_signed_url.blerg"),
 				),
 			},
 		},
@@ -133,17 +132,17 @@ func TestAccStorageSignedUrl_accTest(t *testing.T) {
 			resource.TestStep{
 				Config: testAccTestGoogleStorageObjectSignedURL(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleSignedUrlRetrieval("data.google_storage_object_signed_url.story_url", nil),
-					testAccGoogleSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_headers", headers),
-					testAccGoogleSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_content_type", nil),
-					testAccGoogleSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_md5", nil),
+					testAccSignedUrlRetrieval("data.google_storage_object_signed_url.story_url", nil),
+					testAccSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_headers", headers),
+					testAccSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_content_type", nil),
+					testAccSignedUrlRetrieval("data.google_storage_object_signed_url.story_url_w_md5", nil),
 				),
 			},
 		},
 	})
 }
 
-func testAccGoogleSignedUrlExists(n string) resource.TestCheckFunc {
+func testAccSignedUrlExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		r := s.RootModule().Resources[n]
@@ -157,7 +156,7 @@ func testAccGoogleSignedUrlExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccGoogleSignedUrlRetrieval(n string, headers map[string]string) resource.TestCheckFunc {
+func testAccSignedUrlRetrieval(n string, headers map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r := s.RootModule().Resources[n]
 		if r == nil {

--- a/google/import_container_node_pool_test.go
+++ b/google/import_container_node_pool_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleContainerNodePool_import(t *testing.T) {
+func TestAccContainerNodePool_import(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_container_node_pool.np"

--- a/google/import_google_kms_crypto_key_iam_test.go
+++ b/google/import_google_kms_crypto_key_iam_test.go
@@ -29,7 +29,7 @@ func TestAccKmsCryptoKeyIamMember_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
+				Config: testAccKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
 			},
 
 			resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccKmsCryptoKeyIamBinding_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
+				Config: testAccKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
 			},
 
 			resource.TestStep{

--- a/google/import_google_kms_key_ring_iam_test.go
+++ b/google/import_google_kms_key_ring_iam_test.go
@@ -28,7 +28,7 @@ func TestAccKmsKeyRingIamMember_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 			},
 
 			resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccKmsKeyRingIamPolicy_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 			},
 
 			resource.TestStep{
@@ -91,7 +91,7 @@ func TestAccKmsKeyRingIamBinding_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 			},
 
 			resource.TestStep{

--- a/google/import_google_organization_iam_test.go
+++ b/google/import_google_organization_iam_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleOrganizationIamMember_importBasic(t *testing.T) {
+func TestAccOrganizationIamMember_importBasic(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -20,7 +20,7 @@ func TestAccGoogleOrganizationIamMember_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleOrganizationIamMember_basic(account, orgId),
+				Config: testAccOrganizationIamMember_basic(account, orgId),
 			},
 
 			resource.TestStep{
@@ -32,7 +32,7 @@ func TestAccGoogleOrganizationIamMember_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleOrganizationIamBinding_importBasic(t *testing.T) {
+func TestAccOrganizationIamBinding_importBasic(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -44,7 +44,7 @@ func TestAccGoogleOrganizationIamBinding_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleOrganizationIamBinding_basic(account, roleId, orgId),
+				Config: testAccOrganizationIamBinding_basic(account, roleId, orgId),
 			},
 
 			resource.TestStep{

--- a/google/import_google_project_iam_custom_role_test.go
+++ b/google/import_google_project_iam_custom_role_test.go
@@ -1,12 +1,13 @@
 package google
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"testing"
 )
 
-func TestAccGoogleProjectIamCustomRole_import(t *testing.T) {
+func TestAccProjectIamCustomRole_import(t *testing.T) {
 	t.Parallel()
 
 	roleId := "tfIamRole" + acctest.RandString(10)

--- a/google/import_google_project_iam_test.go
+++ b/google/import_google_project_iam_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleProjectIamMember_importBasic(t *testing.T) {
+func TestAccProjectIamMember_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_project_iam_member.acceptance"
@@ -20,7 +20,7 @@ func TestAccGoogleProjectIamMember_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateMemberBasic(pid, "Acceptance", org),
+				Config: testAccProjectAssociateMemberBasic(pid, "Acceptance", org),
 			},
 
 			resource.TestStep{
@@ -32,7 +32,7 @@ func TestAccGoogleProjectIamMember_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleProjectIamBinding_importBasic(t *testing.T) {
+func TestAccProjectIamBinding_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_project_iam_binding.acceptance"
@@ -44,7 +44,7 @@ func TestAccGoogleProjectIamBinding_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateBindingBasic(pid, "Acceptance", org),
+				Config: testAccProjectAssociateBindingBasic(pid, "Acceptance", org),
 			},
 
 			resource.TestStep{

--- a/google/import_google_project_services_test.go
+++ b/google/import_google_project_services_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleProjectServices_importBasic(t *testing.T) {
+func TestAccProjectServices_importBasic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -15,7 +15,7 @@ func TestAccGoogleProjectServices_importBasic(t *testing.T) {
 	projectId := "terraform-" + acctest.RandString(10)
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com", "servicemanagement.googleapis.com"}
 
-	conf := testAccGoogleProjectAssociateServicesBasic(services, projectId, pname, org)
+	conf := testAccProjectAssociateServicesBasic(services, projectId, pname, org)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/google/import_google_service_account_test.go
+++ b/google/import_google_service_account_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleServiceAccount_importBasic(t *testing.T) {
+func TestAccServiceAccount_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -16,7 +16,7 @@ func TestAccGoogleServiceAccount_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleServiceAccount_import("terraform-" + acctest.RandString(10)),
+				Config: testAccServiceAccount_import("terraform-" + acctest.RandString(10)),
 			},
 
 			resource.TestStep{
@@ -28,7 +28,7 @@ func TestAccGoogleServiceAccount_importBasic(t *testing.T) {
 	})
 }
 
-func testAccGoogleServiceAccount_import(saName string) string {
+func testAccServiceAccount_import(saName string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
     account_id = "%s"
@@ -36,7 +36,7 @@ resource "google_service_account" "acceptance" {
 }`, saName, saName)
 }
 
-func TestAccGoogleServiceAccount_importWithProject(t *testing.T) {
+func TestAccServiceAccount_importWithProject(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -44,7 +44,7 @@ func TestAccGoogleServiceAccount_importWithProject(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleServiceAccount_importWithProject(getTestProjectFromEnv(), "terraform-"+acctest.RandString(10)),
+				Config: testAccServiceAccount_importWithProject(getTestProjectFromEnv(), "terraform-"+acctest.RandString(10)),
 			},
 
 			resource.TestStep{
@@ -56,7 +56,7 @@ func TestAccGoogleServiceAccount_importWithProject(t *testing.T) {
 	})
 }
 
-func testAccGoogleServiceAccount_importWithProject(project, saName string) string {
+func testAccServiceAccount_importWithProject(project, saName string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
     project = "%s"

--- a/google/import_kms_crypto_key_test.go
+++ b/google/import_kms_crypto_key_test.go
@@ -1,9 +1,8 @@
 package google
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/google/import_kms_crypto_key_test.go
+++ b/google/import_kms_crypto_key_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleKmsCryptoKey_importBasic(t *testing.T) {
+func TestAccKmsCryptoKey_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_kms_crypto_key.crypto_key"

--- a/google/import_kms_key_ring_test.go
+++ b/google/import_kms_key_ring_test.go
@@ -1,9 +1,8 @@
 package google
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/google/import_kms_key_ring_test.go
+++ b/google/import_kms_key_ring_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleKmsKeyRing_importBasic(t *testing.T) {
+func TestAccKmsKeyRing_importBasic(t *testing.T) {
 	resourceName := "google_kms_key_ring.key_ring"
 
 	projectId := "terraform-" + acctest.RandString(10)

--- a/google/import_sql_database_instance_test.go
+++ b/google/import_sql_database_instance_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Test importing a first generation database
-func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
+func TestAccSqlDatabaseInstance_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_sql_database_instance.instance"
@@ -18,7 +18,7 @@ func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -35,7 +35,7 @@ func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
 }
 
 // Test importing a second generation database
-func TestAccGoogleSqlDatabaseInstance_importBasic3(t *testing.T) {
+func TestAccSqlDatabaseInstance_importBasic3(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_sql_database_instance.instance"
@@ -44,7 +44,7 @@ func TestAccGoogleSqlDatabaseInstance_importBasic3(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(

--- a/google/import_sql_database_test.go
+++ b/google/import_sql_database_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccGoogleSqlDatabase_importBasic(t *testing.T) {
+func TestAccSqlDatabase_importBasic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_sql_database.database"
@@ -16,7 +16,7 @@ func TestAccGoogleSqlDatabase_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(

--- a/google/resource_google_folder_iam_binding_test.go
+++ b/google/resource_google_folder_iam_binding_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Test that an IAM binding can be applied to a folder
-func TestAccGoogleFolderIamBinding_basic(t *testing.T) {
+func TestAccFolderIamBinding_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -23,14 +23,14 @@ func TestAccGoogleFolderIamBinding_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingBasic(org, fname),
+				Config: testAccFolderAssociateBindingBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -43,7 +43,7 @@ func TestAccGoogleFolderIamBinding_basic(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a folder, one at a time
-func TestAccGoogleFolderIamBinding_multiple(t *testing.T) {
+func TestAccFolderIamBinding_multiple(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -54,14 +54,14 @@ func TestAccGoogleFolderIamBinding_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingBasic(org, fname),
+				Config: testAccFolderAssociateBindingBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -71,7 +71,7 @@ func TestAccGoogleFolderIamBinding_multiple(t *testing.T) {
 			},
 			// Apply another IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingMultiple(org, fname),
+				Config: testAccFolderAssociateBindingMultiple(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/viewer",
@@ -88,7 +88,7 @@ func TestAccGoogleFolderIamBinding_multiple(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a folder all at once
-func TestAccGoogleFolderIamBinding_multipleAtOnce(t *testing.T) {
+func TestAccFolderIamBinding_multipleAtOnce(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -99,14 +99,14 @@ func TestAccGoogleFolderIamBinding_multipleAtOnce(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingMultiple(org, fname),
+				Config: testAccFolderAssociateBindingMultiple(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -123,7 +123,7 @@ func TestAccGoogleFolderIamBinding_multipleAtOnce(t *testing.T) {
 }
 
 // Test that an IAM binding can be updated once applied to a folder
-func TestAccGoogleFolderIamBinding_update(t *testing.T) {
+func TestAccFolderIamBinding_update(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -134,14 +134,14 @@ func TestAccGoogleFolderIamBinding_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingBasic(org, fname),
+				Config: testAccFolderAssociateBindingBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -151,7 +151,7 @@ func TestAccGoogleFolderIamBinding_update(t *testing.T) {
 			},
 			// Apply an updated IAM binding
 			{
-				Config: testAccGoogleFolderAssociateBindingUpdated(org, fname),
+				Config: testAccFolderAssociateBindingUpdated(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.updated", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -161,7 +161,7 @@ func TestAccGoogleFolderIamBinding_update(t *testing.T) {
 			},
 			// Drop the original member
 			{
-				Config: testAccGoogleFolderAssociateBindingDropMemberFromBasic(org, fname),
+				Config: testAccFolderAssociateBindingDropMemberFromBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.dropped", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -174,7 +174,7 @@ func TestAccGoogleFolderIamBinding_update(t *testing.T) {
 }
 
 // Test that an IAM binding can be removed from a folder
-func TestAccGoogleFolderIamBinding_remove(t *testing.T) {
+func TestAccFolderIamBinding_remove(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -185,14 +185,14 @@ func TestAccGoogleFolderIamBinding_remove(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply multiple IAM bindings
 			{
-				Config: testAccGoogleFolderAssociateBindingMultiple(org, fname),
+				Config: testAccFolderAssociateBindingMultiple(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_binding.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/viewer",
@@ -206,9 +206,9 @@ func TestAccGoogleFolderIamBinding_remove(t *testing.T) {
 			},
 			// Remove the bindings
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 		},
@@ -247,7 +247,7 @@ func testAccCheckGoogleFolderIamBindingExists(key string, expected *cloudresourc
 	}
 }
 
-func testAccGoogleFolderIamBasic(org, fname string) string {
+func testAccFolderIamBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"
@@ -256,7 +256,7 @@ resource "google_folder" "acceptance" {
 `, org, fname)
 }
 
-func testAccGoogleFolderAssociateBindingBasic(org, fname string) string {
+func testAccFolderAssociateBindingBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"
@@ -271,7 +271,7 @@ resource "google_folder_iam_binding" "acceptance" {
 `, org, fname)
 }
 
-func testAccGoogleFolderAssociateBindingMultiple(org, fname string) string {
+func testAccFolderAssociateBindingMultiple(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"
@@ -292,7 +292,7 @@ resource "google_folder_iam_binding" "multiple" {
 `, org, fname)
 }
 
-func testAccGoogleFolderAssociateBindingUpdated(org, fname string) string {
+func testAccFolderAssociateBindingUpdated(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"
@@ -307,7 +307,7 @@ resource "google_folder_iam_binding" "acceptance" {
 `, org, fname)
 }
 
-func testAccGoogleFolderAssociateBindingDropMemberFromBasic(org, fname string) string {
+func testAccFolderAssociateBindingDropMemberFromBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"

--- a/google/resource_google_folder_iam_member_test.go
+++ b/google/resource_google_folder_iam_member_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test that an IAM binding can be applied to a folder
-func TestAccGoogleFolderIamMember_basic(t *testing.T) {
+func TestAccFolderIamMember_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -21,14 +21,14 @@ func TestAccGoogleFolderIamMember_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateMemberBasic(org, fname),
+				Config: testAccFolderAssociateMemberBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -41,7 +41,7 @@ func TestAccGoogleFolderIamMember_basic(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a folder
-func TestAccGoogleFolderIamMember_multiple(t *testing.T) {
+func TestAccFolderIamMember_multiple(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -52,14 +52,14 @@ func TestAccGoogleFolderIamMember_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleFolderAssociateMemberBasic(org, fname),
+				Config: testAccFolderAssociateMemberBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -69,7 +69,7 @@ func TestAccGoogleFolderIamMember_multiple(t *testing.T) {
 			},
 			// Apply another IAM binding
 			{
-				Config: testAccGoogleFolderAssociateMemberMultiple(org, fname),
+				Config: testAccFolderAssociateMemberMultiple(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_member.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -82,7 +82,7 @@ func TestAccGoogleFolderIamMember_multiple(t *testing.T) {
 }
 
 // Test that an IAM binding can be removed from a folder
-func TestAccGoogleFolderIamMember_remove(t *testing.T) {
+func TestAccFolderIamMember_remove(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -93,14 +93,14 @@ func TestAccGoogleFolderIamMember_remove(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new folder
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 			// Apply multiple IAM bindings
 			{
-				Config: testAccGoogleFolderAssociateMemberMultiple(org, fname),
+				Config: testAccFolderAssociateMemberMultiple(org, fname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderIamBindingExists("google_folder_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -110,16 +110,16 @@ func TestAccGoogleFolderIamMember_remove(t *testing.T) {
 			},
 			// Remove the bindings
 			{
-				Config: testAccGoogleFolderIamBasic(org, fname),
+				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(org, fname),
 				),
 			},
 		},
 	})
 }
 
-func testAccGoogleFolderAssociateMemberBasic(org, fname string) string {
+func testAccFolderAssociateMemberBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"
@@ -134,7 +134,7 @@ resource "google_folder_iam_member" "acceptance" {
 `, org, fname)
 }
 
-func testAccGoogleFolderAssociateMemberMultiple(org, fname string) string {
+func testAccFolderAssociateMemberMultiple(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {
   parent       = "organizations/%s"

--- a/google/resource_google_folder_iam_policy_test.go
+++ b/google/resource_google_folder_iam_policy_test.go
@@ -12,7 +12,7 @@ import (
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
 )
 
-func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
+func TestAccFolderIamPolicy_basic(t *testing.T) {
 	t.Parallel()
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
@@ -36,14 +36,14 @@ func TestAccGoogleFolderIamPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderIamPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy),
+				Config: testAccFolderIamPolicy_basic(folderDisplayName, parent, policy),
 				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy),
 			},
 		},
 	})
 }
 
-func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
+func TestAccFolderIamPolicy_update(t *testing.T) {
 	t.Parallel()
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
@@ -83,11 +83,11 @@ func TestAccGoogleFolderIamPolicy_update(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderIamPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy1),
+				Config: testAccFolderIamPolicy_basic(folderDisplayName, parent, policy1),
 				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy1),
 			},
 			resource.TestStep{
-				Config: testAccGoogleFolderIamPolicy_basic(folderDisplayName, parent, policy2),
+				Config: testAccFolderIamPolicy_basic(folderDisplayName, parent, policy2),
 				Check:  testAccCheckGoogleFolderIamPolicy("google_folder_iam_policy.test", policy2),
 			},
 		},
@@ -147,7 +147,7 @@ func testAccCheckGoogleFolderIamPolicy(n string, policy *resourceManagerV2Beta1.
 }
 
 // Confirm that a folder has an IAM policy with at least 1 binding
-func testAccGoogleFolderExistingPolicy(org, fname string) resource.TestCheckFunc {
+func testAccFolderExistingPolicy(org, fname string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := testAccProvider.Meta().(*Config)
 		var err error
@@ -162,7 +162,7 @@ func testAccGoogleFolderExistingPolicy(org, fname string) resource.TestCheckFunc
 	}
 }
 
-func testAccGoogleFolderIamPolicy_basic(folder, parent string, policy *resourceManagerV2Beta1.Policy) string {
+func testAccFolderIamPolicy_basic(folder, parent string, policy *resourceManagerV2Beta1.Policy) string {
 	var bindingBuffer bytes.Buffer
 
 	for _, binding := range policy.Bindings {

--- a/google/resource_google_folder_organization_policy_test.go
+++ b/google/resource_google_folder_organization_policy_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
 
-func TestAccGoogleFolderOrganizationPolicy_boolean(t *testing.T) {
+func TestAccFolderOrganizationPolicy_boolean(t *testing.T) {
 	t.Parallel()
 
 	folder := acctest.RandomWithPrefix("tf-test")
@@ -25,12 +25,12 @@ func TestAccGoogleFolderOrganizationPolicy_boolean(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test creation of an enforced boolean policy
-				Config: testAccGoogleFolderOrganizationPolicy_boolean(org, folder, true),
+				Config: testAccFolderOrganizationPolicy_boolean(org, folder, true),
 				Check:  testAccCheckGoogleFolderOrganizationBooleanPolicy("bool", true),
 			},
 			{
 				// Test update from enforced to not
-				Config: testAccGoogleFolderOrganizationPolicy_boolean(org, folder, false),
+				Config: testAccFolderOrganizationPolicy_boolean(org, folder, false),
 				Check:  testAccCheckGoogleFolderOrganizationBooleanPolicy("bool", false),
 			},
 			{
@@ -39,19 +39,19 @@ func TestAccGoogleFolderOrganizationPolicy_boolean(t *testing.T) {
 			},
 			{
 				// Test creation of a not enforced boolean policy
-				Config: testAccGoogleFolderOrganizationPolicy_boolean(org, folder, false),
+				Config: testAccFolderOrganizationPolicy_boolean(org, folder, false),
 				Check:  testAccCheckGoogleFolderOrganizationBooleanPolicy("bool", false),
 			},
 			{
 				// Test update from not enforced to enforced
-				Config: testAccGoogleFolderOrganizationPolicy_boolean(org, folder, true),
+				Config: testAccFolderOrganizationPolicy_boolean(org, folder, true),
 				Check:  testAccCheckGoogleFolderOrganizationBooleanPolicy("bool", true),
 			},
 		},
 	})
 }
 
-func TestAccGoogleFolderOrganizationPolicy_list_allowAll(t *testing.T) {
+func TestAccFolderOrganizationPolicy_list_allowAll(t *testing.T) {
 	t.Parallel()
 
 	folder := acctest.RandomWithPrefix("tf-test")
@@ -63,14 +63,14 @@ func TestAccGoogleFolderOrganizationPolicy_list_allowAll(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleFolderOrganizationPolicy_list_allowAll(org, folder),
+				Config: testAccFolderOrganizationPolicy_list_allowAll(org, folder),
 				Check:  testAccCheckGoogleFolderOrganizationListPolicyAll("list", "ALLOW"),
 			},
 		},
 	})
 }
 
-func TestAccGoogleFolderOrganizationPolicy_list_allowSome(t *testing.T) {
+func TestAccFolderOrganizationPolicy_list_allowSome(t *testing.T) {
 	t.Parallel()
 
 	folder := acctest.RandomWithPrefix("tf-test")
@@ -82,14 +82,14 @@ func TestAccGoogleFolderOrganizationPolicy_list_allowSome(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleFolderOrganizationPolicy_list_allowSome(org, folder, project),
+				Config: testAccFolderOrganizationPolicy_list_allowSome(org, folder, project),
 				Check:  testAccCheckGoogleFolderOrganizationListPolicyAllowedValues("list", []string{project}),
 			},
 		},
 	})
 }
 
-func TestAccGoogleFolderOrganizationPolicy_list_denySome(t *testing.T) {
+func TestAccFolderOrganizationPolicy_list_denySome(t *testing.T) {
 	t.Parallel()
 
 	folder := acctest.RandomWithPrefix("tf-test")
@@ -100,14 +100,14 @@ func TestAccGoogleFolderOrganizationPolicy_list_denySome(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleFolderOrganizationPolicy_list_denySome(org, folder),
+				Config: testAccFolderOrganizationPolicy_list_denySome(org, folder),
 				Check:  testAccCheckGoogleFolderOrganizationListPolicyDeniedValues("list", DENIED_ORG_POLICIES),
 			},
 		},
 	})
 }
 
-func TestAccGoogleFolderOrganizationPolicy_list_update(t *testing.T) {
+func TestAccFolderOrganizationPolicy_list_update(t *testing.T) {
 	t.Parallel()
 
 	folder := acctest.RandomWithPrefix("tf-test")
@@ -118,11 +118,11 @@ func TestAccGoogleFolderOrganizationPolicy_list_update(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleFolderOrganizationPolicy_list_allowAll(org, folder),
+				Config: testAccFolderOrganizationPolicy_list_allowAll(org, folder),
 				Check:  testAccCheckGoogleFolderOrganizationListPolicyAll("list", "ALLOW"),
 			},
 			{
-				Config: testAccGoogleFolderOrganizationPolicy_list_denySome(org, folder),
+				Config: testAccFolderOrganizationPolicy_list_denySome(org, folder),
 				Check:  testAccCheckGoogleFolderOrganizationListPolicyDeniedValues("list", DENIED_ORG_POLICIES),
 			},
 		},
@@ -241,7 +241,7 @@ func getGoogleFolderOrganizationPolicyTestResource(s *terraform.State, n string)
 	}).Do()
 }
 
-func testAccGoogleFolderOrganizationPolicy_boolean(org, folder string, enforced bool) string {
+func testAccFolderOrganizationPolicy_boolean(org, folder string, enforced bool) string {
 	return fmt.Sprintf(`
 resource "google_folder" "orgpolicy" {
   display_name = "%s"
@@ -260,7 +260,7 @@ resource "google_folder_organization_policy" "bool" {
 `, folder, "organizations/"+org, enforced)
 }
 
-func testAccGoogleFolderOrganizationPolicy_list_allowAll(org, folder string) string {
+func testAccFolderOrganizationPolicy_list_allowAll(org, folder string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "orgpolicy" {
   display_name = "%s"
@@ -280,7 +280,7 @@ resource "google_folder_organization_policy" "list" {
 `, folder, "organizations/"+org)
 }
 
-func testAccGoogleFolderOrganizationPolicy_list_allowSome(org, folder, project string) string {
+func testAccFolderOrganizationPolicy_list_allowSome(org, folder, project string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "orgpolicy" {
   display_name = "%s"
@@ -300,7 +300,7 @@ resource "google_folder_organization_policy" "list" {
 `, folder, "organizations/"+org, project)
 }
 
-func testAccGoogleFolderOrganizationPolicy_list_denySome(org, folder string) string {
+func testAccFolderOrganizationPolicy_list_denySome(org, folder string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "orgpolicy" {
   display_name = "%s"

--- a/google/resource_google_folder_test.go
+++ b/google/resource_google_folder_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
 )
 
-func TestAccGoogleFolder_rename(t *testing.T) {
+func TestAccFolder_rename(t *testing.T) {
 	t.Parallel()
 
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
@@ -25,7 +26,7 @@ func TestAccGoogleFolder_rename(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleFolder_basic(folderDisplayName, parent),
+				Config: testAccFolder_basic(folderDisplayName, parent),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderExists("google_folder.folder1", &folder),
 					testAccCheckGoogleFolderParent(&folder, parent),
@@ -33,7 +34,7 @@ func TestAccGoogleFolder_rename(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccGoogleFolder_basic(newFolderDisplayName, parent),
+				Config: testAccFolder_basic(newFolderDisplayName, parent),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderExists("google_folder.folder1", &folder),
 					testAccCheckGoogleFolderParent(&folder, parent),
@@ -48,7 +49,7 @@ func TestAccGoogleFolder_rename(t *testing.T) {
 	})
 }
 
-func TestAccGoogleFolder_moveParent(t *testing.T) {
+func TestAccFolder_moveParent(t *testing.T) {
 	t.Parallel()
 
 	folder1DisplayName := "tf-test-" + acctest.RandString(10)
@@ -64,7 +65,7 @@ func TestAccGoogleFolder_moveParent(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleFolderDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleFolder_basic(folder1DisplayName, parent),
+				Config: testAccFolder_basic(folder1DisplayName, parent),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderExists("google_folder.folder1", &folder1),
 					testAccCheckGoogleFolderParent(&folder1, parent),
@@ -72,7 +73,7 @@ func TestAccGoogleFolder_moveParent(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccGoogleFolder_move(folder1DisplayName, folder2DisplayName, parent),
+				Config: testAccFolder_move(folder1DisplayName, folder2DisplayName, parent),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderExists("google_folder.folder1", &folder1),
 					testAccCheckGoogleFolderDisplayName(&folder1, folder1DisplayName),
@@ -144,7 +145,7 @@ func testAccCheckGoogleFolderParent(folder *resourceManagerV2Beta1.Folder, paren
 	}
 }
 
-func testAccGoogleFolder_basic(folder, parent string) string {
+func testAccFolder_basic(folder, parent string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "folder1" {
   display_name = "%s"
@@ -153,7 +154,7 @@ resource "google_folder" "folder1" {
 `, folder, parent)
 }
 
-func testAccGoogleFolder_move(folder1, folder2, parent string) string {
+func testAccFolder_move(folder1, folder2, parent string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "folder1" {
   display_name = "%s"

--- a/google/resource_google_organization_iam_custom_role_test.go
+++ b/google/resource_google_organization_iam_custom_role_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleOrganizationIamCustomRole_basic(t *testing.T) {
+func TestAccOrganizationIamCustomRole_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -48,7 +49,7 @@ func TestAccGoogleOrganizationIamCustomRole_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleOrganizationIamCustomRole_undelete(t *testing.T) {
+func TestAccOrganizationIamCustomRole_undelete(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/google/resource_google_organization_policy_test.go
+++ b/google/resource_google_organization_policy_test.go
@@ -19,7 +19,7 @@ var DENIED_ORG_POLICIES = []string{
 // Since each test here is acting on the same organization, run the tests serially to
 // avoid race conditions and aborted operations.
 
-func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
+func TestAccOrganizationPolicy_boolean(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -28,12 +28,12 @@ func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test creation of an enforced boolean policy
-				Config: testAccGoogleOrganizationPolicy_boolean(org, true),
+				Config: testAccOrganizationPolicy_boolean(org, true),
 				Check:  testAccCheckGoogleOrganizationBooleanPolicy("bool", true),
 			},
 			{
 				// Test update from enforced to not
-				Config: testAccGoogleOrganizationPolicy_boolean(org, false),
+				Config: testAccOrganizationPolicy_boolean(org, false),
 				Check:  testAccCheckGoogleOrganizationBooleanPolicy("bool", false),
 			},
 			{
@@ -42,12 +42,12 @@ func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
 			},
 			{
 				// Test creation of a not enforced boolean policy
-				Config: testAccGoogleOrganizationPolicy_boolean(org, false),
+				Config: testAccOrganizationPolicy_boolean(org, false),
 				Check:  testAccCheckGoogleOrganizationBooleanPolicy("bool", false),
 			},
 			{
 				// Test update from not enforced to enforced
-				Config: testAccGoogleOrganizationPolicy_boolean(org, true),
+				Config: testAccOrganizationPolicy_boolean(org, true),
 				Check:  testAccCheckGoogleOrganizationBooleanPolicy("bool", true),
 			},
 			{
@@ -60,7 +60,7 @@ func TestAccGoogleOrganizationPolicy_boolean(t *testing.T) {
 
 }
 
-func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
+func TestAccOrganizationPolicy_list_allowAll(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,7 +68,7 @@ func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleOrganizationPolicy_list_allowAll(org),
+				Config: testAccOrganizationPolicy_list_allowAll(org),
 				Check:  testAccCheckGoogleOrganizationListPolicyAll("list", "ALLOW"),
 			},
 			{
@@ -80,7 +80,7 @@ func TestAccGoogleOrganizationPolicy_list_allowAll(t *testing.T) {
 	})
 }
 
-func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
+func TestAccOrganizationPolicy_list_allowSome(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	project := getTestProjectFromEnv()
 	resource.Test(t, resource.TestCase{
@@ -89,7 +89,7 @@ func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleOrganizationPolicy_list_allowSome(org, project),
+				Config: testAccOrganizationPolicy_list_allowSome(org, project),
 				Check:  testAccCheckGoogleOrganizationListPolicyAllowedValues("list", []string{project}),
 			},
 			{
@@ -101,7 +101,7 @@ func TestAccGoogleOrganizationPolicy_list_allowSome(t *testing.T) {
 	})
 }
 
-func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
+func TestAccOrganizationPolicy_list_denySome(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -109,7 +109,7 @@ func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleOrganizationPolicy_list_denySome(org),
+				Config: testAccOrganizationPolicy_list_denySome(org),
 				Check:  testAccCheckGoogleOrganizationListPolicyDeniedValues("list", DENIED_ORG_POLICIES),
 			},
 			{
@@ -121,7 +121,7 @@ func TestAccGoogleOrganizationPolicy_list_denySome(t *testing.T) {
 	})
 }
 
-func TestAccGoogleOrganizationPolicy_list_update(t *testing.T) {
+func TestAccOrganizationPolicy_list_update(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,11 +129,11 @@ func TestAccGoogleOrganizationPolicy_list_update(t *testing.T) {
 		CheckDestroy: testAccCheckGoogleOrganizationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleOrganizationPolicy_list_allowAll(org),
+				Config: testAccOrganizationPolicy_list_allowAll(org),
 				Check:  testAccCheckGoogleOrganizationListPolicyAll("list", "ALLOW"),
 			},
 			{
-				Config: testAccGoogleOrganizationPolicy_list_denySome(org),
+				Config: testAccOrganizationPolicy_list_denySome(org),
 				Check:  testAccCheckGoogleOrganizationListPolicyDeniedValues("list", DENIED_ORG_POLICIES),
 			},
 			{
@@ -256,7 +256,7 @@ func getGoogleOrganizationPolicyTestResource(s *terraform.State, n string) (*clo
 	}).Do()
 }
 
-func testAccGoogleOrganizationPolicy_boolean(org string, enforced bool) string {
+func testAccOrganizationPolicy_boolean(org string, enforced bool) string {
 	return fmt.Sprintf(`
 resource "google_organization_policy" "bool" {
 	org_id = "%s"
@@ -269,7 +269,7 @@ resource "google_organization_policy" "bool" {
 `, org, enforced)
 }
 
-func testAccGoogleOrganizationPolicy_list_allowAll(org string) string {
+func testAccOrganizationPolicy_list_allowAll(org string) string {
 	return fmt.Sprintf(`
 resource "google_organization_policy" "list" {
 	org_id = "%s"
@@ -284,7 +284,7 @@ resource "google_organization_policy" "list" {
 `, org)
 }
 
-func testAccGoogleOrganizationPolicy_list_allowSome(org, project string) string {
+func testAccOrganizationPolicy_list_allowSome(org, project string) string {
 	return fmt.Sprintf(`
 resource "google_organization_policy" "list" {
 	org_id = "%s"
@@ -301,7 +301,7 @@ resource "google_organization_policy" "list" {
 `, org, project)
 }
 
-func testAccGoogleOrganizationPolicy_list_denySome(org string) string {
+func testAccOrganizationPolicy_list_denySome(org string) string {
 	return fmt.Sprintf(`
 resource "google_organization_policy" "list" {
 	org_id = "%s"

--- a/google/resource_google_project_iam_binding_test.go
+++ b/google/resource_google_project_iam_binding_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Test that an IAM binding can be applied to a project
-func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
+func TestAccProjectIamBinding_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -23,14 +23,14 @@ func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Config: testAccProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -43,7 +43,7 @@ func TestAccGoogleProjectIamBinding_basic(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a project, one at a time
-func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
+func TestAccProjectIamBinding_multiple(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -54,14 +54,14 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Config: testAccProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -71,7 +71,7 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 			},
 			// Apply another IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
+				Config: testAccProjectAssociateBindingMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/viewer",
@@ -88,7 +88,7 @@ func TestAccGoogleProjectIamBinding_multiple(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a project all at once
-func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
+func TestAccProjectIamBinding_multipleAtOnce(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -99,14 +99,14 @@ func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
+				Config: testAccProjectAssociateBindingMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -123,7 +123,7 @@ func TestAccGoogleProjectIamBinding_multipleAtOnce(t *testing.T) {
 }
 
 // Test that an IAM binding can be updated once applied to a project
-func TestAccGoogleProjectIamBinding_update(t *testing.T) {
+func TestAccProjectIamBinding_update(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -134,14 +134,14 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingBasic(pid, pname, org),
+				Config: testAccProjectAssociateBindingBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -151,7 +151,7 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 			},
 			// Apply an updated IAM binding
 			{
-				Config: testAccGoogleProjectAssociateBindingUpdated(pid, pname, org),
+				Config: testAccProjectAssociateBindingUpdated(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.updated", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -161,7 +161,7 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 			},
 			// Drop the original member
 			{
-				Config: testAccGoogleProjectAssociateBindingDropMemberFromBasic(pid, pname, org),
+				Config: testAccProjectAssociateBindingDropMemberFromBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.dropped", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -174,7 +174,7 @@ func TestAccGoogleProjectIamBinding_update(t *testing.T) {
 }
 
 // Test that an IAM binding can be removed from a project
-func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
+func TestAccProjectIamBinding_remove(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -185,14 +185,14 @@ func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply multiple IAM bindings
 			{
-				Config: testAccGoogleProjectAssociateBindingMultiple(pid, pname, org),
+				Config: testAccProjectAssociateBindingMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_binding.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/viewer",
@@ -206,9 +206,9 @@ func TestAccGoogleProjectIamBinding_remove(t *testing.T) {
 			},
 			// Remove the bindings
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 		},
@@ -247,7 +247,7 @@ func testAccCheckGoogleProjectIamBindingExists(key string, expected *cloudresour
 	}
 }
 
-func testAccGoogleProjectAssociateBindingBasic(pid, name, org string) string {
+func testAccProjectAssociateBindingBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -263,7 +263,7 @@ resource "google_project_iam_binding" "acceptance" {
 `, pid, name, org)
 }
 
-func testAccGoogleProjectAssociateBindingMultiple(pid, name, org string) string {
+func testAccProjectAssociateBindingMultiple(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -285,7 +285,7 @@ resource "google_project_iam_binding" "multiple" {
 `, pid, name, org)
 }
 
-func testAccGoogleProjectAssociateBindingUpdated(pid, name, org string) string {
+func testAccProjectAssociateBindingUpdated(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -301,7 +301,7 @@ resource "google_project_iam_binding" "acceptance" {
 `, pid, name, org)
 }
 
-func testAccGoogleProjectAssociateBindingDropMemberFromBasic(pid, name, org string) string {
+func testAccProjectAssociateBindingDropMemberFromBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"

--- a/google/resource_google_project_iam_custom_role_test.go
+++ b/google/resource_google_project_iam_custom_role_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleProjectIamCustomRole_basic(t *testing.T) {
+func TestAccProjectIamCustomRole_basic(t *testing.T) {
 	t.Parallel()
 
 	roleId := "tfIamCustomRole" + acctest.RandString(10)
@@ -42,7 +43,7 @@ func TestAccGoogleProjectIamCustomRole_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleProjectIamCustomRole_undelete(t *testing.T) {
+func TestAccProjectIamCustomRole_undelete(t *testing.T) {
 	t.Parallel()
 
 	roleId := "tfIamCustomRole" + acctest.RandString(10)

--- a/google/resource_google_project_iam_member_test.go
+++ b/google/resource_google_project_iam_member_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test that an IAM binding can be applied to a project
-func TestAccGoogleProjectIamMember_basic(t *testing.T) {
+func TestAccProjectIamMember_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -21,14 +21,14 @@ func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
+				Config: testAccProjectAssociateMemberBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -41,7 +41,7 @@ func TestAccGoogleProjectIamMember_basic(t *testing.T) {
 }
 
 // Test that multiple IAM bindings can be applied to a project
-func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
+func TestAccProjectIamMember_multiple(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -54,14 +54,14 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM binding
 			{
-				Config: testAccGoogleProjectAssociateMemberBasic(pid, pname, org),
+				Config: testAccProjectAssociateMemberBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -71,7 +71,7 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 			},
 			// Apply another IAM binding
 			{
-				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
+				Config: testAccProjectAssociateMemberMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.multiple", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -84,7 +84,7 @@ func TestAccGoogleProjectIamMember_multiple(t *testing.T) {
 }
 
 // Test that an IAM binding can be removed from a project
-func TestAccGoogleProjectIamMember_remove(t *testing.T) {
+func TestAccProjectIamMember_remove(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -97,14 +97,14 @@ func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply multiple IAM bindings
 			{
-				Config: testAccGoogleProjectAssociateMemberMultiple(pid, pname, org),
+				Config: testAccProjectAssociateMemberMultiple(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamBindingExists("google_project_iam_member.acceptance", &cloudresourcemanager.Binding{
 						Role:    "roles/compute.instanceAdmin",
@@ -114,16 +114,16 @@ func TestAccGoogleProjectIamMember_remove(t *testing.T) {
 			},
 			// Remove the bindings
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 		},
 	})
 }
 
-func testAccGoogleProjectAssociateMemberBasic(pid, name, org string) string {
+func testAccProjectAssociateMemberBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -139,7 +139,7 @@ resource "google_project_iam_member" "acceptance" {
 `, pid, name, org)
 }
 
-func testAccGoogleProjectAssociateMemberMultiple(pid, name, org string) string {
+func testAccProjectAssociateMemberMultiple(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"

--- a/google/resource_google_project_iam_policy_test.go
+++ b/google/resource_google_project_iam_policy_test.go
@@ -221,7 +221,7 @@ func TestSubtractIamPolicy(t *testing.T) {
 }
 
 // Test that an IAM policy can be applied to a project
-func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
+func TestAccProjectIamPolicy_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -232,15 +232,15 @@ func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 			// Apply an IAM policy from a data source. The application
 			// merges policies, so we validate the expected state.
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociatePolicyBasic(pid, pname, org),
+				Config: testAccProjectAssociatePolicyBasic(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", pid),
 				),
@@ -248,9 +248,9 @@ func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 			// Finally, remove the custom IAM policy from config and apply, then
 			// confirm that the project is in its original state.
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(pid),
 				),
 			},
 		},
@@ -258,7 +258,7 @@ func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 }
 
 // Test that an IAM policy can be applied to a project when no project is set in the resource
-func TestAccGoogleProjectIamPolicy_defaultProject(t *testing.T) {
+func TestAccProjectIamPolicy_defaultProject(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -267,15 +267,15 @@ func TestAccGoogleProjectIamPolicy_defaultProject(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project
 			resource.TestStep{
-				Config: testAccGoogleProjectDefaultAssociatePolicyBasic(),
+				Config: testAccProjectDefaultAssociatePolicyBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(getTestProjectFromEnv()),
+					testAccProjectExistingPolicy(getTestProjectFromEnv()),
 				),
 			},
 			// Apply an IAM policy from a data source. The application
 			// merges policies, so we validate the expected state.
 			resource.TestStep{
-				Config: testAccGoogleProjectDefaultAssociatePolicyBasic(),
+				Config: testAccProjectDefaultAssociatePolicyBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", getTestProjectFromEnv()),
 				),
@@ -285,7 +285,7 @@ func TestAccGoogleProjectIamPolicy_defaultProject(t *testing.T) {
 }
 
 // Test that a non-collapsed IAM policy doesn't perpetually diff
-func TestAccGoogleProjectIamPolicy_expanded(t *testing.T) {
+func TestAccProjectIamPolicy_expanded(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -295,7 +295,7 @@ func TestAccGoogleProjectIamPolicy_expanded(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociatePolicyExpanded(pid, pname, org),
+				Config: testAccProjectAssociatePolicyExpanded(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectIamPolicyExists("google_project_iam_policy.acceptance", "data.google_iam_policy.expanded", pid),
 				),
@@ -647,7 +647,7 @@ func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Bin
 }
 
 // Confirm that a project has an IAM policy with at least 1 binding
-func testAccGoogleProjectExistingPolicy(pid string) resource.TestCheckFunc {
+func testAccProjectExistingPolicy(pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := testAccProvider.Meta().(*Config)
 		var err error
@@ -662,7 +662,7 @@ func testAccGoogleProjectExistingPolicy(pid string) resource.TestCheckFunc {
 	}
 }
 
-func testAccGoogleProjectDefaultAssociatePolicyBasic() string {
+func testAccProjectDefaultAssociatePolicyBasic() string {
 	return fmt.Sprintf(`
 resource "google_project_iam_policy" "acceptance" {
     policy_data = "${data.google_iam_policy.admin.policy_data}"
@@ -685,7 +685,7 @@ data "google_iam_policy" "admin" {
 `)
 }
 
-func testAccGoogleProjectAssociatePolicyBasic(pid, name, org string) string {
+func testAccProjectAssociatePolicyBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
@@ -714,7 +714,7 @@ data "google_iam_policy" "admin" {
 `, pid, name, org)
 }
 
-func testAccGoogleProject_createWithoutOrg(pid, name string) string {
+func testAccProject_createWithoutOrg(pid, name string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
@@ -722,7 +722,7 @@ resource "google_project" "acceptance" {
 }`, pid, name)
 }
 
-func testAccGoogleProject_create(pid, name, org string) string {
+func testAccProject_create(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
@@ -731,7 +731,7 @@ resource "google_project" "acceptance" {
 }`, pid, name, org)
 }
 
-func testAccGoogleProject_createBilling(pid, name, org, billing string) string {
+func testAccProject_createBilling(pid, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
@@ -741,7 +741,7 @@ resource "google_project" "acceptance" {
 }`, pid, name, org, billing)
 }
 
-func testAccGoogleProjectAssociatePolicyExpanded(pid, name, org string) string {
+func testAccProjectAssociatePolicyExpanded(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"

--- a/google/resource_google_project_service_test.go
+++ b/google/resource_google_project_service_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test that services can be enabled and disabled on a project
-func TestAccGoogleProjectService_basic(t *testing.T) {
+func TestAccProjectService_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -21,28 +21,28 @@ func TestAccGoogleProjectService_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectService_basic(services, pid, pname, org),
+				Config: testAccProjectService_basic(services, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectService(services, pid, true),
 				),
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectService(services, pid, false),
 				),
 			},
 			// Create services with disabling turned off.
 			resource.TestStep{
-				Config: testAccGoogleProjectService_noDisable(services, pid, pname, org),
+				Config: testAccProjectService_noDisable(services, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectService(services, pid, true),
 				),
 			},
 			// Check that services are still enabled even after the resources are deleted.
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectService(services, pid, true),
 				),
@@ -79,7 +79,7 @@ func testAccCheckProjectService(services []string, pid string, expectEnabled boo
 	}
 }
 
-func testAccGoogleProjectService_basic(services []string, pid, name, org string) string {
+func testAccProjectService_basic(services []string, pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -99,7 +99,7 @@ resource "google_project_service" "test2" {
 `, pid, name, org, services[0], services[1])
 }
 
-func testAccGoogleProjectService_noDisable(services []string, pid, name, org string) string {
+func testAccProjectService_noDisable(services []string, pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"

--- a/google/resource_google_project_services_test.go
+++ b/google/resource_google_project_services_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Test that services can be enabled and disabled on a project
-func TestAccGoogleProjectServices_basic(t *testing.T) {
+func TestAccProjectServices_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -28,14 +28,14 @@ func TestAccGoogleProjectServices_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project with some services
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateServicesBasic(services1, pid, pname, org),
+				Config: testAccProjectAssociateServicesBasic(services1, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services1, pid),
 				),
 			},
 			// Update services to remove one
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateServicesBasic(services2, pid, pname, org),
+				Config: testAccProjectAssociateServicesBasic(services2, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services2, pid),
 				),
@@ -46,7 +46,7 @@ func TestAccGoogleProjectServices_basic(t *testing.T) {
 					config := testAccProvider.Meta().(*Config)
 					enableService(oobService, pid, config)
 				},
-				Config: testAccGoogleProjectAssociateServicesBasic(services2, pid, pname, org),
+				Config: testAccProjectAssociateServicesBasic(services2, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services2, pid),
 				),
@@ -57,7 +57,7 @@ func TestAccGoogleProjectServices_basic(t *testing.T) {
 
 // Test that services are authoritative when a project has existing
 // sevices not represented in config
-func TestAccGoogleProjectServices_authoritative(t *testing.T) {
+func TestAccProjectServices_authoritative(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -70,7 +70,7 @@ func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project with no services
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
@@ -82,7 +82,7 @@ func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 					config := testAccProvider.Meta().(*Config)
 					enableService(oobService, pid, config)
 				},
-				Config: testAccGoogleProjectAssociateServicesBasic(services, pid, pname, org),
+				Config: testAccProjectAssociateServicesBasic(services, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services, pid),
 				),
@@ -94,7 +94,7 @@ func TestAccGoogleProjectServices_authoritative(t *testing.T) {
 // Test that services are authoritative when a project has existing
 // sevices, some which are represented in the config and others
 // that are not
-func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
+func TestAccProjectServices_authoritative2(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -108,7 +108,7 @@ func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a new project with no services
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
@@ -122,7 +122,7 @@ func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 						enableService(s, pid, config)
 					}
 				},
-				Config: testAccGoogleProjectAssociateServicesBasic(services, pid, pname, org),
+				Config: testAccProjectAssociateServicesBasic(services, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services, pid),
 				),
@@ -134,7 +134,7 @@ func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
 // Test that services that can't be enabled on their own (such as dataproc-control.googleapis.com)
 // don't end up causing diffs when they are enabled as a side-effect of a different service's
 // enablement.
-func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
+func TestAccProjectServices_ignoreUnenablableServices(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -160,7 +160,7 @@ func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateServicesBasic_withBilling(services, pid, pname, org, billingId),
+				Config: testAccProjectAssociateServicesBasic_withBilling(services, pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services, pid),
 				),
@@ -169,7 +169,7 @@ func TestAccGoogleProjectServices_ignoreUnenablableServices(t *testing.T) {
 	})
 }
 
-func TestAccGoogleProjectServices_manyServices(t *testing.T) {
+func TestAccProjectServices_manyServices(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -211,7 +211,7 @@ func TestAccGoogleProjectServices_manyServices(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleProjectAssociateServicesBasic_withBilling(services, pid, pname, org, billingId),
+				Config: testAccProjectAssociateServicesBasic_withBilling(services, pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testProjectServicesMatch(services, pid),
 				),
@@ -220,7 +220,7 @@ func TestAccGoogleProjectServices_manyServices(t *testing.T) {
 	})
 }
 
-func testAccGoogleProjectAssociateServicesBasic(services []string, pid, name, org string) string {
+func testAccProjectAssociateServicesBasic(services []string, pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
@@ -234,7 +234,7 @@ resource "google_project_services" "acceptance" {
 `, pid, name, org, testStringsToString(services))
 }
 
-func testAccGoogleProjectAssociateServicesBasic_withBilling(services []string, pid, name, org, billing string) string {
+func testAccProjectAssociateServicesBasic_withBilling(services []string, pid, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 // Test that a Project resource can be created without an organization
-func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
+func TestAccProject_createWithoutOrg(t *testing.T) {
 	t.Parallel()
 
 	creds := multiEnvSearch(credsEnvVars)
@@ -36,7 +36,7 @@ func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
 		Steps: []resource.TestStep{
 			// This step creates a new project
 			resource.TestStep{
-				Config: testAccGoogleProject_createWithoutOrg(pid, pname),
+				Config: testAccProject_createWithoutOrg(pid, pname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
@@ -47,7 +47,7 @@ func TestAccGoogleProject_createWithoutOrg(t *testing.T) {
 
 // Test that a Project resource can be created and an IAM policy
 // associated
-func TestAccGoogleProject_create(t *testing.T) {
+func TestAccProject_create(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -58,7 +58,7 @@ func TestAccGoogleProject_create(t *testing.T) {
 		Steps: []resource.TestStep{
 			// This step creates a new project
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
@@ -69,7 +69,7 @@ func TestAccGoogleProject_create(t *testing.T) {
 
 // Test that a Project resource can be created with an associated
 // billing account
-func TestAccGoogleProject_billing(t *testing.T) {
+func TestAccProject_billing(t *testing.T) {
 	t.Parallel()
 	org := getTestOrgFromEnv(t)
 	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT_2")
@@ -82,7 +82,7 @@ func TestAccGoogleProject_billing(t *testing.T) {
 		Steps: []resource.TestStep{
 			// This step creates a new project with a billing account
 			resource.TestStep{
-				Config: testAccGoogleProject_createBilling(pid, pname, org, billingId),
+				Config: testAccProject_createBilling(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasBillingAccount("google_project.acceptance", pid, billingId),
 				),
@@ -95,14 +95,14 @@ func TestAccGoogleProject_billing(t *testing.T) {
 			},
 			// Update to a different  billing account
 			resource.TestStep{
-				Config: testAccGoogleProject_createBilling(pid, pname, org, billingId2),
+				Config: testAccProject_createBilling(pid, pname, org, billingId2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasBillingAccount("google_project.acceptance", pid, billingId2),
 				),
 			},
 			// Unlink the billing account
 			resource.TestStep{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasBillingAccount("google_project.acceptance", pid, ""),
 				),
@@ -112,7 +112,7 @@ func TestAccGoogleProject_billing(t *testing.T) {
 }
 
 // Test that a Project resource can be created with labels
-func TestAccGoogleProject_labels(t *testing.T) {
+func TestAccProject_labels(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -122,7 +122,7 @@ func TestAccGoogleProject_labels(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleProject_labels(pid, pname, org, map[string]string{"test": "that"}),
+				Config: testAccProject_labels(pid, pname, org, map[string]string{"test": "that"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasLabels("google_project.acceptance", pid, map[string]string{"test": "that"}),
 				),
@@ -135,7 +135,7 @@ func TestAccGoogleProject_labels(t *testing.T) {
 			},
 			// update project with labels
 			{
-				Config: testAccGoogleProject_labels(pid, pname, org, map[string]string{"label": "label-value"}),
+				Config: testAccProject_labels(pid, pname, org, map[string]string{"label": "label-value"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 					testAccCheckGoogleProjectHasLabels("google_project.acceptance", pid, map[string]string{"label": "label-value"}),
@@ -143,7 +143,7 @@ func TestAccGoogleProject_labels(t *testing.T) {
 			},
 			// update project delete labels
 			{
-				Config: testAccGoogleProject_create(pid, pname, org),
+				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 					testAccCheckGoogleProjectHasNoLabels("google_project.acceptance", pid),
@@ -269,7 +269,7 @@ func testAccCheckGoogleProjectHasNoLabels(r, pid string) resource.TestCheckFunc 
 	}
 }
 
-func testAccGoogleProject_labels(pid, name, org string, labels map[string]string) string {
+func testAccProject_labels(pid, name, org string, labels map[string]string) string {
 	r := fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"

--- a/google/resource_google_service_account_iam_test.go
+++ b/google/resource_google_service_account_iam_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleServiceAccountIamBinding(t *testing.T) {
+func TestAccServiceAccountIamBinding(t *testing.T) {
 	t.Parallel()
 
 	account := acctest.RandomWithPrefix("tf-test")
@@ -20,7 +21,7 @@ func TestAccGoogleServiceAccountIamBinding(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleServiceAccountIamBinding_basic(account),
+				Config: testAccServiceAccountIamBinding_basic(account),
 				Check: testAccCheckGoogleServiceAccountIam(account, "roles/viewer", []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
 				}),
@@ -34,7 +35,7 @@ func TestAccGoogleServiceAccountIamBinding(t *testing.T) {
 	})
 }
 
-func TestAccGoogleServiceAccountIamMember(t *testing.T) {
+func TestAccServiceAccountIamMember(t *testing.T) {
 	t.Parallel()
 
 	account := acctest.RandomWithPrefix("tf-test")
@@ -45,7 +46,7 @@ func TestAccGoogleServiceAccountIamMember(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleServiceAccountIamMember_basic(account),
+				Config: testAccServiceAccountIamMember_basic(account),
 				Check:  testAccCheckGoogleServiceAccountIam(account, "roles/editor", []string{identity}),
 			},
 			{
@@ -57,7 +58,7 @@ func TestAccGoogleServiceAccountIamMember(t *testing.T) {
 	})
 }
 
-func TestAccGoogleServiceAccountIamPolicy(t *testing.T) {
+func TestAccServiceAccountIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	account := acctest.RandomWithPrefix("tf-test")
@@ -67,7 +68,7 @@ func TestAccGoogleServiceAccountIamPolicy(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleServiceAccountIamPolicy_basic(account),
+				Config: testAccServiceAccountIamPolicy_basic(account),
 				Check: testAccCheckGoogleServiceAccountIam(account, "roles/owner", []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
 				}),
@@ -110,7 +111,7 @@ func getServiceAccountCanonicalId(account string) string {
 	return fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", getTestProjectFromEnv(), account, getTestProjectFromEnv())
 }
 
-func testAccGoogleServiceAccountIamBinding_basic(account string) string {
+func testAccServiceAccountIamBinding_basic(account string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "test_account" {
   account_id   = "%s"
@@ -125,7 +126,7 @@ resource "google_service_account_iam_binding" "foo" {
 `, account)
 }
 
-func testAccGoogleServiceAccountIamMember_basic(account string) string {
+func testAccServiceAccountIamMember_basic(account string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "test_account" {
   account_id   = "%s"
@@ -140,7 +141,7 @@ resource "google_service_account_iam_member" "foo" {
 `, account)
 }
 
-func testAccGoogleServiceAccountIamPolicy_basic(account string) string {
+func testAccServiceAccountIamPolicy_basic(account string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "test_account" {
   account_id   = "%s"

--- a/google/resource_google_service_account_key_test.go
+++ b/google/resource_google_service_account_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test that a service account key can be created and destroyed
-func TestAccGoogleServiceAccountKey_basic(t *testing.T) {
+func TestAccServiceAccountKey_basic(t *testing.T) {
 	t.Parallel()
 
 	resourceName := "google_service_account_key.acceptance"
@@ -21,7 +21,7 @@ func TestAccGoogleServiceAccountKey_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountKey(accountID, displayName),
+				Config: testAccServiceAccountKey(accountID, displayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountKeyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -34,7 +34,7 @@ func TestAccGoogleServiceAccountKey_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleServiceAccountKey_pgp(t *testing.T) {
+func TestAccServiceAccountKey_pgp(t *testing.T) {
 	t.Parallel()
 	resourceName := "google_service_account_key.acceptance"
 	accountID := "a" + acctest.RandString(10)
@@ -44,7 +44,7 @@ func TestAccGoogleServiceAccountKey_pgp(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountKey_pgp(accountID, displayName, testKeyPairPubKey1),
+				Config: testAccServiceAccountKey_pgp(accountID, displayName, testKeyPairPubKey1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountKeyExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -78,7 +78,7 @@ func testAccCheckGoogleServiceAccountKeyExists(r string) resource.TestCheckFunc 
 	}
 }
 
-func testAccGoogleServiceAccountKey(account, name string) string {
+func testAccServiceAccountKey(account, name string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
 	account_id = "%s"
@@ -92,7 +92,7 @@ resource "google_service_account_key" "acceptance" {
 `, account, name)
 }
 
-func testAccGoogleServiceAccountKey_pgp(account, name string, key string) string {
+func testAccServiceAccountKey_pgp(account, name string, key string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
 	account_id = "%s"

--- a/google/resource_google_service_account_test.go
+++ b/google/resource_google_service_account_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test that a service account resource can be created, updated, and destroyed
-func TestAccGoogleServiceAccount_basic(t *testing.T) {
+func TestAccServiceAccount_basic(t *testing.T) {
 	t.Parallel()
 
 	accountId := "a" + acctest.RandString(10)
@@ -24,7 +24,7 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// The first step creates a basic service account
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountBasic(accountId, displayName),
+				Config: testAccServiceAccountBasic(accountId, displayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountExists("google_service_account.acceptance"),
 					resource.TestCheckResourceAttr(
@@ -33,7 +33,7 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 			},
 			// The second step updates the service account
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountBasic(accountId, displayName2),
+				Config: testAccServiceAccountBasic(accountId, displayName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountNameModified("google_service_account.acceptance", displayName2),
 					resource.TestCheckResourceAttr(
@@ -44,7 +44,7 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 			// The third step explicitely adds the same default project to the service account configuration
 			// and ensure the service account is not recreated by comparing the value of its unique_id with the one from the previous step
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountWithProject(project, accountId, displayName2),
+				Config: testAccServiceAccountWithProject(project, accountId, displayName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountNameModified("google_service_account.acceptance", displayName2),
 					resource.TestCheckResourceAttr(
@@ -59,7 +59,7 @@ func TestAccGoogleServiceAccount_basic(t *testing.T) {
 
 // Test that a service account resource can be created with a policy, updated,
 // and destroyed.
-func TestAccGoogleServiceAccount_createPolicy(t *testing.T) {
+func TestAccServiceAccount_createPolicy(t *testing.T) {
 	t.Parallel()
 
 	accountId := "a" + acctest.RandString(10)
@@ -70,21 +70,21 @@ func TestAccGoogleServiceAccount_createPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			// The first step creates a basic service account with an IAM policy
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountPolicy(accountId, getTestProjectFromEnv()),
+				Config: testAccServiceAccountPolicy(accountId, getTestProjectFromEnv()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountPolicyCount("google_service_account.acceptance", 1),
 				),
 			},
 			// The second step updates the service account with no IAM policy
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountBasic(accountId, displayName),
+				Config: testAccServiceAccountBasic(accountId, displayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountPolicyCount("google_service_account.acceptance", 0),
 				),
 			},
 			// The final step re-applies the IAM policy
 			resource.TestStep{
-				Config: testAccGoogleServiceAccountPolicy(accountId, getTestProjectFromEnv()),
+				Config: testAccServiceAccountPolicy(accountId, getTestProjectFromEnv()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountPolicyCount("google_service_account.acceptance", 1),
 				),
@@ -144,7 +144,7 @@ func testAccCheckGoogleServiceAccountNameModified(r, n string) resource.TestChec
 	}
 }
 
-func testAccGoogleServiceAccountBasic(account, name string) string {
+func testAccServiceAccountBasic(account, name string) string {
 	t := `resource "google_service_account" "acceptance" {
     account_id = "%v"
 	display_name = "%v"
@@ -152,7 +152,7 @@ func testAccGoogleServiceAccountBasic(account, name string) string {
 	return fmt.Sprintf(t, account, name)
 }
 
-func testAccGoogleServiceAccountWithProject(project, account, name string) string {
+func testAccServiceAccountWithProject(project, account, name string) string {
 	t := `resource "google_service_account" "acceptance" {
     project = "%v"
     account_id = "%v"
@@ -161,7 +161,7 @@ func testAccGoogleServiceAccountWithProject(project, account, name string) strin
 	return fmt.Sprintf(t, project, account, name)
 }
 
-func testAccGoogleServiceAccountPolicy(account, project string) string {
+func testAccServiceAccountPolicy(account, project string) string {
 
 	t := `resource "google_service_account" "acceptance" {
     account_id = "%v"

--- a/google/resource_kms_crypto_key_iam_test.go
+++ b/google/resource_kms_crypto_key_iam_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleKmsCryptoKeyIamBinding(t *testing.T) {
+func TestAccKmsCryptoKeyIamBinding(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -27,14 +28,14 @@ func TestAccGoogleKmsCryptoKeyIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test Iam Binding creation
-				Config: testAccGoogleKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
+				Config: testAccKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
 				Check: testAccCheckGoogleKmsCryptoKeyIamBindingExists("foo", roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 				}),
 			},
 			{
 				// Test Iam Binding update
-				Config: testAccGoogleKmsCryptoKeyIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
+				Config: testAccKmsCryptoKeyIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
 				Check: testAccCheckGoogleKmsCryptoKeyIamBindingExists("foo", roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 					fmt.Sprintf("serviceAccount:%s-2@%s.iam.gserviceaccount.com", account, projectId),
@@ -44,7 +45,7 @@ func TestAccGoogleKmsCryptoKeyIamBinding(t *testing.T) {
 	})
 }
 
-func TestAccGoogleKmsCryptoKeyIamMember(t *testing.T) {
+func TestAccKmsCryptoKeyIamMember(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -61,7 +62,7 @@ func TestAccGoogleKmsCryptoKeyIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test Iam Member creation (no update for member, no need to test)
-				Config: testAccGoogleKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
+				Config: testAccKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId),
 				Check: testAccCheckGoogleKmsCryptoKeyIamMemberExists("foo", roleId,
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 				),
@@ -143,7 +144,7 @@ func testAccCheckGoogleKmsCryptoKeyIamMemberExists(n, role, member string) resou
 
 // We are using a custom role since iam_binding is authoritative on the member list and
 // we want to avoid removing members from an existing role to prevent unwanted side effects.
-func testAccGoogleKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
+func testAccKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"
@@ -186,7 +187,7 @@ resource "google_kms_crypto_key_iam_binding" "foo" {
 `, projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId)
 }
 
-func testAccGoogleKmsCryptoKeyIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
+func testAccKmsCryptoKeyIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"
@@ -238,7 +239,7 @@ resource "google_kms_crypto_key_iam_binding" "foo" {
 `, projectId, orgId, billingAccount, account, account, keyRingName, cryptoKeyName, roleId)
 }
 
-func testAccGoogleKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
+func testAccKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -104,7 +104,7 @@ func TestCryptoKeyNextRotationCalculation_validation(t *testing.T) {
 	}
 }
 
-func TestAccGoogleKmsCryptoKey_basic(t *testing.T) {
+func TestAccKmsCryptoKey_basic(t *testing.T) {
 	t.Parallel()
 
 	projectId := "terraform-" + acctest.RandString(10)
@@ -136,7 +136,7 @@ func TestAccGoogleKmsCryptoKey_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleKmsCryptoKey_rotation(t *testing.T) {
+func TestAccKmsCryptoKey_rotation(t *testing.T) {
 	t.Parallel()
 
 	projectId := "terraform-" + acctest.RandString(10)

--- a/google/resource_kms_key_ring_iam_test.go
+++ b/google/resource_kms_key_ring_iam_test.go
@@ -2,17 +2,18 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 const DEFAULT_KMS_TEST_LOCATION = "us-central1"
 
-func TestAccGoogleKmsKeyRingIamBinding(t *testing.T) {
+func TestAccKmsKeyRingIamBinding(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -34,14 +35,14 @@ func TestAccGoogleKmsKeyRingIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test Iam Binding creation
-				Config: testAccGoogleKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 				Check: testAccCheckGoogleKmsKeyRingIam(keyRingId.keyRingId(), roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 				}),
 			},
 			{
 				// Test Iam Binding update
-				Config: testAccGoogleKmsKeyRingIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, roleId),
 				Check: testAccCheckGoogleKmsKeyRingIam(keyRingId.keyRingId(), roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 					fmt.Sprintf("serviceAccount:%s-2@%s.iam.gserviceaccount.com", account, projectId),
@@ -51,7 +52,7 @@ func TestAccGoogleKmsKeyRingIamBinding(t *testing.T) {
 	})
 }
 
-func TestAccGoogleKmsKeyRingIamMember(t *testing.T) {
+func TestAccKmsKeyRingIamMember(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -73,7 +74,7 @@ func TestAccGoogleKmsKeyRingIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test Iam Member creation (no update for member, no need to test)
-				Config: testAccGoogleKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 				Check: testAccCheckGoogleKmsKeyRingIam(keyRingId.keyRingId(), roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 				}),
@@ -82,7 +83,7 @@ func TestAccGoogleKmsKeyRingIamMember(t *testing.T) {
 	})
 }
 
-func TestAccGoogleKmsKeyRingIamPolicy(t *testing.T) {
+func TestAccKmsKeyRingIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
@@ -103,7 +104,7 @@ func TestAccGoogleKmsKeyRingIamPolicy(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGoogleKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
+				Config: testAccKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId),
 				Check: testAccCheckGoogleKmsKeyRingIam(keyRingId.keyRingId(), roleId, []string{
 					fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, projectId),
 				}),
@@ -139,7 +140,7 @@ func testAccCheckGoogleKmsKeyRingIam(keyRingId, role string, members []string) r
 
 // We are using a custom role since iam_binding is authoritative on the member list and
 // we want to avoid removing members from an existing role to prevent unwanted side effects.
-func testAccGoogleKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
+func testAccKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"
@@ -177,7 +178,7 @@ resource "google_kms_key_ring_iam_binding" "foo" {
 `, projectId, orgId, billingAccount, account, keyRingName, roleId)
 }
 
-func testAccGoogleKmsKeyRingIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
+func testAccKmsKeyRingIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"
@@ -224,7 +225,7 @@ resource "google_kms_key_ring_iam_binding" "foo" {
 `, projectId, orgId, billingAccount, account, account, DEFAULT_KMS_TEST_LOCATION, keyRingName, roleId)
 }
 
-func testAccGoogleKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
+func testAccKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"
@@ -262,7 +263,7 @@ resource "google_kms_key_ring_iam_member" "foo" {
 `, projectId, orgId, billingAccount, account, DEFAULT_KMS_TEST_LOCATION, keyRingName, roleId)
 }
 
-func testAccGoogleKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
+func testAccKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
   name            = "Test project"

--- a/google/resource_kms_key_ring_test.go
+++ b/google/resource_kms_key_ring_test.go
@@ -2,9 +2,8 @@ package google
 
 import (
 	"fmt"
-	"testing"
-
 	"log"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/google/resource_kms_key_ring_test.go
+++ b/google/resource_kms_key_ring_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"log"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
 )
 
 func TestKeyRingIdParsing(t *testing.T) {
@@ -66,7 +67,7 @@ func TestKeyRingIdParsing(t *testing.T) {
 	}
 }
 
-func TestAccGoogleKmsKeyRing_basic(t *testing.T) {
+func TestAccKmsKeyRing_basic(t *testing.T) {
 	projectId := "terraform-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -139,7 +139,7 @@ func testSweepDatabases(region string) error {
 	return nil
 }
 
-func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
+func TestAccSqlDatabaseInstance_basic(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -148,7 +148,7 @@ func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -164,7 +164,7 @@ func TestAccGoogleSqlDatabaseInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
+func TestAccSqlDatabaseInstance_basic2(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -172,7 +172,7 @@ func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleSqlDatabaseInstance_basic2,
@@ -187,7 +187,7 @@ func TestAccGoogleSqlDatabaseInstance_basic2(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_basic3(t *testing.T) {
+func TestAccSqlDatabaseInstance_basic3(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -196,7 +196,7 @@ func TestAccGoogleSqlDatabaseInstance_basic3(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -214,7 +214,7 @@ func TestAccGoogleSqlDatabaseInstance_basic3(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
+func TestAccSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -227,7 +227,7 @@ func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleSqlDatabaseInstanceConfig_withoutReplica(databaseName),
@@ -263,7 +263,7 @@ func TestAccGoogleSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
+func TestAccSqlDatabaseInstance_settings_basic(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -272,7 +272,7 @@ func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -288,7 +288,7 @@ func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
+func TestAccSqlDatabaseInstance_slave(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -298,7 +298,7 @@ func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -318,7 +318,7 @@ func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_highAvailability(t *testing.T) {
+func TestAccSqlDatabaseInstance_highAvailability(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -327,7 +327,7 @@ func TestAccGoogleSqlDatabaseInstance_highAvailability(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -352,7 +352,7 @@ func TestAccGoogleSqlDatabaseInstance_highAvailability(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
+func TestAccSqlDatabaseInstance_diskspecs(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -361,7 +361,7 @@ func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -377,7 +377,7 @@ func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_maintenance(t *testing.T) {
+func TestAccSqlDatabaseInstance_maintenance(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -386,7 +386,7 @@ func TestAccGoogleSqlDatabaseInstance_maintenance(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -402,7 +402,7 @@ func TestAccGoogleSqlDatabaseInstance_maintenance(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
+func TestAccSqlDatabaseInstance_settings_upgrade(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -411,7 +411,7 @@ func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -437,7 +437,7 @@ func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabaseInstance_settingsDowngrade(t *testing.T) {
+func TestAccSqlDatabaseInstance_settingsDowngrade(t *testing.T) {
 	t.Parallel()
 
 	var instance sqladmin.DatabaseInstance
@@ -446,7 +446,7 @@ func TestAccGoogleSqlDatabaseInstance_settingsDowngrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -473,7 +473,7 @@ func TestAccGoogleSqlDatabaseInstance_settingsDowngrade(t *testing.T) {
 }
 
 // GH-4222
-func TestAccGoogleSqlDatabaseInstance_authNets(t *testing.T) {
+func TestAccSqlDatabaseInstance_authNets(t *testing.T) {
 	t.Parallel(
 	// var instance sqladmin.DatabaseInstance
 	)
@@ -483,7 +483,7 @@ func TestAccGoogleSqlDatabaseInstance_authNets(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -503,7 +503,7 @@ func TestAccGoogleSqlDatabaseInstance_authNets(t *testing.T) {
 
 // Tests that a SQL instance can be referenced from more than one other resource without
 // throwing an error during provisioning, see #9018.
-func TestAccGoogleSqlDatabaseInstance_multipleOperations(t *testing.T) {
+func TestAccSqlDatabaseInstance_multipleOperations(t *testing.T) {
 	t.Parallel()
 
 	databaseID, instanceID, userID := acctest.RandString(8), acctest.RandString(8), acctest.RandString(8)
@@ -511,7 +511,7 @@ func TestAccGoogleSqlDatabaseInstance_multipleOperations(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -725,7 +725,7 @@ func testAccCheckGoogleSqlDatabaseInstanceExists(n string,
 	}
 }
 
-func testAccGoogleSqlDatabaseInstanceDestroy(s *terraform.State) error {
+func testAccSqlDatabaseInstanceDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		config := testAccProvider.Meta().(*Config)
 		if rs.Type != "google_sql_database_instance" {

--- a/google/resource_sql_database_test.go
+++ b/google/resource_sql_database_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/sqladmin/v1beta4"
 )
 
-func TestAccGoogleSqlDatabase_basic(t *testing.T) {
+func TestAccSqlDatabase_basic(t *testing.T) {
 	t.Parallel()
 
 	var database sqladmin.Database
@@ -19,7 +19,7 @@ func TestAccGoogleSqlDatabase_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseDestroy,
+		CheckDestroy: testAccSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -35,7 +35,7 @@ func TestAccGoogleSqlDatabase_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlDatabase_update(t *testing.T) {
+func TestAccSqlDatabase_update(t *testing.T) {
 	t.Parallel()
 
 	var database sqladmin.Database
@@ -46,7 +46,7 @@ func TestAccGoogleSqlDatabase_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlDatabaseDestroy,
+		CheckDestroy: testAccSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(
@@ -129,7 +129,7 @@ func testAccCheckGoogleSqlDatabaseExists(n string,
 	}
 }
 
-func testAccGoogleSqlDatabaseDestroy(s *terraform.State) error {
+func testAccSqlDatabaseDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		config := testAccProvider.Meta().(*Config)
 		if rs.Type != "google_sql_database" {

--- a/google/resource_sql_user_test.go
+++ b/google/resource_sql_user_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleSqlUser_firstGen(t *testing.T) {
+func TestAccSqlUser_firstGen(t *testing.T) {
 	t.Parallel()
 
 	instance := acctest.RandomWithPrefix("i")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlUserDestroy,
+		CheckDestroy: testAccSqlUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleSqlUser_firstGen(instance, "password"),
@@ -44,14 +44,14 @@ func TestAccGoogleSqlUser_firstGen(t *testing.T) {
 	})
 }
 
-func TestAccGoogleSqlUser_secondGen(t *testing.T) {
+func TestAccSqlUser_secondGen(t *testing.T) {
 	t.Parallel()
 
 	instance := acctest.RandomWithPrefix("i")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleSqlUserDestroy,
+		CheckDestroy: testAccSqlUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleSqlUser_secondGen(instance, "password"),
@@ -100,7 +100,7 @@ func testAccCheckGoogleSqlUserExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccGoogleSqlUserDestroy(s *terraform.State) error {
+func testAccSqlUserDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		config := testAccProvider.Meta().(*Config)
 		if rs.Type != "google_sql_database" {

--- a/google/resource_storage_bucket_acl_test.go
+++ b/google/resource_storage_bucket_acl_test.go
@@ -25,7 +25,7 @@ func testBucketName() string {
 	return fmt.Sprintf("%s-%d", "tf-test-acl-bucket", acctest.RandInt())
 }
 
-func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
+func TestAccStorageBucketAcl_basic(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -33,7 +33,7 @@ func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
+		CheckDestroy: testAccStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsAclBasic1(bucketName),
@@ -46,7 +46,7 @@ func TestAccGoogleStorageBucketAcl_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
+func TestAccStorageBucketAcl_upgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -54,7 +54,7 @@ func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
+		CheckDestroy: testAccStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsAclBasic1(bucketName),
@@ -84,7 +84,7 @@ func TestAccGoogleStorageBucketAcl_upgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
+func TestAccStorageBucketAcl_downgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -92,7 +92,7 @@ func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
+		CheckDestroy: testAccStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsAclBasic2(bucketName),
@@ -122,14 +122,14 @@ func TestAccGoogleStorageBucketAcl_downgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageBucketAcl_predefined(t *testing.T) {
+func TestAccStorageBucketAcl_predefined(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageBucketAclDestroy,
+		CheckDestroy: testAccStorageBucketAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsAclPredefined(bucketName),
@@ -172,7 +172,7 @@ func testAccCheckGoogleStorageBucketAcl(bucket, roleEntityS string) resource.Tes
 	}
 }
 
-func testAccGoogleStorageBucketAclDestroy(s *terraform.State) error {
+func testAccStorageBucketAclDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {

--- a/google/resource_storage_bucket_iam_test.go
+++ b/google/resource_storage_bucket_iam_test.go
@@ -2,15 +2,16 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleStorageBucketIamBinding(t *testing.T) {
+func TestAccStorageBucketIamBinding(t *testing.T) {
 	t.Parallel()
 
 	bucket := acctest.RandomWithPrefix("tf-test")
@@ -22,14 +23,14 @@ func TestAccGoogleStorageBucketIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccGoogleStorageBucketIamBinding_basic(bucket, account),
+				Config: testAccStorageBucketIamBinding_basic(bucket, account),
 				Check: testAccCheckGoogleStorageBucketIam(bucket, "roles/storage.objectViewer", []string{
 					fmt.Sprintf("serviceAccount:%s-1@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
 				}),
 			},
 			{
 				// Test IAM Binding update
-				Config: testAccGoogleStorageBucketIamBinding_update(bucket, account),
+				Config: testAccStorageBucketIamBinding_update(bucket, account),
 				Check: testAccCheckGoogleStorageBucketIam(bucket, "roles/storage.objectViewer", []string{
 					fmt.Sprintf("serviceAccount:%s-1@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
 					fmt.Sprintf("serviceAccount:%s-2@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
@@ -39,7 +40,7 @@ func TestAccGoogleStorageBucketIamBinding(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageBucketIamMember(t *testing.T) {
+func TestAccStorageBucketIamMember(t *testing.T) {
 	t.Parallel()
 
 	bucket := acctest.RandomWithPrefix("tf-test")
@@ -51,7 +52,7 @@ func TestAccGoogleStorageBucketIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test Iam Member creation (no update for member, no need to test)
-				Config: testAccGoogleStorageBucketIamMember_basic(bucket, account),
+				Config: testAccStorageBucketIamMember_basic(bucket, account),
 				Check: testAccCheckGoogleStorageBucketIam(bucket, "roles/storage.admin", []string{
 					fmt.Sprintf("serviceAccount:%s-1@%s.iam.gserviceaccount.com", account, getTestProjectFromEnv()),
 				}),
@@ -85,7 +86,7 @@ func testAccCheckGoogleStorageBucketIam(bucket, role string, members []string) r
 	}
 }
 
-func testAccGoogleStorageBucketIamBinding_basic(bucket, account string) string {
+func testAccStorageBucketIamBinding_basic(bucket, account string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name = "%s"
@@ -106,7 +107,7 @@ resource "google_storage_bucket_iam_binding" "foo" {
 `, bucket, account)
 }
 
-func testAccGoogleStorageBucketIamBinding_update(bucket, account string) string {
+func testAccStorageBucketIamBinding_update(bucket, account string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name = "%s"
@@ -133,7 +134,7 @@ resource "google_storage_bucket_iam_binding" "foo" {
 `, bucket, account, account)
 }
 
-func testAccGoogleStorageBucketIamMember_basic(bucket, account string) string {
+func testAccStorageBucketIamMember_basic(bucket, account string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name = "%s"

--- a/google/resource_storage_bucket_object_test.go
+++ b/google/resource_storage_bucket_object_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"google.golang.org/api/storage/v1"
 	"os"
+
+	"google.golang.org/api/storage/v1"
 )
 
 const (
@@ -19,7 +20,7 @@ const (
 	content    = "now this is content!"
 )
 
-func TestAccGoogleStorageObject_basic(t *testing.T) {
+func TestAccStorageObject_basic(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -33,7 +34,7 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectBasic(bucketName, testFile.Name()),
@@ -43,7 +44,7 @@ func TestAccGoogleStorageObject_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_recreate(t *testing.T) {
+func TestAccStorageObject_recreate(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -64,7 +65,7 @@ func TestAccGoogleStorageObject_recreate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectBasic(bucketName, testFile.Name()),
@@ -84,7 +85,7 @@ func TestAccGoogleStorageObject_recreate(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_content(t *testing.T) {
+func TestAccStorageObject_content(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -98,7 +99,7 @@ func TestAccGoogleStorageObject_content(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectContent(bucketName),
@@ -114,7 +115,7 @@ func TestAccGoogleStorageObject_content(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
+func TestAccStorageObject_withContentCharacteristics(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -129,7 +130,7 @@ func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObject_optionalContentFields(
@@ -150,13 +151,13 @@ func TestAccGoogleStorageObject_withContentCharacteristics(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_dynamicContent(t *testing.T) {
+func TestAccStorageObject_dynamicContent(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObjectDynamicContent(testBucketName()),
@@ -171,7 +172,7 @@ func TestAccGoogleStorageObject_dynamicContent(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
+func TestAccStorageObject_cacheControl(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -186,7 +187,7 @@ func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObject_cacheControl(bucketName, testFile.Name(), cacheControl),
@@ -200,7 +201,7 @@ func TestAccGoogleStorageObject_cacheControl(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObject_storageClass(t *testing.T) {
+func TestAccStorageObject_storageClass(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -215,7 +216,7 @@ func TestAccGoogleStorageObject_storageClass(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectDestroy,
+		CheckDestroy: testAccStorageObjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageBucketsObject_storageClass(bucketName, storageClass),
@@ -250,7 +251,7 @@ func testAccCheckGoogleStorageObject(bucket, object, md5 string) resource.TestCh
 	}
 }
 
-func testAccGoogleStorageObjectDestroy(s *terraform.State) error {
+func testAccStorageObjectDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {

--- a/google/resource_storage_default_object_acl_test.go
+++ b/google/resource_storage_default_object_acl_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGoogleStorageDefaultObjectAcl_basic(t *testing.T) {
+func TestAccStorageDefaultObjectAcl_basic(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -16,7 +16,7 @@ func TestAccGoogleStorageDefaultObjectAcl_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
+		CheckDestroy: testAccStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic1, roleEntityBasic2),
@@ -29,7 +29,7 @@ func TestAccGoogleStorageDefaultObjectAcl_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
+func TestAccStorageDefaultObjectAcl_upgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -37,7 +37,7 @@ func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
+		CheckDestroy: testAccStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic1, roleEntityBasic2),
@@ -67,7 +67,7 @@ func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageDefaultObjectAcl_downgrade(t *testing.T) {
+func TestAccStorageDefaultObjectAcl_downgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -75,7 +75,7 @@ func TestAccGoogleStorageDefaultObjectAcl_downgrade(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
+		CheckDestroy: testAccStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic2, roleEntityBasic3_owner),
@@ -125,7 +125,7 @@ func testAccCheckGoogleStorageDefaultObjectAcl(bucket, roleEntityS string) resou
 	}
 }
 
-func testAccGoogleStorageDefaultObjectAclDestroy(s *terraform.State) error {
+func testAccStorageDefaultObjectAclDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {

--- a/google/resource_storage_notification_test.go
+++ b/google/resource_storage_notification_test.go
@@ -17,7 +17,7 @@ var (
 	payload           = "JSON_API_V1"
 )
 
-func TestAccGoogleStorageNotification_basic(t *testing.T) {
+func TestAccStorageNotification_basic(t *testing.T) {
 	t.Parallel()
 
 	skipIfEnvNotSet(t, "GOOGLE_PROJECT")
@@ -30,7 +30,7 @@ func TestAccGoogleStorageNotification_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageNotificationDestroy,
+		CheckDestroy: testAccStorageNotificationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageNotificationBasic(bucketName, topicName, topic),
@@ -61,7 +61,7 @@ func TestAccGoogleStorageNotification_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageNotification_withEventsAndAttributes(t *testing.T) {
+func TestAccStorageNotification_withEventsAndAttributes(t *testing.T) {
 	t.Parallel()
 
 	skipIfEnvNotSet(t, "GOOGLE_PROJECT")
@@ -76,7 +76,7 @@ func TestAccGoogleStorageNotification_withEventsAndAttributes(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageNotificationDestroy,
+		CheckDestroy: testAccStorageNotificationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageNotificationOptionalEventsAttributes(bucketName, topicName, topic, eventType1, eventType2),
@@ -104,7 +104,7 @@ func TestAccGoogleStorageNotification_withEventsAndAttributes(t *testing.T) {
 	})
 }
 
-func testAccGoogleStorageNotificationDestroy(s *terraform.State) error {
+func testAccStorageNotificationDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {

--- a/google/resource_storage_object_acl_test.go
+++ b/google/resource_storage_object_acl_test.go
@@ -19,7 +19,7 @@ func testAclObjectName() string {
 		rand.New(rand.NewSource(time.Now().UnixNano())).Int())
 }
 
-func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
+func TestAccStorageObjectAcl_basic(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -34,7 +34,7 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
+		CheckDestroy: testAccStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
@@ -49,7 +49,7 @@ func TestAccGoogleStorageObjectAcl_basic(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
+func TestAccStorageObjectAcl_upgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -64,7 +64,7 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
+		CheckDestroy: testAccStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
@@ -101,7 +101,7 @@ func TestAccGoogleStorageObjectAcl_upgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
+func TestAccStorageObjectAcl_downgrade(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -116,7 +116,7 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
+		CheckDestroy: testAccStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageObjectsAclBasic2(bucketName, objectName),
@@ -153,7 +153,7 @@ func TestAccGoogleStorageObjectAcl_downgrade(t *testing.T) {
 	})
 }
 
-func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
+func TestAccStorageObjectAcl_predefined(t *testing.T) {
 	t.Parallel()
 
 	bucketName := testBucketName()
@@ -168,7 +168,7 @@ func TestAccGoogleStorageObjectAcl_predefined(t *testing.T) {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageObjectAclDestroy,
+		CheckDestroy: testAccStorageObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testGoogleStorageObjectsAclPredefined(bucketName, objectName),
@@ -213,7 +213,7 @@ func testAccCheckGoogleStorageObjectAclDelete(bucket, object, roleEntityS string
 	}
 }
 
-func testAccGoogleStorageObjectAclDestroy(s *terraform.State) error {
+func testAccStorageObjectAclDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {


### PR DESCRIPTION
Some of our tests have the extra "Google" and others don't. Since we're in the google provider already, all our tests are implicitly Google-based, and so we should standardize on not putting the extra "Google" in.