### PR TITLE
Only check project if it's not present on the resource.

### DIFF
--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -406,17 +406,24 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d, fmt.Sprintf("Storage Bucket %q", d.Get("name").(string)))
 	}
 
-	log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
 	// We need to get the project associated with this bucket because otherwise import
 	// won't work properly.  That means we need to call the projects.get API with the
 	// project number, to get the project ID - there's no project ID field in the
-	// resource response.
-	log.Println("[TRACE] Fetching project ID.")
-	proj, err := config.clientCompute.Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
-	if err != nil {
-		return err
+	// resource response.  However, this requires a call to the Compute API, which
+	// would otherwise not be required for this resource.  So, we're going to
+	// intentionally check whether the project is set *on the resource*.  If it is,
+	// we will not try to fetch the project name.  If it is not, either because
+	// the user intends to use the default provider project, or because the resource
+	// is currently being imported, we will read it from the API.
+	if p, ok := d.GetOk("project"); ok && p != "" {
+		log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
+		proj, err := config.clientCompute.Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Bucket %v is in project number %v, which is project ID %s.\n", res.Name, res.ProjectNumber, proj.Name)
+		d.Set("project", proj.Name)
 	}
-	log.Printf("[DEBUG] Bucket %v is in project number %v, which is project ID %s.\n", res.Name, res.ProjectNumber, proj.Name)
 
 	// Update the bucket ID according to the resource ID
 	d.Set("self_link", res.SelfLink)
@@ -428,7 +435,6 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("versioning", flattenBucketVersioning(res.Versioning))
 	d.Set("lifecycle_rule", flattenBucketLifecycle(res.Lifecycle))
 	d.Set("labels", res.Labels)
-	d.Set("project", proj.Name)
 	d.SetId(res.Id)
 	return nil
 }

--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -415,7 +415,7 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	// we will not try to fetch the project name.  If it is not, either because
 	// the user intends to use the default provider project, or because the resource
 	// is currently being imported, we will read it from the API.
-	if p, ok := d.GetOk("project"); ok && p != "" {
+	if _, ok := d.GetOk("project"); !ok {
 		log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
 		proj, err := config.clientCompute.Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
 		if err != nil {

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -34,6 +34,8 @@ func TestAccStorageBucket_basic(t *testing.T) {
 						"google_storage_bucket.bucket", "location", "US"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "force_destroy", "false"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
 				),
 			},
 			resource.TestStep{
@@ -87,6 +89,8 @@ func TestAccStorageBucket_customAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "EU"),
 					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
+					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "force_destroy", "true"),
 				),
 			},
@@ -116,6 +120,8 @@ func TestAccStorageBucket_lifecycleRules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "lifecycle_rule.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -165,6 +171,8 @@ func TestAccStorageBucket_storageClass(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
+					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "MULTI_REGIONAL"),
 				),
 			},
@@ -174,6 +182,8 @@ func TestAccStorageBucket_storageClass(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
+					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "NEARLINE"),
 				),
 			},
@@ -182,6 +192,8 @@ func TestAccStorageBucket_storageClass(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "REGIONAL"),
 					resource.TestCheckResourceAttr(
@@ -224,6 +236,8 @@ func TestAccStorageBucket_update(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
+					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "US"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "force_destroy", "false"),
@@ -235,6 +249,8 @@ func TestAccStorageBucket_update(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
+					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "EU"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "force_destroy", "true"),
@@ -245,6 +261,8 @@ func TestAccStorageBucket_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", getTestProjectFromEnv()),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "EU"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Fixes #1089 by not requiring compute API unless the project needs to be read.  A bucket / project mapping can't be changed after the fact, so it should be safe, and tests (which cover imports) still pass:

```
TF_ACC=1 go test ./google -v -run=TestAccStorageBucket -timeout 120m
=== RUN   TestAccStorageBucket_basic
=== RUN   TestAccStorageBucket_lowercaseLocation
=== RUN   TestAccStorageBucket_customAttributes
=== RUN   TestAccStorageBucket_lifecycleRules
=== RUN   TestAccStorageBucket_storageClass
=== RUN   TestAccStorageBucket_update
=== RUN   TestAccStorageBucket_forceDestroy
=== RUN   TestAccStorageBucket_versioning
=== RUN   TestAccStorageBucket_logging
=== RUN   TestAccStorageBucket_cors
=== RUN   TestAccStorageBucket_labels
--- PASS: TestAccStorageBucket_basic (1.90s)
--- PASS: TestAccStorageBucket_storageClass (5.11s)
--- PASS: TestAccStorageBucket_customAttributes (4.95s)
--- PASS: TestAccStorageBucket_lifecycleRules (2.01s)
--- PASS: TestAccStorageBucket_lowercaseLocation (4.98s)
--- PASS: TestAccStorageBucket_forceDestroy (12.89s)
--- PASS: TestAccStorageBucket_update (22.06s)
--- PASS: TestAccStorageBucket_cors (10.57s)
--- PASS: TestAccStorageBucket_versioning (10.82s)
--- PASS: TestAccStorageBucket_logging (5.50s)
--- PASS: TestAccStorageBucket_labels (22.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 29.731s
```