### PR TITLE
Update `cluster_ipv4_cidr` For `google_container_cluster`

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -138,7 +138,6 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validateRFC1918Network(8, 32),
 			},
 
 			"description": {

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -134,10 +134,10 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"cluster_ipv4_cidr": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"description": {


### PR DESCRIPTION
This resolves #1132.

- remove CIDR validation check as the field can accept non-cidr values