### PR TITLE
Fix perpetual diff in #863.

### DIFF
--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -40,7 +40,7 @@ func resourceDnsRecordSet() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.Trim(old, `"`) == strings.Trim(new, `"`)
+					return strings.ToLower(strings.Trim(old, `"`)) == strings.ToLower(strings.Trim(new, `"`))
 				},
 			},
 

--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/dns/v1"
-	"strings"
 )
 
 func resourceDnsRecordSet() *schema.Resource {
@@ -37,6 +38,9 @@ func resourceDnsRecordSet() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.Trim(old, `"`) == strings.Trim(new, `"`)
 				},
 			},
 

--- a/google/resource_dns_record_set_test.go
+++ b/google/resource_dns_record_set_test.go
@@ -162,6 +162,26 @@ func TestAccDnsRecordSet_quotedTXT(t *testing.T) {
 	})
 }
 
+func TestAccDnsRecordSet_uppercaseMX(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-txt-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsRecordSet_uppercaseMX(zoneName, 300),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordSetExists(
+						"google_dns_record_set.foobar", zoneName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDnsRecordSetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -292,6 +312,29 @@ func testAccDnsRecordSet_quotedTXT(name string, ttl int) string {
 		name = "test-record.%s.hashicorptest.com."
 		type = "TXT"
 		rrdatas = ["test", "\"quoted test\""]
+		ttl = %d
+	}
+	`, name, name, name, ttl)
+}
+
+func testAccDnsRecordSet_uppercaseMX(name string, ttl int) string {
+	return fmt.Sprintf(`
+	resource "google_dns_managed_zone" "parent-zone" {
+		name = "%s"
+		dns_name = "%s.hashicorptest.com."
+		description = "Test Description"
+	}
+	resource "google_dns_record_set" "foobar" {
+		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
+		name = "test-record.%s.hashicorptest.com."
+		type = "MX"
+		rrdatas = [
+			"1 ASPMX.L.GOOGLE.COM.",
+			"5 ALT1.ASPMX.L.GOOGLE.COM.",
+			"5 ALT2.ASPMX.L.GOOGLE.COM.",
+			"10 ASPMX2.GOOGLEMAIL.COM.",
+			"10 ASPMX3.GOOGLEMAIL.COM.",
+		]
 		ttl = %d
 	}
 	`, name, name, name, ttl)

--- a/google/resource_dns_record_set_test.go
+++ b/google/resource_dns_record_set_test.go
@@ -142,6 +142,26 @@ func TestAccDnsRecordSet_nestedNS(t *testing.T) {
 	})
 }
 
+func TestAccDnsRecordSet_quotedTXT(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-txt-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsRecordSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsRecordSet_quotedTXT(zoneName, 300),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordSetExists(
+						"google_dns_record_set.foobar", zoneName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDnsRecordSetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -196,66 +216,83 @@ func testAccDnsRecordSet_basic(zoneName string, addr2 string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "hashicorptest.com."
+		dns_name = "%s.hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "test-record.hashicorptest.com."
+		name = "test-record.%s.hashicorptest.com."
 		type = "A"
 		rrdatas = ["127.0.0.1", "%s"]
 		ttl = %d
 	}
-	`, zoneName, addr2, ttl)
+	`, zoneName, zoneName, zoneName, addr2, ttl)
 }
 
 func testAccDnsRecordSet_ns(name string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "hashicorptest.com."
+		dns_name = "%s.hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "hashicorptest.com."
+		name = "%s.hashicorptest.com."
 		type = "NS"
 		rrdatas = ["ns.hashicorp.services.", "ns2.hashicorp.services."]
 		ttl = %d
 	}
-	`, name, ttl)
+	`, name, name, name, ttl)
 }
 
 func testAccDnsRecordSet_nestedNS(name string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "hashicorptest.com."
+		dns_name = "%s.hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "nested.hashicorptest.com."
+		name = "nested.%s.hashicorptest.com."
 		type = "NS"
 		rrdatas = ["ns.hashicorp.services.", "ns2.hashicorp.services."]
 		ttl = %d
 	}
-	`, name, ttl)
+	`, name, name, name, ttl)
 }
 
 func testAccDnsRecordSet_bigChange(zoneName string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "hashicorptest.com."
+		dns_name = "%s.hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "test-record.hashicorptest.com."
+		name = "test-record.%s.hashicorptest.com."
 		type = "CNAME"
 		rrdatas = ["www.terraform.io."]
 		ttl = %d
 	}
-	`, zoneName, ttl)
+	`, zoneName, zoneName, zoneName, ttl)
+}
+
+func testAccDnsRecordSet_quotedTXT(name string, ttl int) string {
+	return fmt.Sprintf(`
+	resource "google_dns_managed_zone" "parent-zone" {
+		name = "%s"
+		dns_name = "%s.hashicorptest.com."
+		description = "Test Description"
+	}
+	resource "google_dns_record_set" "foobar" {
+		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
+		name = "test-record.%s.hashicorptest.com."
+		type = "TXT"
+		rrdatas = ["test", "\"quoted test\""]
+		ttl = %d
+	}
+	`, name, name, name, ttl)
 }


### PR DESCRIPTION
This treats record set RRdata values as equivalent if they're quoted and
unquoted, as the GCP backend likes to return TXT records quoted.

It also updates the DNS name we're using to be a subdomain of
hashicorptest.com, as the tests started failing when run in parallel if
I tried adding the same zone domain multiple times.

Fixes #863 