### PR TITLE
Allow importing a pubsub topic using its full id

### DIFF
--- a/google/resource_pubsub_topic.go
+++ b/google/resource_pubsub_topic.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/pubsub/v1"
@@ -94,12 +95,16 @@ func resourcePubsubTopicDelete(d *schema.ResourceData, meta interface{}) error {
 func resourcePubsubTopicStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return nil, err
+	topicId := regexp.MustCompile("^projects/[^/]+/topics/[^/]+$")
+	if topicId.MatchString(d.Id()) {
+		return []*schema.ResourceData{d}, nil
 	}
 
-	id := fmt.Sprintf("projects/%s/topics/%s", project, d.Id())
+	if config.Project == "" {
+		return nil, fmt.Errorf("The default project for the provider must be set when using the `{name}` id format.")
+	}
+
+	id := fmt.Sprintf("projects/%s/topics/%s", config.Project, d.Id())
 
 	d.SetId(id)
 

--- a/google/resource_pubsub_topic_test.go
+++ b/google/resource_pubsub_topic_test.go
@@ -22,9 +22,17 @@ func TestAccPubsubTopic_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccPubsubTopic_basic(topicName),
 			},
+			// Check importing with just the topic name
 			resource.TestStep{
 				ResourceName:            "google_pubsub_topic.foo",
 				ImportStateId:           topicName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			// Check importing with the full resource id
+			resource.TestStep{
+				ResourceName:            "google_pubsub_topic.foo",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},

--- a/website/docs/r/pubsub_topic.html.markdown
+++ b/website/docs/r/pubsub_topic.html.markdown
@@ -3,7 +3,7 @@ layout: "google"
 page_title: "Google: google_pubsub_topic"
 sidebar_current: "docs-google-pubsub-topic-x"
 description: |-
-  Creates a topic in Google's pubsub  queueing system
+  Creates a topic in Google's pubsub queueing system
 ---
 
 # google\_pubsub\_topic
@@ -16,7 +16,7 @@ Creates a topic in Google's pubsub queueing system. For more information see
 ## Example Usage
 
 ```hcl
-resource "google_pubsub_topic" "default" {
+resource "google_pubsub_topic" "mytopic" {
   name = "default-topic"
 }
 ```
@@ -25,7 +25,7 @@ resource "google_pubsub_topic" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) A unique name for the resource, required by pubsub.
+* `name` - (Required) A unique name for the pubsub topic.
     Changing this forces a new resource to be created.
 
 - - -
@@ -39,8 +39,12 @@ Only the arguments listed above are exposed as attributes.
 
 ## Import
 
-Pubsub topics can be imported using the `name`, e.g.
+Pubsub topics can be imported using the `name` or full topic id, e.g.
 
 ```
-$ terraform import google_pubsub_topic.mytopic mytopic
+$ terraform import google_pubsub_topic.mytopic default-topic
 ```
+```
+$ terraform import google_pubsub_topic.mytopic projects/my-gcp-project/topics/default-topic
+```
+When importing using only the name, the provider project must be set.


### PR DESCRIPTION
This allows importing a pubsub topic that doesn't match the provider project. Previously, if you didn't have a provider project set, then this would fail due to the getProject call.

```
$ make testacc TEST=./google TESTARGS='-run=TestAccPubsubTopic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccPubsubTopic_basic -timeout 120m
=== RUN   TestAccPubsubTopic_basic
--- PASS: TestAccPubsubTopic_basic (3.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	4.073s
```