### PR TITLE
computeDiskUserRegexString in resource_compute_disk.go should also accept projectIds that contain ":" or "."

### DIFF
--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	computeDiskUserRegexString = "^(?:https://www.googleapis.com/compute/v1/projects/)?([-_a-zA-Z0-9:.]*)/zones/([-_a-zA-Z0-9]*)/instances/([-_a-zA-Z0-9]*)$"
+	computeDiskUserRegexString = "^(?:https://www.googleapis.com/compute/v1/projects/)?(" + ProjectRegex + ")/zones/([-_a-zA-Z0-9]*)/instances/([-_a-zA-Z0-9]*)$"
 )
 
 var (

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	computeDiskUserRegexString = "^(?:https://www.googleapis.com/compute/v1/projects/)?([-_a-zA-Z0-9]*)/zones/([-_a-zA-Z0-9]*)/instances/([-_a-zA-Z0-9]*)$"
+	computeDiskUserRegexString = "^(?:https://www.googleapis.com/compute/v1/projects/)?([-_a-zA-Z0-9:.]*)/zones/([-_a-zA-Z0-9]*)/instances/([-_a-zA-Z0-9]*)$"
 )
 
 var (

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -375,11 +375,17 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
 
 	shouldPass := []string{
+
 		"https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/123123/zones/us-central1/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/hashicorptest.net:project-123/zones/us-central1/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/123/zones/456/instances/789",
 	}
 
 	shouldFail := []string{
-		"https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central2/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/project#/zones/us-central1/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central#/instances/123",
+		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central1/instances/?",
 	}
 
 	for _, element := range shouldPass {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -386,6 +386,8 @@ func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
 		"https://www.googleapis.com/compute/v1/projects/project#/zones/us-central1/instances/123",
 		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central#/instances/123",
 		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central1/instances/?",
+		"foo.com:bar:baz",
+		"foo.com:",
 	}
 
 	for _, element := range shouldPass {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -386,8 +386,8 @@ func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
 		"https://www.googleapis.com/compute/v1/projects/project#/zones/us-central1/instances/123",
 		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central#/instances/123",
 		"https://www.googleapis.com/compute/v1/projects/project/zones/us-central1/instances/?",
-		"foo.com:bar:baz",
-		"foo.com:",
+		"https://www.googleapis.com/compute/v1/projects/foo.com:bar:baz/zones/us-central1/instances/?",
+		"https://www.googleapis.com/compute/v1/projects/foo.com:/zones/us-central1/instances/?",
 	}
 
 	for _, element := range shouldPass {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -372,6 +372,30 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
+
+	shouldPass := []string{
+		"https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1/instances/123",
+	}
+
+	shouldFail := []string{
+		"https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central2/instances/123",
+	}
+
+	for _, element := range shouldPass {
+		if !computeDiskUserRegex.MatchString(element) {
+			t.Error("computeDiskUserRegex should match on '" + element + "' but doesn't")
+		}
+	}
+
+	for _, element := range shouldFail {
+		if computeDiskUserRegex.MatchString(element) {
+			t.Error("computeDiskUserRegex shouldn't match on '" + element + "' but does")
+		}
+	}
+
+}
+
 func testAccCheckComputeDiskDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 


### PR DESCRIPTION
I ran into problems, when I had a project that was using a project ID in the format of "hashicorptest.net:my-project". 
The problem came up, when terraform tried to delete attached disks and threw an error like "Unknown user XXX of disk YYY"

This PR adds ":" and "." to the projectID part of computeDiskUserRegexString 