### PR TITLE
Make "schema" on "google_bigquery_table" ForceNew.

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -86,6 +86,7 @@ func resourceBigQueryTable() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.ValidateJsonString,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)


### PR DESCRIPTION
I'm not certain that this change should be merged - it solves one
problem but creates another one.  It is useful because most
changes to schema cannot be supported without ForceNew... but
some changes can be.  There's no way to know without sending
the change to BigQuery first, and by the time we send the change
and get back the not-updateable error, it's too late to request
a delete/create.

So we need to choose between two sub-par choices - getting errors
during `apply` because schema changes aren't possible, or ForceNew
being overapplied, including to some changes that shouldn't need it.

If merged, fixes #1144.