### PR TITLE
Datasource for Backend Services

### DIFF
--- a/google/data_source_google_compute_backend_service.go
+++ b/google/data_source_google_compute_backend_service.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleComputeBackendService() *schema.Resource {
+	dsSchema := datasourceSchemaFromResourceSchema(resourceComputeBackendService().Schema)
+
+	// Set 'Required' schema elements
+	addRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	addOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceComputeBackendServiceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{}) error {
+	serviceName := d.Get("name").(string)
+
+	d.SetId(serviceName)
+
+	return resourceComputeBackendServiceRead(d, meta)
+}

--- a/google/data_source_google_compute_backend_service_test.go
+++ b/google/data_source_google_compute_backend_service_test.go
@@ -1,0 +1,85 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceComputeBackendService_basic(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceComputeBackendService_basic(serviceName, checkName),
+				Check:  testAccDataSourceComputeBackendServiceCheck("data.google_compute_backend_service.baz", "google_compute_backend_service.foobar"),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeBackendServiceCheck(dsName, rsName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return fmt.Errorf("can't find resource called %s in state", rsName)
+		}
+
+		ds, ok := s.RootModule().Resources[dsName]
+		if !ok {
+			return fmt.Errorf("can't find data source called %s in state", dsName)
+		}
+
+		dsAttr := ds.Primary.Attributes
+		rsAttr := rs.Primary.Attributes
+
+		attrsToTest := []string{
+			"id",
+			"name",
+			"description",
+			"self_link",
+			"fingerprint",
+			"port_name",
+			"protocol",
+		}
+
+		for _, attrToTest := range attrsToTest {
+			if dsAttr[attrToTest] != rsAttr[attrToTest] {
+				return fmt.Errorf("%s is %s; want %s", attrToTest, dsAttr[attrToTest], rsAttr[attrToTest])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceComputeBackendService_basic(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  description   = "foobar backend service"
+  health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+data "google_compute_backend_service" "baz" {
+  name = "${google_compute_backend_service.foobar.name}"
+}
+`, serviceName, checkName)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -86,6 +86,7 @@ func Provider() terraform.ResourceProvider {
 			"google_organization":                    dataSourceGoogleOrganization(),
 			"google_storage_object_signed_url":       dataSourceGoogleSignedUrl(),
 			"google_storage_project_service_account": dataSourceGoogleStorageProjectServiceAccount(),
+			"google_compute_backend_service":         dataSourceGoogleComputeBackendService(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "google"
+page_title: "Google: google_compute_backend_service"
+sidebar_current: "docs-google-datasource-compute-backend-service"
+description: |-
+  Get information about a Backend Service.
+---
+
+# google\_compute\_backend\_service
+
+Provide acces to a Backend Service's attribute. For more information
+see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
+and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
+
+## Example Usage
+
+```tf
+data "google_compute_backend_service" "baz" {
+  name = "foobar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Backend Service.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `connection_draining_timeout_sec` - Time for which instance will be drained (not accept new connections, but still work to finish started ones).
+
+* `description` - Textual description for the Backend Service.
+
+* `enable_cdn` - Whether or not Cloud CDN is enabled on the Backend Service.
+
+* `fingerprint` - The fingerprint of the Backend Service.
+
+* `port_name` - The name of a service that has been added to an instance group in this backend.
+
+* `protocol` - The protocol for incoming requests.
+
+* `self_link` - The URI of the Backend Service.
+
+* `session_affinity` - The Backend Service session stickyness configuration.
+
+* `timeout_sec` - The number of seconds to wait for a backend to respond to a request before considering the request failed.
+
+* `backend` - The list of backends that serve this Backend Service.
+
+* `health_checks` - The list of HTTP/HTTPS health checks used by the Backend Service.

--- a/website/google.erb
+++ b/website/google.erb
@@ -62,6 +62,9 @@
       <li<%= sidebar_current("docs-google-datasource-container-cluster") %>>
       <a href="/docs/providers/google/d/google_container_cluster.html">google_container_cluster</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
+      <a href="/docs/providers/google/d/datasource_google_compute_backend_service.html">google_compute_backend_service</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-container-versions") %>>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>
       </li>


### PR DESCRIPTION
Exposes existing `google_compute_backend_service` as data sources.
This addresses #149 (except for `google_compute_region_backend_service`,
which is not covered here).

This allows, for instance, to collect a backend service's self_link and
use it from an other workspace/tfstate, sharing most of the
loadbalancers definition.

```
$ env GOOGLE_REGION=us-central1 make testacc TEST=./google TESTARGS='-run=TestAccGoogleComputeBackendService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccGoogleComputeBackendService_ -timeout 120m
=== RUN   TestAccGoogleComputeBackendService_basic
--- PASS: TestAccGoogleComputeBackendService_basic (45.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	45.105s
```