### PR TITLE
Loosen regex on projectId for importSpanner(Instance|Database)Id

### DIFF
--- a/google/resource_spanner_database.go
+++ b/google/resource_spanner_database.go
@@ -217,7 +217,7 @@ func (s spannerDatabaseId) databaseUri() string {
 
 func importSpannerDatabaseId(id string) (*spannerDatabaseId, error) {
 	if !regexp.MustCompile("^[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) &&
-		!regexp.MustCompile("^[a-z0-9-]+/[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
+		!regexp.MustCompile("^"+ProjectRegex+"/[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
 		return nil, fmt.Errorf("Invalid spanner database specifier. " +
 			"Expecting either {projectId}/{instanceId}/{dbId} OR " +
 			"{instanceId}/{dbId} (where project will be derived from the provider)")
@@ -234,7 +234,7 @@ func importSpannerDatabaseId(id string) (*spannerDatabaseId, error) {
 }
 
 func extractSpannerDatabaseId(id string) (*spannerDatabaseId, error) {
-	if !regexp.MustCompile("^[a-z0-9-]+/[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
+	if !regexp.MustCompile("^" + ProjectRegex + "/[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
 		return nil, fmt.Errorf("Invalid spanner id format, expecting {projectId}/{instanceId}/{databaseId}")
 	}
 	parts := strings.Split(id, "/")

--- a/google/resource_spanner_database_test.go
+++ b/google/resource_spanner_database_test.go
@@ -48,6 +48,37 @@ func TestImportSpannerDatabaseId_ProjectInstanceDB(t *testing.T) {
 	expectEquals(t, "database789", id.Database)
 }
 
+func TestImportSpannerDatabaseId_projectId(t *testing.T) {
+	shouldPass := []string{
+		"project-id/instance/database",
+		"123123/instance/123",
+		"hashicorptest.net:project-123/instance/123",
+		"123/456/789",
+	}
+
+	shouldFail := []string{
+		"project-id#/instance/database",
+		"project-id/instance#/database",
+		"project-id/instance/database#",
+		"hashicorptest.net:project-123:invalid:project/instance/123",
+		"hashicorptest.net:/instance/123",
+	}
+
+	for _, element := range shouldPass {
+		_, e := importSpannerDatabaseId(element)
+		if e != nil {
+			t.Error("importSpannerDatabaseId should pass on '" + element + "' but doesn't")
+		}
+	}
+
+	for _, element := range shouldFail {
+		_, e := importSpannerDatabaseId(element)
+		if e == nil {
+			t.Error("importSpannerDatabaseId should fail on '" + element + "' but doesn't")
+		}
+	}
+}
+
 func TestImportSpannerDatabaseId_invalidLeadingSlash(t *testing.T) {
 	id, e := importSpannerDatabaseId("/instance456/database789")
 	expectInvalidSpannerDbImportId(t, id, e)

--- a/google/resource_spanner_instance.go
+++ b/google/resource_spanner_instance.go
@@ -298,7 +298,7 @@ func (s spannerInstanceId) instanceConfigUri(c string) string {
 
 func importSpannerInstanceId(id string) (*spannerInstanceId, error) {
 	if !regexp.MustCompile("^[a-z0-9-]+$").Match([]byte(id)) &&
-		!regexp.MustCompile("^[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
+		!regexp.MustCompile("^"+ProjectRegex+"/[a-z0-9-]+$").Match([]byte(id)) {
 		return nil, fmt.Errorf("Invalid spanner instance specifier. " +
 			"Expecting either {projectId}/{instanceId} OR " +
 			"{instanceId} (where project is to be derived from that specified in provider)")
@@ -315,7 +315,7 @@ func importSpannerInstanceId(id string) (*spannerInstanceId, error) {
 }
 
 func extractSpannerInstanceId(id string) (*spannerInstanceId, error) {
-	if !regexp.MustCompile("^[a-z0-9-]+/[a-z0-9-]+$").Match([]byte(id)) {
+	if !regexp.MustCompile("^" + ProjectRegex + "/[a-z0-9-]+$").Match([]byte(id)) {
 		return nil, fmt.Errorf("Invalid spanner id format, expecting {projectId}/{instanceId}")
 	}
 	parts := strings.Split(id, "/")

--- a/google/resource_spanner_instance_test.go
+++ b/google/resource_spanner_instance_test.go
@@ -92,6 +92,36 @@ func TestImportSpannerInstanceId_invalidMultiSlash(t *testing.T) {
 	expectInvalidSpannerInstanceImport(t, sid, e)
 }
 
+func TestImportSpannerInstanceId_projectId(t *testing.T) {
+	shouldPass := []string{
+		"project-id/instance",
+		"123123/instance",
+		"hashicorptest.net:project-123/instance",
+		"123/456",
+	}
+
+	shouldFail := []string{
+		"project-id#/instance",
+		"project-id/instance#",
+		"hashicorptest.net:project-123:invalid:project/instance",
+		"hashicorptest.net:/instance",
+	}
+
+	for _, element := range shouldPass {
+		_, e := importSpannerInstanceId(element)
+		if e != nil {
+			t.Error("importSpannerInstanceId should pass on '" + element + "' but doesn't")
+		}
+	}
+
+	for _, element := range shouldFail {
+		_, e := importSpannerInstanceId(element)
+		if e == nil {
+			t.Error("importSpannerInstanceId should fail on '" + element + "' but doesn't")
+		}
+	}
+}
+
 func expectInvalidSpannerInstanceImport(t *testing.T, sid *spannerInstanceId, e error) {
 	if sid != nil {
 		t.Errorf("Expected spannerInstanceId to be nil")


### PR DESCRIPTION
This is basically the same as in
https://github.com/terraform-providers/terraform-provider-google/pull/1145
but for importSpannerDatabaseId & importSpannerInstanceId