### PR TITLE
Set ID for GKE resources before waiting

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -567,6 +567,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	d.SetId(clusterName)
+
 	// Wait until it's created
 	waitErr := containerSharedOperationWait(config, op, project, zoneName, "creating GKE cluster", timeoutInMinutes, 3)
 	if waitErr != nil {
@@ -576,8 +578,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[INFO] GKE cluster %s has been created", clusterName)
-
-	d.SetId(clusterName)
 
 	return resourceContainerClusterRead(d, meta)
 }

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -190,6 +190,8 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
+	d.SetId(fmt.Sprintf("%s/%s/%s", zone, cluster, nodePool.Name))
+
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
 	waitErr := containerSharedOperationWait(config, op, project, zone, "creating GKE NodePool", timeoutInMinutes, 3)
 	if waitErr != nil {
@@ -199,8 +201,6 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[INFO] GKE NodePool %s has been created", nodePool.Name)
-
-	d.SetId(fmt.Sprintf("%s/%s/%s", zone, cluster, nodePool.Name))
 
 	return resourceContainerNodePoolRead(d, meta)
 }


### PR DESCRIPTION
This allows Terraform to be aware of the resources existence in case the process ends before the resource has finished creating.