### PR TITLE
increase timeout for dataproc test jobs completing

### DIFF
--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -306,7 +306,7 @@ func testAccCheckDataprocJobCompletesSuccessfully(n string, job *dataproc.Job) r
 			return err
 		}
 
-		jobCompleteTimeoutMins := 3
+		jobCompleteTimeoutMins := 5
 		waitErr := dataprocJobOperationWait(config, region, project, job.Reference.JobId,
 			"Awaiting Dataproc job completion", jobCompleteTimeoutMins, 1)
 		if waitErr != nil {


### PR DESCRIPTION
This is one of two PRs that will hopefully stop the dataproc test flakiness. This one allows jobs to take 5 minutes to complete instead of 3.