### PR TITLE
Update to Cloud Functions Pub/Sub trigger event

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -267,7 +267,7 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 		// Make PubSub event publish as in https://cloud.google.com/functions/docs/calling/pubsub
 		function.EventTrigger = &cloudfunctions.EventTrigger{
 			// Other events are not supported
-			EventType: "providers/cloud.pubsub/eventTypes/topic.publish",
+			EventType: "google.pubsub.topic.publish",
 			// Must be like projects/PROJECT_ID/topics/NAME
 			// Topic must be in same project as function
 			Resource: fmt.Sprintf("projects/%s/topics/%s", project, v.(string)),
@@ -350,7 +350,7 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	if function.EventTrigger != nil {
 		switch function.EventTrigger.EventType {
 		// From https://github.com/google/google-api-go-client/blob/master/cloudfunctions/v1/cloudfunctions-gen.go#L335
-		case "providers/cloud.pubsub/eventTypes/topic.publish":
+		case "google.pubsub.topic.publish":
 			d.Set("trigger_topic", GetResourceNameFromSelfLink(function.EventTrigger.Resource))
 		case "providers/cloud.storage/eventTypes/object.change":
 			d.Set("trigger_bucket", GetResourceNameFromSelfLink(function.EventTrigger.Resource))

--- a/google/resource_cloudfunctions_function_test.go
+++ b/google/resource_cloudfunctions_function_test.go
@@ -296,8 +296,8 @@ func testAccCloudFunctionsFunctionTrigger(n int, function *cloudfunctions.CloudF
 			if function.EventTrigger == nil {
 				return fmt.Errorf("Expected EventTrigger to be set")
 			}
-			if strings.Index(function.EventTrigger.EventType, "cloud.pubsub") == -1 {
-				return fmt.Errorf("Expected cloud.pubsub EventType, found %s", function.EventTrigger.EventType)
+			if strings.Index(function.EventTrigger.EventType, "google.pubsub") == -1 {
+				return fmt.Errorf("Expected google.pubsub EventType, found %s", function.EventTrigger.EventType)
 			}
 		default:
 			return fmt.Errorf("testAccCloudFunctionsFunctionTrigger expects only FUNCTION_TRIGGER_HTTP, " +


### PR DESCRIPTION
The current `providers/cloud.pubsub/eventTypes/topic.publish` trigger event is marked as a legacy event type. There is no issue using it at the moment but is stated that it could be removed at a future date.

https://cloud.google.com/functions/docs/calling/pubsub#legacy_cloud_pubsub_triggers

There are some changes to the event object format that comes through on Pub/Sub messages. Although this doesn't matter for terraform, one thing to note is that functions that have been deployed using the legacy event type (before Feb 28) need to be deleted and redeployed in order to support the new event type. Any new deployments that occur after Feb 28 will use the new event type.

I've created an issue separately for updates to Cloud Storage event triggers: #1179

Here are some snippets from a GCP email I received highlighting these changes:

> Google Cloud Pub/Sub event format
Google Cloud Pub/Sub events will move to a new format to better and more logically organize related attributes. Specifically, all metadata such as [eventId] and [timestamp] will be moved exclusively into the context property of the event parameter. See our documentation on how to use the new events. After February 28, 2018, deploying a new function with the 'gcloud beta functions deploy --trigger-topic' command will cause it to receive this new format.

> What happens to my running functions?
Your running functions will not be affected by either of these changes at this time. They will continue to receive events as usual and with the current schema. These older, legacy event types, however, are no longer being actively supported and will remain in beta indefinitely.

> What if I want to update one of my functions that is using a legacy event type?
After February 28, 2018, attempting to update a function that is using a legacy event type via the --trigger-bucket or --trigger-topic flag in gcloud will not succeed. If you want to update one of your existing functions, we have preserved the legacy Cloud Storage and legacy Pub/Sub events. These will allow you to continue to maintain your code even after the gcloud SDK behavior is changed to take advantage of the new Cloud Storage and Cloud Pub/Sub events.

