### PR TITLE
expect 4 labels in dataproc cluster test

### DIFF
--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -410,14 +410,14 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.with_labels", &cluster),
 
-					// We only provide one, but GCP adds two, so expect 3. This means unfortunately a
+					// We only provide one, but GCP adds three, so expect 4. This means unfortunately a
 					// diff will exist unless the user adds these in. An alternative approach would
 					// be to follow the same approach as properties, i.e. split in into labels
 					// and override_labels
 					//
 					// The config is currently configured with ignore_changes = ["labels"] to handle this
 					//
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "4"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
 				),
 			},


### PR DESCRIPTION
Output from GET shows that GCP is now adding 3 additional labels:
```
    "labels": {
      "goog-dataproc-cluster-name": "dproc-cluster-test-vnk8apsiya",
      "goog-dataproc-cluster-uuid": "c394589d-2c00-4d00-9794-dbbd4ad7fc00",
      "goog-dataproc-location": "us-central1",
      "key1": "value1"
    }
```