### PR TITLE
Force validation of region for cloudfunctions.

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -229,6 +229,8 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	// We do this extra validation here since most regions are not valid, and the
 	// error message that Cloud Functions has for "wrong region" is not specific.
+	// Provider-level region fetching skips validation, because it's not possible
+	// for the provider-level region to know about the field-level validator.
 	_, errs := validCloudFunctionRegion(region, "region")
 	if len(errs) > 0 {
 		return errs[0]


### PR DESCRIPTION
This fixes #1173.  The issue is that neither the user nor I knew that `australia-southeast1` is not a valid region for cloud functions, which meant that the 400 error they got back was confusing to both of us (and my lack of repro, since my test cases run in `us-central1`, was doubly confusing).  Since `ValidateFunc`s don't run on `d.Set()`, calling the function explicitly is the way to go to make this error obvious right away.

I tested this locally with the user's repro case, and the error is clear and helpful.