### PR TITLE
Properly delete dataflow jobs in the event of terraform destroy.

### DIFF
--- a/google/resource_dataflow_job.go
+++ b/google/resource_dataflow_job.go
@@ -184,9 +184,15 @@ func resourceDataflowJobDelete(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
-	d.SetId("")
 
-	return nil
+	// Only remove the job from state if it's actually successfully canceled.
+	if _, ok := dataflowTerminalStatesMap[d.Get("state").(string)]; ok {
+		d.SetId("")
+		return nil
+	}
+
+	return fmt.Errorf("There was a problem canceling the dataflow job '%s' - the final state was %s.", d.Id(), d.Get("state").(string))
+
 }
 
 func mapOnDelete(policy string) (string, error) {

--- a/google/resource_dataflow_job_test.go
+++ b/google/resource_dataflow_job_test.go
@@ -36,7 +36,7 @@ func testAccCheckDataflowJobDestroy(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 		job, err := config.clientDataflow.Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
 		if job != nil {
-			if _, ok := dataflowTerminalStatesMap[job.CurrentState]; ok {
+			if _, ok := dataflowTerminalStatesMap[job.CurrentState]; !ok {
 				return fmt.Errorf("Job still present")
 			}
 		} else if err != nil {


### PR DESCRIPTION
This fixes #1191 - in the event that the job wasn't properly canceled, we'll get an error message, and now we'll actually tear down the jobs.