### PR TITLE
Fix managed zone tests.

### DIFF
--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -802,7 +802,7 @@ func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc
 func flattenInstanceGroupConfig(d *schema.ResourceData, icg *dataproc.InstanceGroupConfig) []map[string]interface{} {
 	disk := map[string]interface{}{}
 	data := map[string]interface{}{
-	//"instance_names": []string{},
+		//"instance_names": []string{},
 	}
 
 	if icg != nil {

--- a/google/resource_dns_managed_zone_test.go
+++ b/google/resource_dns_managed_zone_test.go
@@ -82,6 +82,6 @@ func testAccDnsManagedZone_basic() string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
 	name = "mzone-test-%s"
-	dns_name = "hashicorptest.com."
-}`, acctest.RandString(10))
+	dns_name = "tf-acctest-%s.hashicorptest.com."
+}`, acctest.RandString(10), acctest.RandString(10))
 }


### PR DESCRIPTION
Managed zone tests are failing because we're attempting to use the naked
domain as the managed zone, when it's already being managed by GCP. By
making a subdomain the managed zone, we avoid this problem.

Tests:

```
make testacc TEST=./google TESTARGS='-run=TestAccDnsManagedZone'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccDnsManagedZone -timeout 120m
=== RUN   TestAccDnsManagedZone_importBasic
=== PAUSE TestAccDnsManagedZone_importBasic
=== RUN   TestAccDnsManagedZone_basic
=== PAUSE TestAccDnsManagedZone_basic
=== CONT  TestAccDnsManagedZone_importBasic
=== CONT  TestAccDnsManagedZone_basic
--- PASS: TestAccDnsManagedZone_basic (1.43s)
--- PASS: TestAccDnsManagedZone_importBasic (1.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 1.469s
```