### PR TITLE
Remove commented out code.

### DIFF
--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -801,9 +801,7 @@ func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc
 
 func flattenInstanceGroupConfig(d *schema.ResourceData, icg *dataproc.InstanceGroupConfig) []map[string]interface{} {
 	disk := map[string]interface{}{}
-	data := map[string]interface{}{
-	//"instance_names": []string{},
-	}
+	data := map[string]interface{}{}
 
 	if icg != nil {
 		data["num_instances"] = icg.NumInstances


### PR DESCRIPTION
We don't really need dead code, and this is breaking our `make fmt` test
because it gets indented differently in go 1.10 from in go 1.9.