### PR TITLE
Add deletion protection to resource_compute_instance

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -552,6 +552,12 @@ func resourceComputeInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"deletion_protection": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"label_fingerprint": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -717,19 +723,20 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	// Create the instance information
 	instance := &computeBeta.Instance{
-		CanIpForward:      d.Get("can_ip_forward").(bool),
-		Description:       d.Get("description").(string),
-		Disks:             disks,
-		MachineType:       machineType.SelfLink,
-		Metadata:          metadata,
-		Name:              d.Get("name").(string),
-		NetworkInterfaces: networkInterfaces,
-		Tags:              resourceInstanceTags(d),
-		Labels:            expandLabels(d),
-		ServiceAccounts:   expandServiceAccounts(d.Get("service_account").([]interface{})),
-		GuestAccelerators: accels,
-		MinCpuPlatform:    d.Get("min_cpu_platform").(string),
-		Scheduling:        scheduling,
+		CanIpForward:       d.Get("can_ip_forward").(bool),
+		Description:        d.Get("description").(string),
+		Disks:              disks,
+		MachineType:        machineType.SelfLink,
+		Metadata:           metadata,
+		Name:               d.Get("name").(string),
+		NetworkInterfaces:  networkInterfaces,
+		Tags:               resourceInstanceTags(d),
+		Labels:             expandLabels(d),
+		ServiceAccounts:    expandServiceAccounts(d.Get("service_account").([]interface{})),
+		GuestAccelerators:  accels,
+		MinCpuPlatform:     d.Get("min_cpu_platform").(string),
+		Scheduling:         scheduling,
+		DeletionProtection: d.Get("deletion_protection").(bool),
 	}
 
 	log.Printf("[INFO] Requesting instance creation")
@@ -898,6 +905,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators))
 	d.Set("cpu_platform", instance.CpuPlatform)
 	d.Set("min_cpu_platform", instance.MinCpuPlatform)
+	d.Set("deletion_protection", instance.DeletionProtection)
 	d.Set("self_link", ConvertSelfLinkToV1(instance.SelfLink))
 	d.Set("instance_id", fmt.Sprintf("%d", instance.Id))
 	d.Set("project", project)
@@ -1266,6 +1274,22 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		oScopes := oList[0].(map[string]interface{})["scopes"].(*schema.Set)
 		nScopes := nList[0].(map[string]interface{})["scopes"].(*schema.Set)
 		scopesChange = !oScopes.Equal(nScopes)
+	}
+
+	if d.HasChange("deletion_protection") {
+		nDeletionProtection := d.Get("deletion_protection").(bool)
+
+		op, err := config.clientCompute.Instances.SetDeletionProtection(project, zone, d.Id()).DeletionProtection(nDeletionProtection).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating deletion protection flag: %s", err)
+		}
+
+		opErr := computeOperationWaitTime(config.clientCompute, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		if opErr != nil {
+			return opErr
+		}
+
+		d.SetPartial("deletion_protection")
 	}
 
 	// Attributes which can only be changed if the instance is stopped

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -90,6 +90,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A brief description of this resource.
 
+* `deletion_protection` - (Optional) Enable deletion protection on this instance. Defaults to false.
+
 * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the instance.


### PR DESCRIPTION
- [x] Added `deletion_protection` boolean parameter for `google_compute_instance` resources (in `resource_compute_instance.go`).
  - Parameter is optional, default value is false
- [x] Updated documentation to describe functionality
- [x] Add unit tests to confirm functionality

This resolves #956. 