### PR TITLE
Suppress perpetual diff on logging sink filter with surrounding whitespaces

### DIFF
--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -96,10 +96,6 @@ func TestAccLoggingBillingAccountSink_heredoc(t *testing.T) {
 					testAccCheckLoggingBillingAccountSinkExists("google_logging_billing_account_sink.heredoc", &sink),
 					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.heredoc"),
 				),
-			}, {
-				ResourceName:      "google_logging_billing_account_sink.heredoc",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -96,6 +96,10 @@ func TestAccLoggingBillingAccountSink_heredoc(t *testing.T) {
 					testAccCheckLoggingBillingAccountSinkExists("google_logging_billing_account_sink.heredoc", &sink),
 					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_folder_sink_test.go
+++ b/google/resource_logging_folder_sink_test.go
@@ -127,10 +127,6 @@ func TestAccLoggingFolderSink_heredoc(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.heredoc", &sink),
 					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.heredoc"),
 				),
-			}, {
-				ResourceName:      "google_logging_folder_sink.heredoc",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_folder_sink_test.go
+++ b/google/resource_logging_folder_sink_test.go
@@ -127,6 +127,10 @@ func TestAccLoggingFolderSink_heredoc(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.heredoc", &sink),
 					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_folder_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_organization_sink_test.go
+++ b/google/resource_logging_organization_sink_test.go
@@ -97,10 +97,6 @@ func TestAccLoggingOrganizationSink_heredoc(t *testing.T) {
 					testAccCheckLoggingOrganizationSinkExists("google_logging_organization_sink.heredoc", &sink),
 					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.heredoc"),
 				),
-			}, {
-				ResourceName:      "google_logging_organization_sink.heredoc",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_organization_sink_test.go
+++ b/google/resource_logging_organization_sink_test.go
@@ -97,6 +97,10 @@ func TestAccLoggingOrganizationSink_heredoc(t *testing.T) {
 					testAccCheckLoggingOrganizationSinkExists("google_logging_organization_sink.heredoc", &sink),
 					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_project_sink_test.go
+++ b/google/resource_logging_project_sink_test.go
@@ -121,6 +121,10 @@ func TestAccLoggingProjectSink_heredoc(t *testing.T) {
 					testAccCheckLoggingProjectSinkExists("google_logging_project_sink.heredoc", &sink),
 					testAccCheckLoggingProjectSink(&sink, "google_logging_project_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_project_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -19,8 +19,9 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 		},
 
 		"filter": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:             schema.TypeString,
+			Optional:         true,
+			DiffSuppressFunc: optionalSurroundingSpacesSuppress,
 		},
 
 		"writer_identity": {

--- a/google/utils.go
+++ b/google/utils.go
@@ -184,6 +184,10 @@ func optionalPrefixSuppress(prefix string) schema.SchemaDiffSuppressFunc {
 	}
 }
 
+func optionalSurroundingSpacesSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return strings.TrimSpace(old) == strings.TrimSpace(new)
+}
+
 func emptyOrDefaultStringSuppress(defaultVal string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		return (old == "" && new == defaultVal) || (new == "" && old == defaultVal)


### PR DESCRIPTION
This pull request fixes annoying perpetual diff on `google_logging_project_sink` with `filter` attribute defined using heredoc.

```hcl
resource "google_logging_project_sink" "gke_error" {
	name = "gke_error"
	project = "..."
	destination = "..."
	filter = <<-EOS
		(resource.type=\"gke_cluster\" OR resource.type=\"container\")
		AND severity>=ERROR
		EOS
}
```

Previously, this gives following plan:
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

~ google_logging_project_sink.foo
     filter:            "(resource.type=\"gke_cluster\" OR resource.type=\"container\")\nAND severity>=ERROR" => "(resource.type=\"gke_cluster\" OR resource.type=\"container\")\nAND severity>=ERROR\n"

Plan: 0 to add, 1 to change, 0 to destroy.
```

(See trailing `"\n"`)

It'll be fixed into:
```
No changes. Infrastructure is up-to-date.
```
