### PR TITLE
Add debian-cloud to the list of acceptable projects for images.

### DIFF
--- a/google/resource_google_organization_policy_test.go
+++ b/google/resource_google_organization_policy_test.go
@@ -90,7 +90,7 @@ func TestAccOrganizationPolicy_list_allowSome(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationPolicy_list_allowSome(org, project),
-				Check:  testAccCheckGoogleOrganizationListPolicyAllowedValues("list", []string{"projects/" + project}),
+				Check:  testAccCheckGoogleOrganizationListPolicyAllowedValues("list", []string{"projects/" + project, "projects/debian-cloud"}),
 			},
 			{
 				ResourceName:      "google_organization_policy.list",
@@ -294,6 +294,7 @@ resource "google_organization_policy" "list" {
 		allow {
 			values = [
 				"projects/%s",
+				"projects/debian-cloud"
 			]
 		}
   }


### PR DESCRIPTION
We have a set of constraints we apply to our organization as part of a
test for the organization policy functionality. This can get stuck from
quota issues, or it can run in parallel to other tests. The policy
currently limits the projects that images can be used from to the
project running the test, but a lot of our tests use images from the
debian-cloud project. This just updates the policy to allow debian-cloud
images to be used, too, so even if the policy doesn't properly get
cleaned up or if it runs in parallel with other tests, our tests are
still within the policy.

The real fix for this is to set up a separate org for testing, so we're
not modifying the test environment under running tests, but that'll take
a bit more time, so this is the patchfix until that can happen.