### PR TITLE
Add deletion_protection wrapper for deleting instance

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -91,6 +91,7 @@ The following arguments are supported:
 * `description` - (Optional) A brief description of this resource.
 
 * `deletion_protection` - (Optional) Enable deletion protection on this instance. Defaults to false.
+    **Note:** you must disable deletion protection before removing the resource (e.g., via `terraform destroy`), or the instance cannot be deleted and the Terraform run will not complete successfully.
 
 * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
 


### PR DESCRIPTION
- Throws a friendly error to the user immediately instead of waiting for the API to return a 400

Previously:
```
* google_compute_instance.instance_delprotect: Error deleting instance: googleapi: Error 400: Invalid resource usage: 'Resource cannot be deleted if it's protected against deletion.'., invalidResourceUsage
```

Now:
```
* google_compute_instance.instance_delprotect: Cannot delete instance instance-delprotect: instance Deletion Protection is enabled. Set deletion_protection to false for this resource and run "terraform apply" before attempting to delete it.
```

@ndmckinley this is a follow-on to #1205 to add friendly handling when you try to delete an instance with `deletion_protection = true`.