### PR TITLE
Fix our calls to d.Set that returned errors.

### DIFF
--- a/google/data_source_google_compute_image.go
+++ b/google/data_source_google_compute_image.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -149,7 +150,7 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("creation_timestamp", image.CreationTimestamp)
 	d.Set("description", image.Description)
 	d.Set("disk_size_gb", image.DiskSizeGb)
-	d.Set("image_id", image.Id)
+	d.Set("image_id", strconv.FormatUint(image.Id, 10))
 	d.Set("image_encryption_key_sha256", ieks256)
 	d.Set("label_fingerprint", image.LabelFingerprint)
 	d.Set("labels", image.Labels)

--- a/google/data_source_google_compute_region_instance_group.go
+++ b/google/data_source_google_compute_region_instance_group.go
@@ -3,13 +3,14 @@ package google
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	compute "google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
 	"log"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func dataSourceGoogleComputeRegionInstanceGroup() *schema.Resource {
@@ -137,7 +138,6 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 	} else {
 		d.Set("instances", flattenInstancesWithNamedPorts(members.Items))
 	}
-	d.Set("kind", instanceGroup.Kind)
 	d.SetId(strconv.FormatUint(instanceGroup.Id, 16))
 	d.Set("self_link", instanceGroup.SelfLink)
 	d.Set("name", name)

--- a/google/data_source_google_compute_region_instance_group_test.go
+++ b/google/data_source_google_compute_region_instance_group_test.go
@@ -2,21 +2,23 @@ package google
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"testing"
 )
 
 func TestAccDataSourceRegionInstanceGroup(t *testing.T) {
 	t.Parallel()
+	name := "acctest-" + acctest.RandString(6)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceRegionInstanceGroup_basic("foobarbaz"),
+				Config: testAccDataSourceRegionInstanceGroup_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.google_compute_region_instance_group.data_source", "name", "foobarbaz"),
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group.data_source", "name", name),
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group.data_source", "project", getTestProjectFromEnv()),
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group.data_source", "instances.#", "10")),
 			},

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -417,8 +417,8 @@ func expandBackends(configured []interface{}) ([]*compute.Backend, error) {
 	return backends, nil
 }
 
-func flattenBackends(backends []*compute.Backend) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(backends))
+func flattenBackends(backends []*compute.Backend) *schema.Set {
+	result := make([]interface{}, 0, len(backends))
 
 	for _, b := range backends {
 		data := make(map[string]interface{})
@@ -433,7 +433,7 @@ func flattenBackends(backends []*compute.Backend) []map[string]interface{} {
 		result = append(result, data)
 	}
 
-	return result
+	return schema.NewSet(resourceGoogleComputeBackendServiceBackendHash, result)
 }
 
 func expandBackendService(d *schema.ResourceData) (*compute.BackendService, error) {

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -119,7 +119,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error setting metadata: %s", err)
 	}
 
-	d.Set("project", project)
+	d.Set("project", projectID)
 	d.SetId("common_metadata")
 
 	return nil

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -211,7 +211,10 @@ func resourceComputeRegionBackendServiceRead(d *schema.ResourceData, meta interf
 	d.Set("connection_draining_timeout_sec", service.ConnectionDraining.DrainingTimeoutSec)
 	d.Set("fingerprint", service.Fingerprint)
 	d.Set("self_link", service.SelfLink)
-	d.Set("backend", flattenBackends(service.Backends))
+	err = d.Set("backend", flattenRegionBackends(service.Backends))
+	if err != nil {
+		return err
+	}
 	d.Set("health_checks", service.HealthChecks)
 	d.Set("project", project)
 	d.Set("region", region)
@@ -334,4 +337,18 @@ func resourceGoogleComputeRegionBackendServiceBackendHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func flattenRegionBackends(backends []*compute.Backend) *schema.Set {
+	result := make([]interface{}, 0, len(backends))
+
+	for _, b := range backends {
+		data := make(map[string]interface{})
+
+		data["description"] = b.Description
+		data["group"] = b.Group
+		result = append(result, data)
+	}
+
+	return schema.NewSet(resourceGoogleComputeRegionBackendServiceBackendHash, result)
 }

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -701,7 +701,10 @@ func resourceDataprocClusterRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	d.Set("cluster_config", cfg)
+	err = d.Set("cluster_config", cfg)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -724,7 +727,7 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		if err != nil {
 			return nil, err
 		}
-		data["intialization_action"] = val
+		data["initialization_action"] = val
 	}
 	return []map[string]interface{}{data}, nil
 }


### PR DESCRIPTION
We had several calls to `d.Set` that returned errors we weren't
catching, that turning on the panic flag for the tests caught. This PR
addresses them, and fixes the one test that was not safe to run in
parallel because it relied on a hardcoded name being unique.

This is largely just removing calls to `d.Set` for fields that don't
exist in the Schema, fixing how Sets get set, correcting typos, and
converting types.