### PR TITLE
Back out the Set changes from #1217.

### DIFF
--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -417,8 +417,8 @@ func expandBackends(configured []interface{}) ([]*compute.Backend, error) {
 	return backends, nil
 }
 
-func flattenBackends(backends []*compute.Backend) *schema.Set {
-	result := make([]interface{}, 0, len(backends))
+func flattenBackends(backends []*compute.Backend) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(backends))
 
 	for _, b := range backends {
 		data := make(map[string]interface{})
@@ -433,7 +433,7 @@ func flattenBackends(backends []*compute.Backend) *schema.Set {
 		result = append(result, data)
 	}
 
-	return schema.NewSet(resourceGoogleComputeBackendServiceBackendHash, result)
+	return result
 }
 
 func expandBackendService(d *schema.ResourceData) (*compute.BackendService, error) {

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -339,8 +339,8 @@ func resourceGoogleComputeRegionBackendServiceBackendHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func flattenRegionBackends(backends []*compute.Backend) *schema.Set {
-	result := make([]interface{}, 0, len(backends))
+func flattenRegionBackends(backends []*compute.Backend) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(backends))
 
 	for _, b := range backends {
 		data := make(map[string]interface{})
@@ -350,5 +350,5 @@ func flattenRegionBackends(backends []*compute.Backend) *schema.Set {
 		result = append(result, data)
 	}
 
-	return schema.NewSet(resourceGoogleComputeRegionBackendServiceBackendHash, result)
+	return result
 }


### PR DESCRIPTION
PR #1217 mistakenly updated the Set logic when flattening backends,
which caused some cascading errors and wasn't strictly necessary to
resolve the issue at hand. This backs out those changes, and instead
makes the smallest possible change to resolve the initial error, by
separating the logic for flattening regional backends from the logic for
flattening global backends.

Test output:

```
make testacc TEST=./google TESTARGS='-run=TestAccComputeBackendService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeBackendService_ -timeout 120m
=== RUN   TestAccComputeBackendService_basic
=== PAUSE TestAccComputeBackendService_basic
=== RUN   TestAccComputeBackendService_withBackend
=== PAUSE TestAccComputeBackendService_withBackend
=== RUN   TestAccComputeBackendService_withBackendAndIAP
--- PASS: TestAccComputeBackendService_withBackendAndIAP (168.60s)
=== RUN   TestAccComputeBackendService_updatePreservesOptionalParameters
=== PAUSE TestAccComputeBackendService_updatePreservesOptionalParameters
=== RUN   TestAccComputeBackendService_withConnectionDraining
=== PAUSE TestAccComputeBackendService_withConnectionDraining
=== RUN   TestAccComputeBackendService_withConnectionDrainingAndUpdate
=== PAUSE TestAccComputeBackendService_withConnectionDrainingAndUpdate
=== RUN   TestAccComputeBackendService_withHttpsHealthCheck
=== PAUSE TestAccComputeBackendService_withHttpsHealthCheck
=== RUN   TestAccComputeBackendService_withCdnPolicy
=== PAUSE TestAccComputeBackendService_withCdnPolicy
=== RUN   TestAccComputeBackendService_withCDNEnabled
=== PAUSE TestAccComputeBackendService_withCDNEnabled
=== RUN   TestAccComputeBackendService_withSessionAffinity
=== PAUSE TestAccComputeBackendService_withSessionAffinity
=== CONT  TestAccComputeBackendService_basic
=== CONT  TestAccComputeBackendService_withHttpsHealthCheck
=== CONT  TestAccComputeBackendService_withSessionAffinity
=== CONT  TestAccComputeBackendService_withConnectionDrainingAndUpdate
--- PASS: TestAccComputeBackendService_withHttpsHealthCheck (45.76s)
=== CONT  TestAccComputeBackendService_withConnectionDraining
--- PASS: TestAccComputeBackendService_withSessionAffinity (57.48s)
=== CONT  TestAccComputeBackendService_updatePreservesOptionalParameters
--- PASS: TestAccComputeBackendService_withConnectionDrainingAndUpdate (57.51s)
=== CONT  TestAccComputeBackendService_withBackend
--- PASS: TestAccComputeBackendService_basic (68.80s)
=== CONT  TestAccComputeBackendService_withCDNEnabled
--- PASS: TestAccComputeBackendService_withConnectionDraining (45.53s)
=== CONT  TestAccComputeBackendService_withCdnPolicy
--- PASS: TestAccComputeBackendService_withCDNEnabled (45.47s)
--- PASS: TestAccComputeBackendService_updatePreservesOptionalParameters (57.37s)
--- PASS: TestAccComputeBackendService_withCdnPolicy (45.84s)
--- PASS: TestAccComputeBackendService_withBackend (157.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 383.407s

make testacc TEST=./google TESTARGS='-run=TestAccComputeRegionBackendService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeRegionBackendService_ -timeout 120m
=== RUN   TestAccComputeRegionBackendService_basic
=== PAUSE TestAccComputeRegionBackendService_basic
=== RUN   TestAccComputeRegionBackendService_withBackend
=== PAUSE TestAccComputeRegionBackendService_withBackend
=== RUN   TestAccComputeRegionBackendService_withBackendAndUpdate
=== PAUSE TestAccComputeRegionBackendService_withBackendAndUpdate
=== RUN   TestAccComputeRegionBackendService_withConnectionDraining
=== PAUSE TestAccComputeRegionBackendService_withConnectionDraining
=== RUN   TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate
=== PAUSE TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate
=== RUN   TestAccComputeRegionBackendService_withSessionAffinity
=== PAUSE TestAccComputeRegionBackendService_withSessionAffinity
=== CONT  TestAccComputeRegionBackendService_basic
=== CONT  TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate
=== CONT  TestAccComputeRegionBackendService_withBackendAndUpdate
=== CONT  TestAccComputeRegionBackendService_withConnectionDraining
--- PASS: TestAccComputeRegionBackendService_withConnectionDraining (46.13s)
=== CONT  TestAccComputeRegionBackendService_withSessionAffinity
--- PASS: TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate (58.53s)
=== CONT  TestAccComputeRegionBackendService_withBackend
--- PASS: TestAccComputeRegionBackendService_basic (69.53s)
--- PASS: TestAccComputeRegionBackendService_withSessionAffinity (45.58s)
--- PASS: TestAccComputeRegionBackendService_withBackendAndUpdate (192.94s)
--- PASS: TestAccComputeRegionBackendService_withBackend (155.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 213.699s
```