### PR TITLE
Add wait_for_instances field to IGM and self_link option to the IG data source

### DIFF
--- a/google/data_source_google_compute_instance_group.go
+++ b/google/data_source_google_compute_instance_group.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -11,14 +12,23 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 		Read: dataSourceComputeInstanceGroupRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"self_link"},
+			},
+
+			"self_link": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name", "zone"},
 			},
 
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"self_link"},
 			},
 
 			"project": {
@@ -62,11 +72,6 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 				Computed: true,
 			},
 
-			"self_link": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"size": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -76,14 +81,25 @@ func dataSourceGoogleComputeInstanceGroup() *schema.Resource {
 }
 
 func dataSourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
-
-	zone, err := getZone(d, meta.(*Config))
-	if err != nil {
-		return err
+	config := meta.(*Config)
+	if name, ok := d.GetOk("name"); ok {
+		zone, err := getZone(d, config)
+		if err != nil {
+			return err
+		}
+		d.SetId(fmt.Sprintf("%s/%s", zone, name.(string)))
+	} else if selfLink, ok := d.GetOk("self_link"); ok {
+		parsed, err := ParseInstanceGroupFieldValue(selfLink.(string), d, config)
+		if err != nil {
+			return err
+		}
+		d.Set("name", parsed.Name)
+		d.Set("zone", parsed.Zone)
+		d.Set("project", parsed.Project)
+		d.SetId(fmt.Sprintf("%s/%s", parsed.Zone, parsed.Name))
+	} else {
+		return errors.New("Must provide either `self_link` or `zone/name`")
 	}
-	name := d.Get("name").(string)
-
-	d.SetId(fmt.Sprintf("%s/%s", zone, name))
 
 	return resourceComputeInstanceGroupRead(d, meta)
 }

--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -58,6 +58,10 @@ func ParseMachineTypesFieldValue(machineType string, d TerraformResourceData, co
 	return parseZonalFieldValue("machineTypes", machineType, "project", "zone", d, config, false)
 }
 
+func ParseInstanceGroupFieldValue(instanceGroup string, d TerraformResourceData, config *Config) (*ZonalFieldValue, error) {
+	return parseZonalFieldValue("instanceGroups", instanceGroup, "project", "zone", d, config, false)
+}
+
 // ------------------------------------------------------------
 // Base helpers used to create helpers for specific fields.
 // ------------------------------------------------------------

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -450,8 +450,9 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			Timeout: d.Timeout(schema.TimeoutCreate),
 		}
 		_, err := conf.WaitForState()
-		// If err is nil, success.
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 
@@ -197,6 +198,11 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
+			"wait_for_instances": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -312,18 +318,18 @@ func flattenNamedPortsBeta(namedPorts []*computeBeta.NamedPort) []map[string]int
 
 }
 
-func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
+func getManager(d *schema.ResourceData, meta interface{}) (*computeBeta.InstanceGroupManager, error) {
 	computeApiVersion := getComputeApiVersion(d, InstanceGroupManagerBaseApiVersion, InstanceGroupManagerVersionedFeatures)
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	region, err := getRegion(d, config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	manager := &computeBeta.InstanceGroupManager{}
@@ -339,7 +345,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			v1Manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {
-				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
+				return nil, handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
@@ -348,7 +354,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			resource, e = getZonalResourceFromRegion(getInstanceGroupManager, region, config.clientCompute, project)
 
 			if e != nil {
-				return e
+				return nil, e
 			}
 
 			v1Manager = resource.(*compute.InstanceGroupManager)
@@ -359,12 +365,12 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 			// The resource doesn't exist anymore
 			d.SetId("")
-			return nil
+			return nil, nil
 		}
 
 		err = Convert(v1Manager, manager)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 	case v0beta:
@@ -378,7 +384,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			v0betaManager, e = config.clientComputeBeta.InstanceGroupManagers.Get(project, zone, d.Id()).Do()
 
 			if e != nil {
-				return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
+				return nil, handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 			}
 		} else {
 			// If the resource was imported, the only info we have is the ID. Try to find the resource
@@ -386,7 +392,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			var resource interface{}
 			resource, e = getZonalBetaResourceFromRegion(getInstanceGroupManager, region, config.clientComputeBeta, project)
 			if e != nil {
-				return e
+				return nil, e
 			}
 
 			v0betaManager = resource.(*computeBeta.InstanceGroupManager)
@@ -397,10 +403,24 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 			// The resource doesn't exist anymore
 			d.SetId("")
-			return nil
+			return nil, nil
 		}
 
 		manager = v0betaManager
+	}
+	return manager, nil
+}
+
+func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	manager, err := getManager(d, meta)
+	if err != nil {
+		return err
 	}
 
 	d.Set("base_instance_name", manager.BaseInstanceName)
@@ -421,6 +441,18 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	}
 	d.Set("update_strategy", update_strategy.(string))
 	d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies))
+
+	if d.Get("wait_for_instances").(bool) {
+		conf := resource.StateChangeConf{
+			Pending: []string{"creating", "error"},
+			Target:  []string{"created"},
+			Refresh: waitForInstancesRefreshFunc(getManager, d, meta),
+			Timeout: d.Timeout(schema.TimeoutCreate),
+		}
+		_, err := conf.WaitForState()
+		// If err is nil, success.
+		return err
+	}
 
 	return nil
 }

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -302,8 +302,9 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 			Timeout: d.Timeout(schema.TimeoutCreate),
 		}
 		_, err := conf.WaitForState()
-		// If err is nil, success.
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -219,7 +219,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 
 type getInstanceManagerFunc func(*schema.ResourceData, interface{}) (*computeBeta.InstanceGroupManager, error)
 
-func getManager(d *schema.ResourceData, meta interface{}) (*computeBeta.InstanceGroupManager, error) {
+func getRegionalManager(d *schema.ResourceData, meta interface{}) (*computeBeta.InstanceGroupManager, error) {
 	computeApiVersion := getComputeApiVersion(d, RegionInstanceGroupManagerBaseApiVersion, RegionInstanceGroupManagerVersionedFeatures)
 	config := meta.(*Config)
 
@@ -257,17 +257,17 @@ func waitForInstancesRefreshFunc(f getInstanceManagerFunc, d *schema.ResourceDat
 			log.Printf("[WARNING] Error in fetching manager while waiting for instances to come up: %s\n", err)
 			return nil, "error", err
 		}
-		if creatingCount := m.CurrentActions.Creating + m.CurrentActions.CreatingWithoutRetries; creatingCount > 0 {
-			return creatingCount, "creating", nil
+		if done := m.CurrentActions.None; done < m.TargetSize {
+			return done, "creating", nil
 		} else {
-			return creatingCount, "created", nil
+			return done, "created", nil
 		}
 	}
 }
 
 func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	manager, err := getManager(d, meta)
+	manager, err := getRegionalManager(d, meta)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 		conf := resource.StateChangeConf{
 			Pending: []string{"creating", "error"},
 			Target:  []string{"created"},
-			Refresh: waitForInstancesRefreshFunc(getManager, d, meta),
+			Refresh: waitForInstancesRefreshFunc(getRegionalManager, d, meta),
 			Timeout: d.Timeout(schema.TimeoutCreate),
 		}
 		_, err := conf.WaitForState()

--- a/website/docs/d/google_compute_instance_group.html.markdown
+++ b/website/docs/d/google_compute_instance_group.html.markdown
@@ -23,14 +23,15 @@ data "google_compute_instance_group" "all" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the instance group.
-
-* `zone` - (Required) The zone of the instance group.
-
-- - -
+* `name` - (Optional) The name of the instance group. Either `name` or `self_link` must be provided.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
+
+* `self_link` - (Optional) The self link of the instance group. Either `name` or `self_link` must be provided.
+
+* `zone` - (Optional) The zone of the instance group. If referencing the instance group by name
+    and `zone` is not provided, the provider zone is used.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -101,6 +101,10 @@ The following arguments are supported:
     instances in the group are added. Updating the target pools attribute does
     not affect existing instances.
 
+* `wait_for_instances` - (Optional) Whether to wait for all instances to be created/updated before
+    returning. Note that if this is set to true and the operation does not succeed, Terraform will
+    continue trying until it times out.
+
 ---
 
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -95,6 +95,10 @@ The following arguments are supported:
     instances in the group are added. Updating the target pools attribute does
     not affect existing instances.
 
+* `wait_for_instances` - (Optional) Whether to wait for all instances to be created/updated before
+    returning. Note that if this is set to true and the operation does not succeed, Terraform will
+    continue trying until it times out.
+
 ---
 
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance


### PR DESCRIPTION
Fixes #1213.

(even though it's two changes, doing it in a single PR enables the test I wanted to write)

```
$ make testacc TEST=./google TESTARGS='-run=TestAccDataSourceGoogleComputeInstanceGroup_fromIGM'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccDataSourceGoogleComputeInstanceGroup_fromIGM -timeout 120m
=== RUN   TestAccDataSourceGoogleComputeInstanceGroup_fromIGM
=== PAUSE TestAccDataSourceGoogleComputeInstanceGroup_fromIGM
=== CONT  TestAccDataSourceGoogleComputeInstanceGroup_fromIGM
--- PASS: TestAccDataSourceGoogleComputeInstanceGroup_fromIGM (121.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	121.848s
```