### PR TITLE
Set wait_for_instances when importing IGMs, make defaults match

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -27,7 +27,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 		Update: resourceComputeInstanceGroupManagerUpdate,
 		Delete: resourceComputeInstanceGroupManagerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceInstanceGroupManagerStateImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -201,7 +201,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"wait_for_instances": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 		},
 	}
@@ -901,4 +901,9 @@ func flattenAutoHealingPolicies(autoHealingPolicies []*computeBeta.InstanceGroup
 		autoHealingPoliciesSchema = append(autoHealingPoliciesSchema, data)
 	}
 	return autoHealingPoliciesSchema
+}
+
+func resourceInstanceGroupManagerStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("wait_for_instances", false)
+	return []*schema.ResourceData{d}, nil
 }

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -28,7 +28,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 		Update: resourceComputeRegionInstanceGroupManagerUpdate,
 		Delete: resourceComputeRegionInstanceGroupManagerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceRegionInstanceGroupManagerStateImporter,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -567,4 +567,9 @@ func hashZoneFromSelfLinkOrResourceName(value interface{}) int {
 	resource := parts[len(parts)-1]
 
 	return hashcode.String(resource)
+}
+
+func resourceRegionInstanceGroupManagerStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("wait_for_instances", false)
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This fixes `TestAccInstanceGroupManager_basic`, which is currently failing in CI.

While doing so, I realized the default for `wait_for_instances` was true for IGMs but false for regional IGMs so I adjusted it to false to match.