### PR TITLE
Add time partitioning field to google_bigquery_table resource

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -440,10 +440,9 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 
 func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interface{} {
 	result := map[string]interface{}{"type": tp.Type}
-	result["field"] = tp.Type
 
-	if tp.Type != "" {
-		result["field"] = tp.Type
+	if tp.Field != "" {
+		result["field"] = tp.Field
 	}
 
 	if tp.ExpirationMs != 0 {

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -148,6 +148,7 @@ func resourceBigQueryTable() *schema.Resource {
 						"field": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -141,6 +141,14 @@ func resourceBigQueryTable() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"DAY"}, false),
 						},
+
+						// Type: [Optional] The field used to determine how to create a time-based
+						// partition. If time-based partitioning is enabled without this value, the
+						// table is partitioned based on the load time.
+						"field": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -419,6 +427,10 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 	raw := configured.([]interface{})[0].(map[string]interface{})
 	tp := &bigquery.TimePartitioning{Type: raw["type"].(string)}
 
+	if v, ok := raw["field"]; ok {
+		tp.Field = v.(string)
+	}
+
 	if v, ok := raw["expiration_ms"]; ok {
 		tp.ExpirationMs = int64(v.(int))
 	}
@@ -428,6 +440,11 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 
 func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interface{} {
 	result := map[string]interface{}{"type": tp.Type}
+	result["field"] = tp.Type
+
+	if tp.Type != "" {
+		result["field"] = tp.Type
+	}
 
 	if tp.ExpirationMs != 0 {
 		result["expiration_ms"] = tp.ExpirationMs

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -37,13 +37,6 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccBigQueryTableWithTimePartitioningField(datasetID, tableID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccBigQueryTableExists(resourceName),
-				),
-			},
-
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -209,10 +202,15 @@ resource "google_bigquery_table" "test" {
 
   time_partitioning {
     type = "DAY"
+    field = "ts"	
   }
 
   schema = <<EOH
 [
+  {
+    "name": "ts",
+    "type": "TIMESTAMP"
+  },
   {
     "name": "city",
     "type": "RECORD",
@@ -232,44 +230,6 @@ resource "google_bigquery_table" "test" {
         ]
       }
     ]
-  }
-]
-EOH
-}`, datasetID, tableID)
-}
-
-func testAccBigQueryTableWithTimePartitioningField(datasetID, tableID string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-  dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-  table_id   = "%s"
-  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
-
-  time_partitioning {
-    type = "DAY"
-    field = "ts"	
-  }
-
-  schema = <<EOH
-[
-  {
-    "name": "ts",
-    "type": "TIMESTAMP"
-  },
-  {
-    "name": "column1",
-    "type": "STRING"
-  },
-  {
-    "name": "column2",
-    "type": "INTEGER"
-  },
-  {
-    "name": "column4",
-    "type": "STRING"
   }
 ]
 EOH

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -36,21 +36,7 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 						"google_bigquery_table.test"),
 				),
 			},
-		},
-	})
-}
 
-func TestAccBigQueryTable_TimePartitioningField(t *testing.T) {
-	t.Parallel()
-
-	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBigQueryTableDestroy,
-		Steps: []resource.TestStep{
 			{
 				Config: testAccBigQueryTableWithTimePartitioningField(datasetID, tableID),
 				Check: resource.ComposeTestCheckFunc(

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccBigQueryTable_Basic(t *testing.T) {
 	t.Parallel()
 
+	resourceName := "google_bigquery_table.test"
 	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
@@ -24,25 +25,28 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 			{
 				Config: testAccBigQueryTable(datasetID, tableID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccBigQueryTableExists(
-						"google_bigquery_table.test"),
+					testAccBigQueryTableExists(resourceName),
 				),
 			},
 
 			{
 				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccBigQueryTableExists(
-						"google_bigquery_table.test"),
+					testAccBigQueryTableExists(resourceName),
 				),
 			},
 
 			{
 				Config: testAccBigQueryTableWithTimePartitioningField(datasetID, tableID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccBigQueryTableExists(
-						"google_bigquery_table.test"),
+					testAccBigQueryTableExists(resourceName),
 				),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -81,6 +81,10 @@ The `time_partitioning` block supports:
 * `expiration_ms` -  (Optional) Number of milliseconds for which to keep the
     storage for a partition.
 
+* `field` - (Optional) The field used to determine how to create a time-based
+    partition. If time-based partitioning is enabled without this value, the
+    table is partitioned based on the load time.
+
 * `type` - (Required) The only type supported is DAY, which will generate
     one partition per day based on data loading time.
 


### PR DESCRIPTION
Add time partitioning field to [google_bigquery_table](https://www.terraform.io/docs/providers/google/r/bigquery_table.html) resource. This field is available on type [`TimePartitioning`](https://godoc.org/cloud.google.com/go/bigquery#TimePartitioning) from package [`bigquery`](https://godoc.org/cloud.google.com/go/bigquery):

```go
type TimePartitioning struct {
    ...

    // If empty, the table is partitioned by pseudo column '_PARTITIONTIME'; if set, the
    // table is partitioned by this field. The field must be a top-level TIMESTAMP or
    // DATE field. Its mode must be NULLABLE or REQUIRED.
    Field string
}
```