### PR TITLE
allow setting service account email for keys

### DIFF
--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/encryption"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -17,10 +18,9 @@ func resourceGoogleServiceAccountKey() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			// Required
 			"service_account_id": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateRegexp(ServiceAccountLinkRegex),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			// Optional
 			"key_algorithm": &schema.Schema{
@@ -89,6 +89,9 @@ func resourceGoogleServiceAccountKeyCreate(d *schema.ResourceData, meta interfac
 	config := meta.(*Config)
 
 	serviceAccount := d.Get("service_account_id").(string)
+	if !strings.HasPrefix(serviceAccount, "projects/") {
+		serviceAccount = "projects/-/serviceAccounts/" + serviceAccount
+	}
 
 	r := &iam.CreateServiceAccountKeyRequest{
 		KeyAlgorithm:   d.Get("key_algorithm").(string),

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -20,7 +20,7 @@ resource "google_service_account" "acceptance" {
 }
 
 resource "google_service_account_key" "acceptance" {
-  service_account_id = "${google_service_account.acceptance.id}"
+  service_account_id = "${google_service_account.acceptance.name}"
   public_key_type = "TYPE_X509_PEM_FILE"
 }
 ```
@@ -33,7 +33,7 @@ resource "google_service_account" "myaccount" {
   display_name = "My Service Account"
 }
 resource "google_service_account_key" "mykey" {
-  service_account_id = "${google_service_account.myaccount.id}"
+  service_account_id = "${google_service_account.myaccount.name}"
 }
 resource "kubernetes_secret" "google-application-credentials" {
   metadata {
@@ -54,7 +54,7 @@ resource "google_service_account" "acceptance" {
 }
 
 resource "google_service_account_key" "acceptance" {
-  service_account_id = "${google_service_account.acceptance.id}"
+  service_account_id = "${google_service_account.acceptance.name}"
   pgp_key = "keybase:keybaseusername"
   public_key_type = "TYPE_X509_PEM_FILE"
 }
@@ -64,7 +64,9 @@ resource "google_service_account_key" "acceptance" {
 
 The following arguments are supported:
 
-* `service_account_id` - (Required) The Service account id of the Key Pair.
+* `service_account_id` - (Required) The Service account id of the Key Pair. This can be a string in the format
+`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the email address or
+unique id of the service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
 
 * `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
 Valid values are listed at


### PR DESCRIPTION
Fixes #1248 by allowing the `service_account_id` field to just be the email/unique id of the service account so users don't have to construct the `projects/PROJECT/serviceAccounts/ACCOUNT` string.

Also changes places where we refer to the id of the service account resource, because that's generally not a great idea- people should be referring to values of documented fields instead.

I also took out the validation completely for this field since the unique ids don't have a documented format.