### PR TITLE
Set isn't a valid key for a TypeMap

### DIFF
--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -111,7 +111,6 @@ func resourceComputeDisk() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 
 			"label_fingerprint": &schema.Schema{


### PR DESCRIPTION
This line wasn't doing anything so we might as well get rid of it.  :)