### PR TITLE
Escape the display name in active folder data source (in case of spaces, etc)

### DIFF
--- a/google/data_source_google_active_folder.go
+++ b/google/data_source_google_active_folder.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
@@ -34,7 +35,7 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 	parent := d.Get("parent").(string)
 	displayName := d.Get("display_name").(string)
 
-	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, displayName)
+	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, url.QueryEscape(displayName))
 	searchRequest := &resourceManagerV2Beta1.SearchFoldersRequest{
 		Query: queryString,
 	}

--- a/google/data_source_google_active_folder.go
+++ b/google/data_source_google_active_folder.go
@@ -44,12 +44,12 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 		return handleNotFoundError(err, d, fmt.Sprintf("Folder Not Found : %s", displayName))
 	}
 
-	folders := searchResponse.Folders
-	if len(folders) != 1 {
-		return fmt.Errorf("More than one folder found")
+	for _, folder := range searchResponse.Folders {
+		if folder.DisplayName == displayName {
+			d.SetId(folder.Name)
+			d.Set("name", folder.Name)
+			return nil
+		}
 	}
-
-	d.SetId(folders[0].Name)
-	d.Set("name", folders[0].Name)
-	return nil
+	return fmt.Errorf("Folder not found")
 }

--- a/google/data_source_google_active_folder_test.go
+++ b/google/data_source_google_active_folder_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceGoogleActiveFolder(t *testing.T) {
 				Config: testAccDataSourceGoogleActiveFolderConfig(parent, displayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGoogleActiveFolderCheck("data.google_active_folder.my_folder", "google_folder.foobar"),
+					testAccDataSourceGoogleActiveFolderCheck("data.google_active_folder.my_folder_space", "google_folder.foobar_space"),
 				),
 			},
 		},
@@ -69,6 +70,16 @@ resource "google_folder" "foobar" {
 data "google_active_folder" "my_folder" {
   parent = "${google_folder.foobar.parent}"
   display_name = "${google_folder.foobar.display_name}"
+}
+
+resource "google_folder" "foobar_space" {
+  parent = "%s"
+  display_name = "Space %s"
+}
+
+data "google_active_folder" "my_folder_space" {
+  parent = "${google_folder.foobar_space.parent}"
+  display_name = "${google_folder.foobar_space.display_name}"
 }
 `, parent, displayName)
 }

--- a/google/data_source_google_active_folder_test.go
+++ b/google/data_source_google_active_folder_test.go
@@ -81,5 +81,5 @@ data "google_active_folder" "my_folder_space" {
   parent = "${google_folder.foobar_space.parent}"
   display_name = "${google_folder.foobar_space.display_name}"
 }
-`, parent, displayName)
+`, parent, displayName, parent, displayName)
 }

--- a/google/data_source_google_active_folder_test.go
+++ b/google/data_source_google_active_folder_test.go
@@ -13,17 +13,24 @@ func TestAccDataSourceGoogleActiveFolder(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 
 	parent := fmt.Sprintf("organizations/%s", org)
-	displayName := "terraform-test-" + acctest.RandString(10)
+	suffix := acctest.RandString(10)
+	folderResource := "google_folder.foobar"
+	dataSource := "data.google_active_folder.my_folder"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceGoogleActiveFolderConfig(parent, displayName),
+				Config: testAccDataSourceGoogleActiveFolderConfig(parent, "terraform-test-"+suffix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceGoogleActiveFolderCheck("data.google_active_folder.my_folder", "google_folder.foobar"),
-					testAccDataSourceGoogleActiveFolderCheck("data.google_active_folder.my_folder_space", "google_folder.foobar_space"),
+					testAccDataSourceGoogleActiveFolderCheck(dataSource, folderResource),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDataSourceGoogleActiveFolderConfig(parent, "terraform test "+suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleActiveFolderCheck(dataSource, folderResource),
 				),
 			},
 		},
@@ -71,15 +78,5 @@ data "google_active_folder" "my_folder" {
   parent = "${google_folder.foobar.parent}"
   display_name = "${google_folder.foobar.display_name}"
 }
-
-resource "google_folder" "foobar_space" {
-  parent = "%s"
-  display_name = "Space %s"
-}
-
-data "google_active_folder" "my_folder_space" {
-  parent = "${google_folder.foobar_space.parent}"
-  display_name = "${google_folder.foobar_space.display_name}"
-}
-`, parent, displayName, parent, displayName)
+`, parent, displayName)
 }


### PR DESCRIPTION
Folders can have spaces in them. This change makes it so that the active_folder data source can correctly query for these.