### PR TITLE
Fix IAM policy deletion/read for deleted resources 

### DIFF
--- a/google/iam_folder.go
+++ b/google/iam_folder.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
-	"google.golang.org/api/googleapi"
 )
 
 var IamFolderSchema = map[string]*schema.Schema{

--- a/google/iam_kms_crypto_key.go
+++ b/google/iam_kms_crypto_key.go
@@ -26,7 +26,7 @@ func NewKmsCryptoKeyIamUpdater(d *schema.ResourceData, config *Config) (Resource
 	cryptoKeyId, err := parseKmsCryptoKeyId(cryptoKey, config)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing resource ID for for %s: %s", cryptoKey, err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error parsing resource ID for for %s: {{err}}", cryptoKey), err)
 	}
 
 	return &KmsCryptoKeyIamUpdater{
@@ -44,13 +44,13 @@ func (u *KmsCryptoKeyIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.P
 	p, err := u.Config.clientKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(u.resourceId).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	cloudResourcePolicy, err := kmsToResourceManagerPolicy(p)
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return cloudResourcePolicy, nil
@@ -60,7 +60,7 @@ func (u *KmsCryptoKeyIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanag
 	kmsPolicy, err := resourceManagerToKmsPolicy(policy)
 
 	if err != nil {
-		return fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	_, err = u.Config.clientKms.Projects.Locations.KeyRings.CryptoKeys.SetIamPolicy(u.resourceId, &cloudkms.SetIamPolicyRequest{
@@ -68,7 +68,7 @@ func (u *KmsCryptoKeyIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanag
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil

--- a/google/iam_kms_key_ring.go
+++ b/google/iam_kms_key_ring.go
@@ -26,7 +26,7 @@ func NewKmsKeyRingIamUpdater(d *schema.ResourceData, config *Config) (ResourceIa
 	keyRingId, err := parseKmsKeyRingId(keyRing, config)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing resource ID for for %s: %s", keyRing, err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error parsing resource ID for for %s: {{err}}", keyRing), err)
 	}
 
 	return &KmsKeyRingIamUpdater{
@@ -44,13 +44,13 @@ func (u *KmsKeyRingIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Pol
 	p, err := u.Config.clientKms.Projects.Locations.KeyRings.GetIamPolicy(u.resourceId).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	cloudResourcePolicy, err := kmsToResourceManagerPolicy(p)
 
 	if err != nil {
-		return nil, fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return cloudResourcePolicy, nil
@@ -60,7 +60,7 @@ func (u *KmsKeyRingIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager
 	kmsPolicy, err := resourceManagerToKmsPolicy(policy)
 
 	if err != nil {
-		return fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	_, err = u.Config.clientKms.Projects.Locations.KeyRings.SetIamPolicy(u.resourceId, &cloudkms.SetIamPolicyRequest{
@@ -68,7 +68,7 @@ func (u *KmsKeyRingIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func resourceManagerToKmsPolicy(p *cloudresourcemanager.Policy) (*cloudkms.Polic
 	out := &cloudkms.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a v1 policy to a kms policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a v1 policy to a kms policy: {{err}}", err)
 	}
 	return out, nil
 }
@@ -99,7 +99,7 @@ func kmsToResourceManagerPolicy(p *cloudkms.Policy) (*cloudresourcemanager.Polic
 	out := &cloudresourcemanager.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a kms policy to a v1 policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a kms policy to a v1 policy: {{err}}", err)
 	}
 	return out, nil
 }

--- a/google/iam_organization.go
+++ b/google/iam_organization.go
@@ -35,7 +35,7 @@ func OrgIdParseFunc(d *schema.ResourceData, _ *Config) error {
 func (u *OrganizationIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
 	p, err := u.Config.clientResourceManager.Organizations.GetIamPolicy("organizations/"+u.resourceId, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return p, nil
@@ -47,7 +47,7 @@ func (u *OrganizationIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanag
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil

--- a/google/iam_project.go
+++ b/google/iam_project.go
@@ -42,7 +42,7 @@ func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy
 		&cloudresourcemanager.GetIamPolicyRequest{}).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return p, nil
@@ -54,7 +54,7 @@ func (u *ProjectIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Po
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil

--- a/google/iam_pubsub_subscription.go
+++ b/google/iam_pubsub_subscription.go
@@ -51,7 +51,7 @@ func (u *PubsubSubscriptionIamUpdater) GetResourceIamPolicy() (*cloudresourceman
 	p, err := u.Config.clientPubsub.Projects.Subscriptions.GetIamPolicy(u.subscription).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	v1Policy, err := pubsubToResourceManagerPolicy(p)
@@ -73,7 +73,7 @@ func (u *PubsubSubscriptionIamUpdater) SetResourceIamPolicy(policy *cloudresourc
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil

--- a/google/iam_pubsub_topic.go
+++ b/google/iam_pubsub_topic.go
@@ -51,7 +51,7 @@ func (u *PubsubTopicIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Po
 	p, err := u.Config.clientPubsub.Projects.Topics.GetIamPolicy(u.topic).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	v1Policy, err := pubsubToResourceManagerPolicy(p)
@@ -73,7 +73,7 @@ func (u *PubsubTopicIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanage
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil
@@ -96,7 +96,7 @@ func resourceManagerToPubsubPolicy(in *cloudresourcemanager.Policy) (*pubsub.Pol
 	out := &pubsub.Policy{}
 	err := Convert(in, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a v1 policy to a pubsub policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a v1 policy to a pubsub policy: {{err}}", err)
 	}
 	return out, nil
 }
@@ -105,7 +105,7 @@ func pubsubToResourceManagerPolicy(in *pubsub.Policy) (*cloudresourcemanager.Pol
 	out := &cloudresourcemanager.Policy{}
 	err := Convert(in, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a pubsub policy to a v1 policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a pubsub policy to a v1 policy: {{err}}", err)
 	}
 	return out, nil
 }

--- a/google/iam_service_account.go
+++ b/google/iam_service_account.go
@@ -38,7 +38,7 @@ func (u *ServiceAccountIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager
 	p, err := u.Config.clientIAM.Projects.ServiceAccounts.GetIamPolicy(u.serviceAccountId).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	cloudResourcePolicy, err := iamToResourceManagerPolicy(p)
@@ -60,7 +60,7 @@ func (u *ServiceAccountIamUpdater) SetResourceIamPolicy(policy *cloudresourceman
 	}).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil
@@ -82,7 +82,7 @@ func resourceManagerToIamPolicy(p *cloudresourcemanager.Policy) (*iam.Policy, er
 	out := &iam.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a v1 policy to a iam policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a v1 policy to a iam policy: {{err}}", err)
 	}
 	return out, nil
 }
@@ -91,7 +91,7 @@ func iamToResourceManagerPolicy(p *iam.Policy) (*cloudresourcemanager.Policy, er
 	out := &cloudresourcemanager.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a iam policy to a v1 policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a iam policy to a v1 policy: {{err}}", err)
 	}
 	return out, nil
 }

--- a/google/iam_storage_bucket.go
+++ b/google/iam_storage_bucket.go
@@ -33,12 +33,12 @@ func NewStorageBucketIamUpdater(d *schema.ResourceData, config *Config) (Resourc
 func (u *StorageBucketIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
 	p, err := u.Config.clientStorage.Buckets.GetIamPolicy(u.bucket).Do()
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	cloudResourcePolicy, err := storageToResourceManagerPolicy(p)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return cloudResourcePolicy, nil
@@ -48,13 +48,13 @@ func (u *StorageBucketIamUpdater) SetResourceIamPolicy(policy *cloudresourcemana
 	storagePolicy, err := resourceManagerToStoragePolicy(policy)
 
 	if err != nil {
-		return fmt.Errorf("Invalid IAM policy for %s: %s", u.DescribeResource(), err)
+		return errwrap.Wrapf(fmt.Sprintf("Invalid IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	_, err = u.Config.clientStorage.Buckets.SetIamPolicy(u.bucket, storagePolicy).Do()
 
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("Error setting IAM policy for %s.", u.DescribeResource()), err)
+		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return nil
@@ -76,7 +76,7 @@ func resourceManagerToStoragePolicy(p *cloudresourcemanager.Policy) (*storage.Po
 	out := &storage.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a v1 policy to a storage policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a v1 policy to a storage policy: {{err}}", err)
 	}
 	return out, nil
 }
@@ -85,7 +85,7 @@ func storageToResourceManagerPolicy(p *storage.Policy) (*cloudresourcemanager.Po
 	out := &cloudresourcemanager.Policy{}
 	err := Convert(p, out)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot convert a storage policy to a v1 policy: %s", err)
+		return nil, errwrap.Wrapf("Cannot convert a storage policy to a v1 policy: {{err}}", err)
 	}
 	return out, nil
 }

--- a/google/resource_iam_binding.go
+++ b/google/resource_iam_binding.go
@@ -83,13 +83,14 @@ func resourceIamBindingRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Rea
 		p, err := updater.GetResourceIamPolicy()
 		if err != nil {
 			if isGoogleApiErrorWithCode(err, 404) {
-				log.Printf("[DEBUG]: Binding for role %q not found for non-existant resource %s, removing from state file.\n", updater.DescribeResource(), eBinding.Role)
+				log.Printf("[DEBUG]: Binding for role %q not found for non-existant resource %s, removing from state file.", updater.DescribeResource(), eBinding.Role)
+				d.SetId("")
 				return nil
 			}
 
 			return err
 		}
-		log.Printf("[DEBUG]: Retrieved policy for %s: %+v\n", updater.DescribeResource(), p)
+		log.Printf("[DEBUG]: Retrieved policy for %s: %+v", updater.DescribeResource(), p)
 
 		var binding *cloudresourcemanager.Binding
 		for _, b := range p.Bindings {
@@ -100,7 +101,7 @@ func resourceIamBindingRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Rea
 			break
 		}
 		if binding == nil {
-			log.Printf("[DEBUG]: Binding for role %q not found in policy for %s, removing from state file.\n", eBinding.Role, updater.DescribeResource())
+			log.Printf("[DEBUG]: Binding for role %q not found in policy for %s, removing from state file.", eBinding.Role, updater.DescribeResource())
 			d.SetId("")
 			return nil
 		}

--- a/google/resource_iam_policy.go
+++ b/google/resource_iam_policy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	"log"
 )
 
 var IamPolicyBaseSchema = map[string]*schema.Schema{
@@ -82,6 +83,10 @@ func ResourceIamPolicyRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Read
 
 		policy, err := updater.GetResourceIamPolicy()
 		if err != nil {
+			if isGoogleApiErrorWithCode(err, 404) {
+				log.Printf("[DEBUG]: Policy does not exist for non-existant resource %q", updater.GetResourceId())
+				return nil
+			}
 			return err
 		}
 

--- a/google/utils.go
+++ b/google/utils.go
@@ -148,7 +148,7 @@ func getRouterLockName(region string, router string) string {
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData, resource string) error {
-	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+	if isGoogleApiErrorWithCode(err, 404) {
 		log.Printf("[WARN] Removing %s because it's gone", resource)
 		// The resource doesn't exist anymore
 		d.SetId("")
@@ -157,6 +157,11 @@ func handleNotFoundError(err error, d *schema.ResourceData, resource string) err
 	}
 
 	return fmt.Errorf("Error reading %s: %s", resource, err)
+}
+
+func isGoogleApiErrorWithCode(err error, errCode int) bool {
+	gerr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error)
+	return ok && gerr != nil && gerr.Code == errCode
 }
 
 func isConflictError(err error) bool {


### PR DESCRIPTION
Fixes #1251 (at least 404s)

- Added helper that handles wrapped googleapi errors
- Clean up error wrapping for IAM policy get/set
- Make sure reading/deleting policies on deleted resources doesn't fail (happened while trying to refresh policy state for a deleted resource, destroying a policy after the initial resource has already been destroyed)