### PR TITLE
Add DiffSuppress for Target HTTP(S) Proxies

### DIFF
--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -28,8 +28,9 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 			},
 
 			"url_map": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"description": &schema.Schema{

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -30,7 +30,7 @@ func resourceComputeTargetHttpProxy() *schema.Resource {
 			"url_map": &schema.Schema{
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: compareSelfLinkOrResourceName,
+				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 
 			"description": &schema.Schema{

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -43,7 +43,7 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 			"url_map": &schema.Schema{
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: compareSelfLinkOrResourceName,
+				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 
 			"description": &schema.Schema{

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -41,8 +41,9 @@ func resourceComputeTargetHttpsProxy() *schema.Resource {
 			},
 
 			"url_map": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
 			},
 
 			"description": &schema.Schema{


### PR DESCRIPTION
Prevents no-op diff/change during plan/apply. Example of such a no-op diff:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ google_compute_target_https_proxy.foobar
      url_map: "https://www.googleapis.com/compute/beta/projects/***/global/urlMaps/httpsproxy-test-url-map" => "https://www.googleapis.com/compute/v1/projects/***/global/urlMaps/httpsproxy-test-url-map"


Plan: 0 to add, 1 to change, 0 to destroy.
```

Example with DiffSuppress:
```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```