### PR TITLE
Retrieve current OAuth access token from google_client_config data source

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	client    *http.Client
 	userAgent string
 
+	tokenSource oauth2.TokenSource
+
 	clientBilling                *cloudbilling.Service
 	clientCompute                *compute.Service
 	clientComputeBeta            *computeBeta.Service
@@ -134,6 +136,8 @@ func (c *Config) loadAndValidate() error {
 			return err
 		}
 	}
+
+	c.tokenSource = tokenSource
 
 	client.Transport = logging.NewTransport("Google", client.Transport)
 

--- a/google/data_source_google_client_config.go
+++ b/google/data_source_google_client_config.go
@@ -19,6 +19,12 @@ func dataSourceGoogleClientConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"access_token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -29,6 +35,12 @@ func dataSourceClientConfigRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(time.Now().UTC().String())
 	d.Set("project", config.Project)
 	d.Set("region", config.Region)
+
+	token, err := config.tokenSource.Token()
+	if err != nil {
+		return err
+	}
+	d.Set("access_token", token.AccessToken)
 
 	return nil
 }

--- a/google/data_source_google_client_config_test.go
+++ b/google/data_source_google_client_config_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project"),
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
 				),
 			},
 		},

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -22,10 +22,8 @@ output "project" {
 
 ## Example Usage: Configure Kubernetes provider with OAuth2 access token
 
-```
-data "google_client_config" "default" {
-
-}
+```tf
+data "google_client_config" "default" {}
 
 data "google_container_cluster" "my_cluster" {
   name   = "my-cluster"

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -20,6 +20,27 @@ output "project" {
 }
 ```
 
+## Example Usage: Configure Kubernetes provider with OAuth2 access token
+
+```
+data "google_client_config" "default" {
+
+}
+
+data "google_container_cluster" "my_cluster" {
+  name   = "my-cluster"
+  zone   = "us-east1-a"
+}
+
+provider "kubernetes" {
+  load_config_file = false
+
+  host = "https://${google_container_cluster.my_cluster.endpoint}"
+  token = "${data.google_client_config.default.access_token}"
+  cluster_ca_certificate = "${base64decode(google_container_cluster.my_cluster.master_auth.0.cluster_ca_certificate)}"
+}
+```
+
 ## Argument Reference
 
 There are no arguments available for this data source.
@@ -31,3 +52,5 @@ In addition to the arguments listed above, the following attributes are exported
 * `project` - The ID of the project to apply any resources to.
 
 * `region` - The region to operate under.
+
+* `access_token` - The OAuth2 access token used by the client to authenticate against the Google Cloud API.


### PR DESCRIPTION
This pull request adds the field `access_token` to the `google_client_config` data source. The field `access_token` provides the current OAuth2 token of the client which is used by the provider to authenticate against the Google Cloud API. 

I decided to add the field to the `google_client_config` since this data source refers to the provider client already instead of creating a separate data source. From a hypothetical data source such as `google_oauth_token`, I would expect that it creates a "fresh" token not used by the provider client and that it allows defining the *scope*. 

## Use Case: GKE on GCP with Terraform

A particular use case is to allow the `terraform` provider to authenticate against a GKE cluster using the credentials already used by the `google` provider. The following example integrates both, the `google` and the `kubernetes` provider in a single Terraform configuration to provision a GKE cluster and create a simple Kubernetes service while purely relying on Google IAM for authentication.

I have added a shorter version of this use case as an example to the documentation of the `google_client_config` data source.

```
resource "google_project_service" "container" {
    service = "container.googleapis.com"
    disable_on_destroy = false
}

data "google_client_config" "default" {

}

resource "google_container_cluster" "default" {
    name = "test"
    description = "Test container cluster"

    zone = "us-central1-c"

    min_master_version = "1.9.4-gke.1"
    enable_legacy_abac = false

    master_authorized_networks_config {
        // This configuration is insecure and NOT be used in production
        cidr_blocks {
            display_name = "internet"
            cidr_block = "0.0.0.0/0"
        }
    }

    logging_service = "logging.googleapis.com"
    monitoring_service = "monitoring.googleapis.com"

    node_pool {
        name = "default"
        node_count = "1"

        node_config {
            machine_type = "g1-small"
            image_type = "COS"

            disk_size_gb = 10

            oauth_scopes = [
                "https://www.googleapis.com/auth/compute",
                "https://www.googleapis.com/auth/devstorage.read_only",
                "https://www.googleapis.com/auth/logging.write",
                "https://www.googleapis.com/auth/monitoring",
            ]
        }
    }

    depends_on = [
        "google_project_service.container"
    ]
}

provider "kubernetes" {
    load_config_file = false

    host = "https://${google_container_cluster.default.endpoint}"
    token = "${data.google_client_config.default.access_token}"
    cluster_ca_certificate = "${base64decode(google_container_cluster.default.master_auth.0.cluster_ca_certificate)}"
}

resource "kubernetes_service" "a_service" {
    metadata {
        name = "a-service"
    }

    spec {
        selector {
            app = "a-service"
        }

        type = "ClusterIP"

        port {
            name = "http"
            port = 80
            target_port = 80
        }
    }
}
```