### PR TITLE
Updates container_cluster to set enable_legacy_abac to false by default

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -206,7 +206,7 @@ func resourceContainerCluster() *schema.Resource {
 			"enable_legacy_abac": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 
 			"initial_node_count": {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -372,7 +372,7 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 	Since GKE disables legacy ABAC by default in Kubernetes version 1.8+, and the default Kubernetes
 	version for GKE is also 1.8+, this test will ensure that legacy ABAC is disabled by default to be
 	more consistent with default settings in the Cloud Console
- */
+*/
 func TestAccContainerCluster_withDefaultLegacyAbac(t *testing.T) {
 	t.Parallel()
 

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -387,6 +387,12 @@ func TestAccContainerCluster_withDefaultLegacyAbac(t *testing.T) {
 					resource.TestCheckResourceAttr("google_container_cluster.default_legacy_abac", "enable_legacy_abac", "false"),
 				),
 			},
+			{
+				ResourceName:        "google_container_cluster.default_legacy_abac",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -369,9 +369,9 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 }
 
 /*
-	Since GKE disables legacy ABAC by default in Kubernetes version 1.8+, and the default Kubernetes version for GKE is
-	also 1.8+, this test will ensure that legacy ABAC is disabled by default to be more consistent with default settings
-	in the Cloud Console
+	Since GKE disables legacy ABAC by default in Kubernetes version 1.8+, and the default Kubernetes
+	version for GKE is also 1.8+, this test will ensure that legacy ABAC is disabled by default to be
+	more consistent with default settings in the Cloud Console
  */
 func TestAccContainerCluster_withDefaultLegacyAbac(t *testing.T) {
 	t.Parallel()

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -368,6 +368,29 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 	})
 }
 
+/*
+	Since GKE disables legacy ABAC by default in Kubernetes version 1.8+, and the default Kubernetes version for GKE is
+	also 1.8+, this test will ensure that legacy ABAC is disabled by default to be more consistent with default settings
+	in the Cloud Console
+ */
+func TestAccContainerCluster_withDefaultLegacyAbac(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_defaultLegacyAbac(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.default_legacy_abac", "enable_legacy_abac", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withVersion(t *testing.T) {
 	t.Parallel()
 
@@ -1311,6 +1334,15 @@ resource "google_container_cluster" "with_kubernetes_alpha" {
 	initial_node_count = 1
 
 	enable_kubernetes_alpha = true
+}`, clusterName)
+}
+
+func testAccContainerCluster_defaultLegacyAbac(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "default_legacy_abac" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
 }`, clusterName)
 }
 

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -94,7 +94,7 @@ output "cluster_ca_certificate" {
 * `enable_legacy_abac` - (Optional) Whether the ABAC authorizer is enabled for this cluster.
     When enabled, identities in the system, including service accounts, nodes, and controllers,
     will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
-    Defaults to `true`
+    Defaults to `false`
     
 * `initial_node_count` - (Optional) The number of nodes to create in this
     cluster (not including the Kubernetes master). Must be set if `node_pool` is not set.


### PR DESCRIPTION
Discussion in #1116.

GKE disables legacy ABAC by default in 1.8, and the current default GKE version (as of opening this PR) is 1.8.8.  This means that creating a GKE cluster using the cloud console and leaving all values as default will result legacy ABAC being disabled, but creating a GKE cluster using Terraform and leaving all values as default will keep it enabled.  This PR disables legacy ABAC by default so the default behavior is more consistent with the cloud console.

Test:

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccContainerCluster_withDefaultLegacyAbac -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccContainerCluster_withDefaultLegacyAbac
--- PASS: TestAccContainerCluster_withDefaultLegacyAbac (243.16s)
```