### PR TITLE
Add additional example usages to google_dns_record_set documentation

### DIFF
--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -83,7 +83,7 @@ resource "google_dns_record_set" "mx" {
   ttl  = 3600
 
   rrdatas = [
-    "100 aspmx.l.google.com.",
+    "1 aspmx.l.google.com.",
     "5 alt1.aspmx.l.google.com.",
     "5 alt2.aspmx.l.google.com.",
     "10 alt3.aspmx.l.google.com.",

--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -73,7 +73,7 @@ resource "google_dns_managed_zone" "prod" {
 }
 ```
 
-### Adding a MX record
+### Adding an MX record
 
 ```hcl
 resource "google_dns_record_set" "mx" {
@@ -97,7 +97,7 @@ resource "google_dns_managed_zone" "prod" {
 }
 ```
 
-### Adding a SPF record
+### Adding an SPF record
 
 `\"` must be added around your `rrdatas` for a SPF record. Otherwise `rrdatas` string gets split on spaces.
 

--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -55,6 +55,48 @@ resource "google_dns_managed_zone" "prod" {
 }
 ```
 
+### Adding an A record
+
+```hcl
+resource "google_dns_record_set" "a" {
+  name = "backend.${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+  type = "A"
+  ttl  = 300
+
+  rrdatas = ["8.8.8.8"]
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
+}
+```
+
+### Adding a MX record
+
+```hcl
+resource "google_dns_record_set" "mx" {
+  name = "${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+  type = "MX"
+  ttl  = 3600
+
+  rrdatas = [
+    "100 aspmx.l.google.com.",
+    "5 alt1.aspmx.l.google.com.",
+    "5 alt2.aspmx.l.google.com.",
+    "10 alt3.aspmx.l.google.com.",
+    "10 alt4.aspmx.l.google.com."
+  ]
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
+}
+```
+
 ### Adding a SPF record
 
 `\"` must be added around your `rrdatas` for a SPF record. Otherwise `rrdatas` string gets split on spaces.


### PR DESCRIPTION
I have recently started using the Terraform Google provider in several projects. When it comes to managing DNS records, I had the feeling that the documentation of the `dns_record_set` resource could feature more example usage. For my case, I struggled with specifying multiple MX records before figuring out how to define them using the `dns_record_set`.

Therefore, I suggest to add these example usage so that especially new adopters of the provider could use them as a copy & paste template from the documentation.