### PR TITLE
Make it clearer that google managed zone dns_name argument requires a…

### DIFF
--- a/website/docs/d/dns_managed_zone.html.markdown
+++ b/website/docs/d/dns_managed_zone.html.markdown
@@ -40,7 +40,7 @@ resource "google_dns_record_set" "dns" {
 
 The following attributes are exported:
 
-* `dns_name` - The DNS name of this zone, e.g. "terraform.io".
+* `dns_name` - The fully qualified DNS name of this zone, e.g. `terraform.io.`.
 
 * `description` - A textual description field.
 

--- a/website/docs/r/dns_managed_zone.markdown
+++ b/website/docs/r/dns_managed_zone.markdown
@@ -25,7 +25,7 @@ resource "google_dns_managed_zone" "prod" {
 
 The following arguments are supported:
 
-* `dns_name` - (Required) The DNS name of this zone, e.g. "terraform.io".
+* `dns_name` - (Required) The fully qualified DNS name of this zone, e.g. `terraform.io.`.
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.


### PR DESCRIPTION
… fully qualified

domain name with the "." at the end