### PR TITLE
Use correct Project ID regex in instanceGroupManagerURL

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	instanceGroupManagerURL           = regexp.MustCompile("^https://www.googleapis.com/compute/v1/projects/([a-z][a-z0-9-]{5}(?:[-a-z0-9]{0,23}[a-z0-9])?)/zones/([a-z0-9-]*)/instanceGroupManagers/([^/]*)")
+	instanceGroupManagerURL = regexp.MustCompile(fmt.Sprintf("^https://www.googleapis.com/compute/v1/projects/(%s)/zones/([a-z0-9-]*)/instanceGroupManagers/([^/]*)", ProjectRegex))
+
 	ContainerClusterBaseApiVersion    = v1
 	ContainerClusterVersionedFeatures = []Feature{
 		{Version: v1beta1, Item: "pod_security_policy_config"},


### PR DESCRIPTION
Attempting to create a GKE cluster with a (valid) project ID containing a ':' results in the following error:

```
Error reading instance group manage URL '"https://www.googleapis.com/compute/v1/projects/example.io:example/zones/us-central1-a/instanceGroupManagers/gke-example-product-terraform-201804-4f57f12f-grp"'
```

This error is raised [here](https://github.com/terraform-providers/terraform-provider-google/blob/7596164ad13eed4bc1fa2545f8d42dbdd8045bd1/google/resource_container_node_pool.go#L436), and caused by an overly restrictive project regex [here](https://github.com/terraform-providers/terraform-provider-google/blob/f488a6e6bf3fed3a868bb079faa5ca9c5dc95eea/google/resource_container_cluster.go#L20).

The correct project ID regex is already defined in the repo [here](https://github.com/terraform-providers/terraform-provider-google/blob/411017c35f96ff73b951e49607093b442cad360a/google/validation.go#L15).

This PR updates the `instanceGroupManagerURL` regex to use the existing `ProjectRegex`.