### PR TITLE
Docs: creating custom machineType

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -61,10 +61,7 @@ The following arguments are supported:
 * `boot_disk` - (Required) The boot disk for the instance.
     Structure is documented below.
 
-* `machine_type` - (Required) The machine type to create. To create a custom
-    machine type, value should be set as specified
-    [here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType).
-    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true in order to update this field.
+* `machine_type` - (Required) The machine type to create. To create a custom                                                          machine type, value should be formatted like `custom-4-5120[-ext]` ([GCP docs on machineType](https://cloud.google.com/compute/docs/reference/latest/instances#machineType))
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `boot_disk` - (Required) The boot disk for the instance.
     Structure is documented below.
 
-* `machine_type` - (Required) The machine type to create. To create a custom                                                          machine type, value should be formatted like `custom-4-5120[-ext]` ([GCP docs on machineType](https://cloud.google.com/compute/docs/reference/latest/instances#machineType))
+* `machine_type` - (Required) The machine type to create. To create a custom machine type, value should be formatted like `custom-4-5120[-ext]` ([GCP docs on machineType](https://cloud.google.com/compute/docs/reference/latest/instances#machineType))
 
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
     This can be specified multiple times for multiple disks. Structure is
     documented below.
 
-* `machine_type` - (Required) The machine type to create.
+* `machine_type` - (Required) The machine type to create. To create a custom                                                          machine type, value should be formatted like `custom-4-5120[-ext]` ([GCP docs here](https://cloud.google.com/compute/docs/reference/latest/instances#machineType))
 
 - - -
 * `name` - (Optional) The name of the instance template. If you leave


### PR DESCRIPTION
Improves documentation surrounding compute instances & compute instance templates needing a custom machineType