### PR TITLE
un-deprecate name_prefix for instance templates

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -52,8 +52,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 					}
 					return
 				},
-				Deprecated: "Use the random provider instead. See migration instructions at " +
-					"https://github.com/terraform-providers/terraform-provider-google/issues/1054#issuecomment-377390209",
 			},
 
 			"disk": &schema.Schema{

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the instance template. If you leave
   this blank, Terraform will auto-generate a unique name.
 
-* `name_prefix` - (Deprecated, Optional) Creates a unique name beginning with the specified
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.
 
 * `can_ip_forward` - (Optional) Whether to allow sending and receiving of


### PR DESCRIPTION
Instance Templates can't be updated and are generally used with `create_before_destroy`, so using the random provider isn't a great UX because it requires such a long list of keepers. Fixes #1326.

cc @negz 