### PR TITLE
Use standard user-agent header

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"runtime"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/pathorcontents"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/version"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -137,9 +136,9 @@ func (c *Config) loadAndValidate() error {
 
 	client.Transport = logging.NewTransport("Google", client.Transport)
 
-	versionString := terraform.VersionString()
-	userAgent := fmt.Sprintf(
-		"(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, versionString)
+	projectURL := "https://www.terraform.io"
+	userAgent := fmt.Sprintf("Terraform/%s (+%s)",
+		version.String(), projectURL)
 
 	c.client = client
 	c.userAgent = userAgent


### PR DESCRIPTION
This PR does a few things to the User-Agent header:

1. It puts Terraform/(version) first, since that's the way the RFC expects it

2. It removes the goos and goarch data, although I could be convinced to put it back in, I don't see what value it's providing

3. Moves directly to consuming the version package (which is the comment above the function previously being called)