### PR TITLE
Fix auto-delete default network in google_project.

### DIFF
--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -195,9 +195,12 @@ func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	// Delete the network
+	return deleteComputeNetwork(project, d.Id(), config)
+}
+
+func deleteComputeNetwork(project, network string, config *Config) error {
 	op, err := config.clientCompute.Networks.Delete(
-		project, d.Id()).Do()
+		project, network).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
@@ -206,7 +209,5 @@ func resourceComputeNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-
-	d.SetId("")
 	return nil
 }

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -166,12 +166,6 @@ func TestAccProject_deleteDefaultNetwork(t *testing.T) {
 			{
 				Config: testAccProject_deleteDefaultNetwork(pid, pname, org, billingId),
 			},
-			// Make sure import supports labels
-			{
-				ResourceName:      "google_project.acceptance",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/website/docs/r/google_project.html.markdown
+++ b/website/docs/r/google_project.html.markdown
@@ -100,7 +100,8 @@ The following arguments are supported:
 * `auto_create_network` - (Optional) Create the 'default' network automatically.  Default true.
     Note: this might be more accurately described as "Delete Default Network", since the network
     is created automatically then deleted before project creation returns, but we choose this
-    name to match the GCP Console UI.
+    name to match the GCP Console UI. Setting this field to false will enable the Compute Engine
+    API which is required to delete the network.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Use ProjectId when calling the APIs instead of the project name
- The compute API has to be enabled before we can delete the network
- The firewall rules inside the default network must be deleted before we delete the network.
- Update documentation to clarify this side effect.

Fixes #1331 
