### PR TITLE
Fix Instance Group Manager and Region Instance Group Managers plan crash

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -419,7 +419,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	}
 
 	manager, err := getManager(d, meta)
-	if err != nil {
+	if err != nil || manager == nil {
 		return err
 	}
 

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -303,6 +303,14 @@ func getRegionalManager(d *schema.ResourceData, meta interface{}) (*computeBeta.
 		v1Manager := &compute.InstanceGroupManager{}
 		v1Manager, err = config.clientCompute.RegionInstanceGroupManagers.Get(project, region, d.Id()).Do()
 
+		if v1Manager == nil {
+			log.Printf("[WARN] Removing Region Instance Group Manager %q because it's gone", d.Get("name").(string))
+
+			// The resource doesn't exist anymore
+			d.SetId("")
+			return nil, nil
+		}
+
 		err = Convert(v1Manager, manager)
 		if err != nil {
 			return nil, err
@@ -335,7 +343,7 @@ func waitForInstancesRefreshFunc(f getInstanceManagerFunc, d *schema.ResourceDat
 func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	manager, err := getRegionalManager(d, meta)
-	if err != nil {
+	if err != nil || manager == nil {
 		return err
 	}
 


### PR DESCRIPTION
When either an Instance Group Manager or Region Instance Group Manager exists in tfstate but the resource itself no longer exists, running a terraform plan causes a crash.  This fix ensures that terraform plan correctly indicates that the resource should be created.