### PR TITLE
MergeBindings ignores empty bindings.

### DIFF
--- a/google/iam.go
+++ b/google/iam.go
@@ -129,7 +129,9 @@ func mergeBindings(bindings []*cloudresourcemanager.Binding) []*cloudresourceman
 		for m := range members {
 			b.Members = append(b.Members, m)
 		}
-		rb = append(rb, &b)
+		if len(b.Members) > 0 {
+			rb = append(rb, &b)
+		}
 	}
 
 	return rb

--- a/google/resource_google_project_iam_policy_test.go
+++ b/google/resource_google_project_iam_policy_test.go
@@ -594,6 +594,7 @@ func TestIamMergeBindings(t *testing.T) {
 						"member-2",
 					},
 				},
+				{Role: "empty-role", Members: []string{}},
 			},
 			expect: []cloudresourcemanager.Binding{
 				{


### PR DESCRIPTION
Fixes #1338.