### PR TITLE
Add max_connetions and max_connections_per_instance to backend service

### DIFF
--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -101,6 +101,10 @@ func resourceComputeBackendService() *schema.Resource {
 							Type:     schema.TypeFloat,
 							Optional: true,
 						},
+						"max_connections_per_instance": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"max_utilization": &schema.Schema{
 							Type:     schema.TypeFloat,
 							Optional: true,
@@ -469,6 +473,12 @@ func expandBackends(configured []interface{}) ([]*compute.Backend, error) {
 				b.NullFields = append(b.NullFields, "MaxRatePerInstance")
 			}
 		}
+		if v, ok := data["max_connections_per_instance"]; ok {
+			b.MaxConnectionsPerInstance = int64(v.(int))
+			if b.MaxConnectionsPerInstance == 0 {
+				b.NullFields = append(b.NullFields, "MaxConnectionsPerInstance")
+			}
+		}
 		if v, ok := data["max_utilization"]; ok {
 			b.MaxUtilization = v.(float64)
 			b.ForceSendFields = append(b.ForceSendFields, "MaxUtilization")
@@ -492,6 +502,7 @@ func flattenBackends(backends []*computeBeta.Backend) []map[string]interface{} {
 		data["group"] = b.Group
 		data["max_rate"] = b.MaxRate
 		data["max_rate_per_instance"] = b.MaxRatePerInstance
+		data["max_connections_per_instance"] = b.MaxConnectionsPerInstance
 		data["max_utilization"] = b.MaxUtilization
 		result = append(result, data)
 	}

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -101,6 +101,10 @@ func resourceComputeBackendService() *schema.Resource {
 							Type:     schema.TypeFloat,
 							Optional: true,
 						},
+						"max_connections": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"max_connections_per_instance": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -473,6 +477,12 @@ func expandBackends(configured []interface{}) ([]*compute.Backend, error) {
 				b.NullFields = append(b.NullFields, "MaxRatePerInstance")
 			}
 		}
+		if v, ok := data["max_connections"]; ok {
+			b.MaxConnections = int64(v.(int))
+			if b.MaxConnections == 0 {
+				b.NullFields = append(b.NullFields, "MaxConnections")
+			}
+		}
 		if v, ok := data["max_connections_per_instance"]; ok {
 			b.MaxConnectionsPerInstance = int64(v.(int))
 			if b.MaxConnectionsPerInstance == 0 {
@@ -502,6 +512,7 @@ func flattenBackends(backends []*computeBeta.Backend) []map[string]interface{} {
 		data["group"] = b.Group
 		data["max_rate"] = b.MaxRate
 		data["max_rate_per_instance"] = b.MaxRatePerInstance
+		data["max_connections"] = b.MaxConnections
 		data["max_connections_per_instance"] = b.MaxConnectionsPerInstance
 		data["max_utilization"] = b.MaxUtilization
 		result = append(result, data)

--- a/google/resource_compute_backend_service_migrate.go
+++ b/google/resource_compute_backend_service_migrate.go
@@ -117,6 +117,9 @@ func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {
 	if v, ok := m["max_rate_per_instance"]; ok {
 		buf.WriteString(fmt.Sprintf("%f-", v.(float64)))
 	}
+	if v, ok := m["max_connections_per_instance"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", int64(v.(int))))
+	}
 	if v, ok := m["max_rate_per_instance"]; ok {
 		buf.WriteString(fmt.Sprintf("%f-", v.(float64)))
 	}

--- a/google/resource_compute_backend_service_migrate.go
+++ b/google/resource_compute_backend_service_migrate.go
@@ -117,6 +117,9 @@ func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {
 	if v, ok := m["max_rate_per_instance"]; ok {
 		buf.WriteString(fmt.Sprintf("%f-", v.(float64)))
 	}
+	if v, ok := m["max_connections"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", int64(v.(int))))
+	}
 	if v, ok := m["max_connections_per_instance"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", int64(v.(int))))
 	}

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -502,6 +502,92 @@ func TestAccComputeBackendService_withSessionAffinity(t *testing.T) {
 	}
 }
 
+func TestAccComputeBackendService_withMaxConnections(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	var svc compute.BackendService
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withMaxConnections(
+					serviceName, igName, itName, checkName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeBackendService_withMaxConnections(
+					serviceName, igName, itName, checkName, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+	if svc.Backends[0].MaxConnections != 20 {
+		t.Errorf("Expected MaxConnections == 20, got %d", svc.Backends[0].MaxConnections)
+	}
+}
+
+func TestAccComputeBackendService_withMaxConnectionsPerInstance(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	var svc compute.BackendService
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withMaxConnectionsPerInstance(
+					serviceName, igName, itName, checkName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeBackendService_withMaxConnectionsPerInstance(
+					serviceName, igName, itName, checkName, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.lipsum", &svc),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+	if svc.Backends[0].MaxConnectionsPerInstance != 20 {
+		t.Errorf("Expected MaxConnectionsPerInstance == 20, got %d", svc.Backends[0].MaxConnectionsPerInstance)
+	}
+}
+
 func testAccComputeBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -762,4 +848,110 @@ resource "google_compute_security_policy" "policy" {
 	description = "basic security policy"
 }
 `, serviceName, checkName, polName)
+}
+
+func testAccComputeBackendService_withMaxConnections(
+	serviceName, igName, itName, checkName string, maxConnections int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "TCP"
+
+  backend {
+    group = "${google_compute_instance_group_manager.foobar.instance_group}"
+    max_connections = %v
+  }
+
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name               = "%s"
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  base_instance_name = "foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+  auto_healing_policies {
+    health_check = "${google_compute_http_health_check.default.self_link}"
+    initial_delay_sec = "10"
+  }
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = "debian-8-jessie-v20160803"
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  tcp_health_check {
+      port = "110"
+  }
+}
+`, serviceName, maxConnections, igName, itName, checkName)
+}
+
+func testAccComputeBackendService_withMaxConnectionsPerInstance(
+	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "TCP"
+
+  backend {
+    group = "${google_compute_instance_group_manager.foobar.instance_group}"
+    max_connections_per_instance = %v
+  }
+
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name               = "%s"
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  base_instance_name = "foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+  auto_healing_policies {
+    health_check = "${google_compute_http_health_check.default.self_link}"
+    initial_delay_sec = "10"
+  }
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = "debian-8-jessie-v20160803"
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  tcp_health_check {
+      port = "110"
+  }
+}
+`, serviceName, maxConnectionsPerInstance, igName, itName, checkName)
 }

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -874,7 +874,7 @@ resource "google_compute_instance_group_manager" "foobar" {
   zone               = "us-central1-f"
   target_size        = 1
   auto_healing_policies {
-    health_check = "${google_compute_http_health_check.default.self_link}"
+    health_check = "${google_compute_health_check.default.self_link}"
     initial_delay_sec = "10"
   }
 }
@@ -927,7 +927,7 @@ resource "google_compute_instance_group_manager" "foobar" {
   zone               = "us-central1-f"
   target_size        = 1
   auto_healing_policies {
-    health_check = "${google_compute_http_health_check.default.self_link}"
+    health_check = "${google_compute_health_check.default.self_link}"
     initial_delay_sec = "10"
   }
 }

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -129,6 +129,17 @@ The `backend` block supports:
 * `max_rate_per_instance` - (Optional) The maximum per-instance requests per
     second (RPS).
 
+* `max_connections` - (Optional) The max number of simultaneous connections for the
+    group. Can be used with either CONNECTION or UTILIZATION balancing
+    modes. For CONNECTION mode, either maxConnections or
+    maxConnectionsPerInstance must be set.
+
+* `max_connections_per_instance` - (Optional) The max number of simultaneous connections
+    that a single backend instance can handle. This is used to calculate
+    the capacity of the group. Can be used in either CONNECTION or
+    UTILIZATION balancing modes. For CONNECTION mode, either
+    maxConnections or maxConnectionsPerInstance must be set.
+
 * `max_utilization` - (Optional) The target CPU utilization for the group as a
     float in the range [0.0, 1.0]. This flag can only be provided when the
     balancing mode is `UTILIZATION`. Defaults to `0.8`.


### PR DESCRIPTION
Hi,

could you check this pull request? 
It seems max_connections_per_instance is missing for the backend service (max_connections likewise).

This makes it impossible to use external tcp load balancers and internal load balancers that point to the same instance group.