### PR TITLE
Add default cluster version to data source.

### DIFF
--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -19,6 +19,10 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"default_cluster_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"latest_master_version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -60,6 +64,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	d.Set("valid_master_versions", resp.ValidMasterVersions)
+	d.Set("default_cluster_version", resp.DefaultClusterVersion)
 	d.Set("valid_node_versions", resp.ValidNodeVersions)
 	d.Set("latest_master_version", resp.ValidMasterVersions[0])
 	d.Set("latest_node_version", resp.ValidNodeVersions[0])

--- a/google/data_source_google_container_engine_versions_test.go
+++ b/google/data_source_google_container_engine_versions_test.go
@@ -88,6 +88,11 @@ func testAccCheckGoogleContainerEngineVersionsMeta(n string) resource.TestCheckF
 			}
 		}
 
+		_, ok = rs.Primary.Attributes["default_cluster_version"]
+		if !ok {
+			return errors.New("Didn't get a default cluster version.")
+		}
+
 		return nil
 	}
 }

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -44,3 +44,4 @@ The following attributes are exported:
 * `valid_node_versions` - A list of versions available in the given zone for use with node instances.
 * `latest_master_version` - The latest version available in the given zone for use with master instances.
 * `latest_node_version` - The latest version available in the given zone for use with node instances.
+* `default_cluster_version` - Version of Kubernetes the service deploys by default.


### PR DESCRIPTION
Fixes #1351.

```
--- PASS: TestAccContainerEngineVersions_basic (0.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 0.476s
```