### PR TITLE
Move method prior to autogenerating ssl proxy resource

### DIFF
--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -215,3 +215,19 @@ func resourceComputeTargetHttpsProxyDelete(d *schema.ResourceData, meta interfac
 	d.SetId("")
 	return nil
 }
+
+func expandSslCertificates(d *schema.ResourceData, config *Config) ([]string, error) {
+	configured := d.Get("ssl_certificates").([]interface{})
+	certs := make([]string, 0, len(configured))
+
+	for _, sslCertificate := range configured {
+		sslCertificateFieldValue, err := ParseSslCertificateFieldValue(sslCertificate.(string), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid ssl certificate: %s", err)
+		}
+
+		certs = append(certs, sslCertificateFieldValue.RelativeLink())
+	}
+
+	return certs, nil
+}

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -233,19 +233,3 @@ func resourceComputeTargetSslProxyDelete(d *schema.ResourceData, meta interface{
 	d.SetId("")
 	return nil
 }
-
-func expandSslCertificates(d *schema.ResourceData, config *Config) ([]string, error) {
-	configured := d.Get("ssl_certificates").([]interface{})
-	certs := make([]string, 0, len(configured))
-
-	for _, sslCertificate := range configured {
-		sslCertificateFieldValue, err := ParseSslCertificateFieldValue(sslCertificate.(string), d, config)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid ssl certificate: %s", err)
-		}
-
-		certs = append(certs, sslCertificateFieldValue.RelativeLink())
-	}
-
-	return certs, nil
-}


### PR DESCRIPTION
The ssl proxy class will be autogenerated. I moved the `expandSslCertificates` method in the https proxy class since it is the only class that will be using it once the ssl proxy is autogenerated.