### PR TITLE
Regional cluster update support for additional zones

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1007,7 +1007,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		// Since we can't add & remove zones in the same request, first add all the
 		// zones, then remove the ones we aren't using anymore.
 		azSet := azSetOld.Union(azSetNew)
-		azSet.Add(location)
+
+		if isZone(location) {
+			azSet.Add(location)
+		}
 
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
@@ -1021,7 +1024,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 
-		azSetNew.Add(location)
+		if isZone(location) {
+			azSetNew.Add(location)
+		}
 		if !azSet.Equal(azSetNew) {
 			req = &container.UpdateClusterRequest{
 				Update: &container.ClusterUpdate{

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -304,6 +304,38 @@ func TestAccContainerCluster_withAdditionalZones(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_regionalWithAdditionalZones(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_regionalAdditionalZones(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_additional_zones",
+				ImportStateIdPrefix: "us-central1/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_regionalUpdateAdditionalZones(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_additional_zones",
+				ImportStateIdPrefix: "us-central1/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withKubernetesAlpha(t *testing.T) {
 	t.Parallel()
 
@@ -1365,6 +1397,34 @@ resource "google_container_cluster" "with_additional_zones" {
 	additional_zones = [
 		"us-central1-f",
 		"us-central1-c",
+	]
+}`, clusterName)
+}
+
+func testAccContainerCluster_regionalAdditionalZones(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_additional_zones" {
+	name = "%s"
+	region = "us-central1"
+	initial_node_count = 1
+
+	additional_zones = [
+		"us-central1-f",
+		"us-central1-c",
+	]
+}`, clusterName)
+}
+
+func testAccContainerCluster_regionalUpdateAdditionalZones(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_additional_zones" {
+	name = "%s"
+	region = "us-central1"
+	initial_node_count = 1
+
+	additional_zones = [
+		"us-central1-f",
+		"us-central1-b",
 	]
 }`, clusterName)
 }


### PR DESCRIPTION
Fixes #1352.  We can't request that the cluster be placed in its original location if its original location is a region - we had this correct in `Create` but missed it in `Update`.