### PR TITLE
Fix for networkPolicyEnabled test

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1456,6 +1456,12 @@ func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface
 			"enabled":  c.Enabled,
 			"provider": c.Provider,
 		})
+	} else {
+		// Explicitly set the network policy to the default.
+		result = append(result, map[string]interface{}{
+			"enabled":  false,
+			"provider": "PROVIDER_UNSPECIFIED",
+		})
 	}
 	return result
 }


### PR DESCRIPTION
Must explicitly add the default NetworkPolicy object if the result from the API is nil.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccContainerCluster_withNetworkPolicyEnabled -timeout 120m
=== RUN   TestAccContainerCluster_withNetworkPolicyEnabled
--- PASS: TestAccContainerCluster_withNetworkPolicyEnabled (602.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 602.454s
```