### PR TITLE
Fix failing compute tests, which use AccessConfigs (which are broken)

### DIFF
--- a/google/compute_instance_helpers.go
+++ b/google/compute_instance_helpers.go
@@ -106,7 +106,7 @@ func expandAccessConfigs(configs []interface{}) []*computeBeta.AccessConfig {
 			Type:  "ONE_TO_ONE_NAT",
 			NatIP: data["nat_ip"].(string),
 		}
-		if ptr, ok := data["public_ptr_domain_name"]; ok {
+		if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
 			acs[i].SetPublicPtr = true
 			acs[i].PublicPtrDomainName = ptr.(string)
 		}

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -1125,7 +1125,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					Type:  "ONE_TO_ONE_NAT",
 					NatIP: d.Get(acPrefix + ".nat_ip").(string),
 				}
-				if ptr, ok := d.GetOk(acPrefix + ".public_ptr_domain_name"); ok {
+				if ptr, ok := d.GetOk(acPrefix + ".public_ptr_domain_name"); ok && ptr != "" {
 					ac.SetPublicPtr = true
 					ac.PublicPtrDomainName = ptr.(string)
 				}


### PR DESCRIPTION
GetOk returns 'ok' even if the value is unset!  So you have to check to see that the value is set, also.

Tests running now, but a sample locally show successes where they used to fail.