### PR TITLE
Allow compute/app engine default service account ids in regex

### DIFF
--- a/google/validation.go
+++ b/google/validation.go
@@ -20,6 +20,10 @@ const (
 
 	RFC1035NameTemplate = "[a-z](?:[-a-z0-9]{%d,%d}[a-z0-9])"
 	CloudIoTIdRegex     = "^[a-zA-Z][-a-zA-Z0-9._+~%]{2,254}$"
+
+	// Format of default Compute service accounts created by Google
+	// ${PROJECT_ID}-compute@developer.gserviceaccount.com where PROJECT_ID is an int64 (max 20 digits)
+	ComputeServiceAccountNameRegex = "[0-9]{1,20}-compute@developer.gserviceaccount.com"
 )
 
 var (
@@ -29,8 +33,20 @@ var (
 	// 4 and 28 since the first and last character are excluded.
 	ServiceAccountNameRegex = fmt.Sprintf(RFC1035NameTemplate, 4, 28)
 
-	ProjectNameInDNSFormRegex = "[-a-z0-9\\.]{1,63}"
-	ServiceAccountLinkRegex   = "projects/" + ProjectRegex + "/serviceAccounts/" + ServiceAccountNameRegex + "@" + ProjectNameInDNSFormRegex + "\\.iam\\.gserviceaccount\\.com$"
+	ServiceAccountLinkRegexPrefix = "projects/" + ProjectRegex + "/serviceAccounts/"
+	PossibleServiceAccountNames   = []string{
+		AppEngineServiceAccountNameRegex,
+		ComputeServiceAccountNameRegex,
+		CreatedServiceAccountNameRegex,
+	}
+	ServiceAccountLinkRegex = ServiceAccountLinkRegexPrefix + "(" + strings.Join(PossibleServiceAccountNames, "|") + ")"
+
+	// Format of service accounts created through the API
+	CreatedServiceAccountNameRegex = fmt.Sprintf(RFC1035NameTemplate, 4, 28) + "@" + ProjectNameInDNSFormRegex + "\\.iam\\.gserviceaccount\\.com$"
+	ProjectNameInDNSFormRegex      = "[-a-z0-9\\.]{1,63}"
+
+	// Format of default App Engine service accounts created by Google
+	AppEngineServiceAccountNameRegex = ProjectRegex + "@appspot.gserviceaccount.com"
 )
 
 var rfc1918Networks = []string{

--- a/google/validation_test.go
+++ b/google/validation_test.go
@@ -117,6 +117,8 @@ func TestValidateServiceAccountLink(t *testing.T) {
 		{TestName: "valid with dash", Value: "projects/my-project/serviceAccounts/svcacct@my-project.iam.gserviceaccount.com"},
 		{TestName: "valid with colon", Value: "projects/my:project/serviceAccounts/svcacct@project.my.iam.gserviceaccount.com"},
 		{TestName: "valid with dot and colon", Value: "projects/my.thing:project/serviceAccounts/svcacct@project.my.thing.iam.gserviceaccount.com"},
+		{TestName: "valid with compute default service account", Value: "projects/my-project/serviceAccounts/123456-compute@developer.gserviceaccount.com"},
+		{TestName: "valid with app engine default service account", Value: "projects/my-project/serviceAccounts/my-project@appspot.gserviceaccount.com"},
 
 		// Errors
 		{TestName: "multiple colons", Value: "projects/my:project:thing/serviceAccounts/svcacct@thing.project.my.iam.gserviceaccount.com", ExpectError: true},


### PR DESCRIPTION
Used for service_account_id for service account IAM policy.

Fixes #1374.