### PR TITLE
Add issue_client_certificate to cluster

### DIFF
--- a/google/data_source_google_container_cluster_test.go
+++ b/google/data_source_google_container_cluster_test.go
@@ -59,6 +59,7 @@ func testAccDataSourceGoogleContainerClusterCheck(dataSourceName string, resourc
 			"master_auth",
 			"master_auth.0.password",
 			"master_auth.0.username",
+			"master_auth.0.client_certificate_config.0.issue_client_certificate",
 			"master_auth.0.client_certificate",
 			"master_auth.0.client_key",
 			"master_auth.0.cluster_ca_certificate",

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -104,7 +104,7 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withMasterAuth(t *testing.T) {
+func TestAccContainerCluster_withMasterAuthConfig(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -115,8 +115,32 @@ func TestAccContainerCluster_withMasterAuth(t *testing.T) {
 			{
 				Config: testAccContainerCluster_withMasterAuth(),
 			},
-			resource.TestStep{
+			{
 				ResourceName:        "google_container_cluster.with_master_auth",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withMasterAuthConfig_NoCert(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withMasterAuthNoCert(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_master_auth_no_cert", "master_auth.0.client_certificate", ""),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_master_auth_no_cert",
 				ImportStateIdPrefix: "us-central1-a/",
 				ImportState:         true,
 				ImportStateVerify:   true,
@@ -1296,6 +1320,40 @@ resource "google_container_cluster" "with_master_auth" {
 	master_auth {
 		username = "mr.yoda"
 		password = "adoy.rm.123456789"
+	}
+}`, acctest.RandString(10))
+}
+
+func testAccContainerCluster_updateMasterAuthNoCert() string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_master_auth" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm.123456789"
+		client_certificate_config {
+			issue_client_certificate = false
+		}
+	}
+}`, acctest.RandString(10))
+}
+
+func testAccContainerCluster_withMasterAuthNoCert() string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_master_auth_no_cert" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm.123456789"
+		client_certificate_config {
+			issue_client_certificate = false
+		}
 	}
 }`, acctest.RandString(10))
 }


### PR DESCRIPTION
Fixes #1378. 
* Also changed test name so go test filter doesn't conflict with  MasterAuthorization...Tests

make testacc TEST=./google TESTARGS='--run="TestAccContainerCluster_withMasterAuthConfig"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v --run="TestAccContainerCluster_withMasterAuthConfig" -timeout 120m
=== RUN   TestAccContainerCluster_withMasterAuthConfig
=== PAUSE TestAccContainerCluster_withMasterAuthConfig
=== RUN   TestAccContainerCluster_withMasterAuthConfig_NoCert
=== PAUSE TestAccContainerCluster_withMasterAuthConfig_NoCert
=== CONT  TestAccContainerCluster_withMasterAuthConfig
=== CONT  TestAccContainerCluster_withMasterAuthConfig_NoCert
--- PASS: TestAccContainerCluster_withMasterAuthConfig_NoCert (394.82s)
--- PASS: TestAccContainerCluster_withMasterAuthConfig (396.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	396.281s

TF_ACC=1 go test ./google -v --run="TestAccContainerClusterDatasource_basic" -timeout 120m
=== RUN   TestAccContainerClusterDatasource_basic
=== PAUSE TestAccContainerClusterDatasource_basic
=== CONT  TestAccContainerClusterDatasource_basic
--- PASS: TestAccContainerClusterDatasource_basic (311.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	311.870s