### PR TITLE
Check that org listpolicy isn't nil.

### DIFF
--- a/google/resource_google_project_organization_policy_test.go
+++ b/google/resource_google_project_organization_policy_test.go
@@ -169,6 +169,10 @@ func testAccCheckGoogleProjectOrganizationListPolicyAll(n, policyType string) re
 			return err
 		}
 
+		if policy.ListPolicy == nil {
+			return nil
+		}
+
 		if len(policy.ListPolicy.AllowedValues) > 0 || len(policy.ListPolicy.DeniedValues) > 0 {
 			return fmt.Errorf("The `values` field shouldn't be set")
 		}


### PR DESCRIPTION
Fix a panic in our test that is caused by a ListPolicy being nil. I
assume, but cannot verify, that this is an API change in that it may now
send back a nil listpolicy if a default is used.