### PR TITLE
Always parse fixed64 string to int64

### DIFF
--- a/google/resource_compute_http_health_check.go
+++ b/google/resource_compute_http_health_check.go
@@ -393,7 +393,7 @@ func resourceComputeHttpHealthCheckImport(d *schema.ResourceData, meta interface
 func flattenComputeHttpHealthCheckCheckIntervalSec(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -411,7 +411,7 @@ func flattenComputeHttpHealthCheckDescription(v interface{}) interface{} {
 func flattenComputeHttpHealthCheckHealthyThreshold(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -429,7 +429,7 @@ func flattenComputeHttpHealthCheckName(v interface{}) interface{} {
 func flattenComputeHttpHealthCheckPort(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -443,7 +443,7 @@ func flattenComputeHttpHealthCheckRequestPath(v interface{}) interface{} {
 func flattenComputeHttpHealthCheckTimeoutSec(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -453,7 +453,7 @@ func flattenComputeHttpHealthCheckTimeoutSec(v interface{}) interface{} {
 func flattenComputeHttpHealthCheckUnhealthyThreshold(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/google/resource_compute_https_health_check.go
+++ b/google/resource_compute_https_health_check.go
@@ -393,7 +393,7 @@ func resourceComputeHttpsHealthCheckImport(d *schema.ResourceData, meta interfac
 func flattenComputeHttpsHealthCheckCheckIntervalSec(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -411,7 +411,7 @@ func flattenComputeHttpsHealthCheckDescription(v interface{}) interface{} {
 func flattenComputeHttpsHealthCheckHealthyThreshold(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -429,7 +429,7 @@ func flattenComputeHttpsHealthCheckName(v interface{}) interface{} {
 func flattenComputeHttpsHealthCheckPort(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -443,7 +443,7 @@ func flattenComputeHttpsHealthCheckRequestPath(v interface{}) interface{} {
 func flattenComputeHttpsHealthCheckTimeoutSec(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}
@@ -453,7 +453,7 @@ func flattenComputeHttpsHealthCheckTimeoutSec(v interface{}) interface{} {
 func flattenComputeHttpsHealthCheckUnhealthyThreshold(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -299,7 +299,7 @@ func flattenComputeTargetHttpProxyDescription(v interface{}) interface{} {
 func flattenComputeTargetHttpProxyProxyId(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -348,7 +348,7 @@ func flattenComputeTargetHttpsProxyDescription(v interface{}) interface{} {
 func flattenComputeTargetHttpsProxyProxyId(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -397,7 +397,7 @@ func flattenComputeTargetSslProxyDescription(v interface{}) interface{} {
 func flattenComputeTargetSslProxyProxyId(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}

--- a/google/resource_compute_target_tcp_proxy.go
+++ b/google/resource_compute_target_tcp_proxy.go
@@ -347,7 +347,7 @@ func flattenComputeTargetTcpProxyDescription(v interface{}) interface{} {
 func flattenComputeTargetTcpProxyProxyId(v interface{}) interface{} {
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}


### PR DESCRIPTION
Fixes #1426

`strconv.Atoi` returns the result of ParseInt(s, 10, 0). The last parameter is the `bitSize`. When `bitSize` is 0, it uses the default platform number of bits(32 for 32bits architecture) and crashes when parsing.