### PR TITLE
Mark google_compute_instance_template's nat_ip as ForceNew

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -238,6 +238,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 									"nat_ip": &schema.Schema{
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 										Computed: true,
 									},
 									// Instance templates will never have an


### PR DESCRIPTION
Previously, google_compute_instance_template's `network_interface.access_config.nat_ip` was not marked as "ForceNew".
Thus, if you change this and try to apply, you'll see an error saying

```
* google_compute_instance_template.foo: doesn't support update
```

This pull request fixes this.