### PR TITLE
add ability to retry cloud functions on failure

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the function.
 
+* `retry_on_failure` - (Optional) Whether the function should be retried on failure. This only applies to bucket and topic triggers, not HTTPS triggers.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
Fixes #1164.

I opted to top-level this because we already have precedent in this resource for top-leveling instead of nesting, but I could be persuaded otherwise. Also, the API for this is just to send an empty Retry object if you want to enable retries, which would lead to tf configs that look like this if we kept to the API:
```tf
resource "google_cloudfunctions_function" "function" {
  name = "whatever"
  // other properties
  failure_policy {
    retry {
    }
  }
}
```
since right now, the only thing in a failure policy that can be set is retry, which has no attributes of its own.
(see https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions)