### PR TITLE
Can't move from region to region without a recreate.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -107,6 +107,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"zone"},
 			},
 


### PR DESCRIPTION
I think this addresses #1450... moving from region to region should force a recreate.  I'm not certain this will work with provider-level region changes, though - I haven't quite figured out how to deal with that.  Testing on CI now.