### PR TITLE
use google_project_service for tests that enable the compute api

### DIFF
--- a/google/resource_compute_project_metadata_test.go
+++ b/google/resource_compute_project_metadata_test.go
@@ -212,9 +212,9 @@ resource "google_project" "project" {
   billing_account = "%s"
 }
 
-resource "google_project_services" "services" {
+resource "google_project_service" "compute" {
   project = "${google_project.project.project_id}"
-  services = ["compute.googleapis.com"]
+  service = "compute.googleapis.com"
 }
 
 resource "google_compute_project_metadata" "fizzbuzz" {
@@ -223,7 +223,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     banana = "orange"
     sofa = "darwinism"
   }
-  depends_on = ["google_project_services.services"]
+  depends_on = ["google_project_service.compute"]
 }`, projectID, name, org, billing)
 }
 
@@ -236,9 +236,9 @@ resource "google_project" "project" {
   billing_account = "%s"
 }
 
-resource "google_project_services" "services" {
+resource "google_project_service" "compute" {
   project = "${google_project.project.project_id}"
-  services = ["compute.googleapis.com"]
+  service = "compute.googleapis.com"
 }
 
 resource "google_compute_project_metadata" "fizzbuzz" {
@@ -247,7 +247,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     kiwi = "papaya"
     finches = "darwinism"
   }
-  depends_on = ["google_project_services.services"]
+  depends_on = ["google_project_service.compute"]
 }`, projectID, name, org, billing)
 }
 
@@ -260,9 +260,9 @@ resource "google_project" "project" {
   billing_account = "%s"
 }
 
-resource "google_project_services" "services" {
+resource "google_project_service" "compute" {
   project = "${google_project.project.project_id}"
-  services = ["compute.googleapis.com"]
+  service = "compute.googleapis.com"
 }
 
 resource "google_compute_project_metadata" "fizzbuzz" {
@@ -272,7 +272,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     genghis_khan = "french bread"
     happy = "smiling"
   }
-  depends_on = ["google_project_services.services"]
+  depends_on = ["google_project_service.compute"]
 }`, projectID, name, org, billing)
 }
 
@@ -285,9 +285,9 @@ resource "google_project" "project" {
   billing_account = "%s"
 }
 
-resource "google_project_services" "services" {
+resource "google_project_service" "compute" {
   project = "${google_project.project.project_id}"
-  services = ["compute.googleapis.com"]
+  service = "compute.googleapis.com"
 }
 
 resource "google_compute_project_metadata" "fizzbuzz" {
@@ -297,6 +297,6 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     paris = "french bread"
     happy = "laughing"
   }
-  depends_on = ["google_project_services.services"]
+  depends_on = ["google_project_service.compute"]
 }`, projectID, name, org, billing)
 }

--- a/google/resource_compute_shared_vpc_test.go
+++ b/google/resource_compute_shared_vpc_test.go
@@ -109,25 +109,25 @@ resource "google_project" "service" {
 	billing_account = "%s"
 }
 
-resource "google_project_services" "host" {
-	project  = "${google_project.host.project_id}"
-	services = ["compute.googleapis.com"]
+resource "google_project_service" "host" {
+	project = "${google_project.host.project_id}"
+	service = "compute.googleapis.com"
 }
 
-resource "google_project_services" "service" {
-	project  = "${google_project.service.project_id}"
-	services = ["compute.googleapis.com"]
+resource "google_project_service" "service" {
+	project = "${google_project.service.project_id}"
+	service = "compute.googleapis.com"
 }
 
 resource "google_compute_shared_vpc_host_project" "host" {
 	project    = "${google_project.host.project_id}"
-	depends_on = ["google_project_services.host"]
+	depends_on = ["google_project_service.host"]
 }
 
 resource "google_compute_shared_vpc_service_project" "service" {
 	host_project    = "${google_project.host.project_id}"
 	service_project = "${google_project.service.project_id}"
-	depends_on      = ["google_compute_shared_vpc_host_project.host", "google_project_services.service"]
+	depends_on      = ["google_compute_shared_vpc_host_project.host", "google_project_service.service"]
 }`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
 }
 
@@ -147,14 +147,14 @@ resource "google_project" "service" {
 	billing_account = "%s"
 }
 
-resource "google_project_services" "host" {
-	project  = "${google_project.host.project_id}"
-	services = ["compute.googleapis.com"]
+resource "google_project_service" "host" {
+	project = "${google_project.host.project_id}"
+	service = "compute.googleapis.com"
 }
 
-resource "google_project_services" "service" {
+resource "google_project_service" "service" {
 	project  = "${google_project.service.project_id}"
-	services = ["compute.googleapis.com"]
+	service = "compute.googleapis.com"
 }
 `, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
 }


### PR DESCRIPTION
Looks like `oslogin.googleapis.com` is now enabled automatically when compute is enabled. Since it can be enabled manually, I don't want to add it to the list of apis to skip. This fixes tests that enable compute without also enabling oslogin.