### PR TITLE
fix: replica_configuration.password  to be sensitive

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -334,9 +334,10 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							ForceNew: true,
 						},
 						"password": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Sensitive: true,
 						},
 						"ssl_cipher": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
currently, google_sql_database_instance.replica_configuration.password is not sensitve.
i think that sensitive is better.

thank you