### PR TITLE
Compare region_backend_service.backend[].group as a relative path

### DIFF
--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -39,8 +39,9 @@ func resourceComputeRegionBackendService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 						"description": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
In a `region_backend_service` resource, `backend[].group` argument is compared using full url. Therefore, if you pass a `self_link` of `instance_group` with beta feature enabled, you'll suffer from persisting perpetual diff.

E.g.:

```hcl
resource "google_compute_instance_group_manager" "foo" {
  // ...configs (omitted)...
  // ↓ This is beta feature
  update_strategy       = "ROLLING_UPDATE" 
  rolling_update_policy = {
    type           = "PROACTIVE"
    minimal_action = "REPLACE"
  }
}

resource "google_compute_region_backend_service" "foo" {
  // ...configs (omitted)...
  backend = [
    {
        group = "${google_compute_instance_group_manager.foo.self_link}"
    },
  ]
}
```

With this configuration, following diff always occurs.
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ google_compute_region_backend_service.foo
      backend.1111111111.description: "" => ""
      backend.1111111111.group:       "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instanceGroups/igm-foo" => ""
      backend.2222222222.description: "" => ""
      backend.2222222222.group:       "" => "https://www.googleapis.com/compute/beta/projects/my-project/zones/us-central1-a/instanceGroups/igm-foo"

Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------
```

To suppress this, I set `compareSelfLinkRelativePaths` as `DiffSuppressFunc` for `backend[].group`, like non-regional `backend_service` does.
https://github.com/terraform-providers/terraform-provider-google/blob/v1.12.0/google/resource_compute_backend_service.go#L80