### PR TITLE
compute address: use the specified project and region fields

### DIFF
--- a/google/data_source_google_compute_address_test.go
+++ b/google/data_source_google_compute_address_test.go
@@ -80,7 +80,7 @@ func testAccCheckDataSourceComputeAddressDestroy(resource_name string) resource.
 			return fmt.Errorf("can't find %s in state", resource_name)
 		}
 
-		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+		addressId, err := parseComputeAddressId(rs.Primary.ID, "", "")
 
 		_, err = config.clientCompute.Addresses.Get(
 			config.Project, addressId.Region, addressId.Name).Do()

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -131,7 +131,17 @@ func resourceComputeAddressCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	addressId, err := parseComputeAddressId(d.Id(), config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	addressId, err := parseComputeAddressId(d.Id(), project, region)
 	if err != nil {
 		return err
 	}
@@ -160,7 +170,17 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	addressId, err := parseComputeAddressId(d.Id(), config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	addressId, err := parseComputeAddressId(d.Id(), project, region)
 	if err != nil {
 		return err
 	}
@@ -184,7 +204,17 @@ func resourceComputeAddressDelete(d *schema.ResourceData, meta interface{}) erro
 func resourceComputeAddressImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 
-	addressId, err := parseComputeAddressId(d.Id(), config)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	addressId, err := parseComputeAddressId(d.Id(), project, region)
 	if err != nil {
 		return nil, err
 	}

--- a/google/resource_compute_address_migrate.go
+++ b/google/resource_compute_address_migrate.go
@@ -2,9 +2,10 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/terraform"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func resourceComputeAddressMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
@@ -58,7 +59,7 @@ func (s computeAddressId) canonicalId() string {
 	return fmt.Sprintf(computeAddressIdTemplate, s.Project, s.Region, s.Name)
 }
 
-func parseComputeAddressId(id string, config *Config) (*computeAddressId, error) {
+func parseComputeAddressId(id, project, region string) (*computeAddressId, error) {
 	var parts []string
 	if computeAddressLinkRegex.MatchString(id) {
 		parts = computeAddressLinkRegex.FindStringSubmatch(id)
@@ -80,27 +81,27 @@ func parseComputeAddressId(id string, config *Config) (*computeAddressId, error)
 		}, nil
 	} else if len(parts) == 2 {
 		// Project is optional.
-		if config.Project == "" {
+		if project == "" {
 			return nil, fmt.Errorf("The default project for the provider must be set when using the `{region}/{name}` id format.")
 		}
 
 		return &computeAddressId{
-			Project: config.Project,
+			Project: project,
 			Region:  parts[0],
 			Name:    parts[1],
 		}, nil
 	} else if len(parts) == 1 {
 		// Project and region is optional
-		if config.Project == "" {
+		if project == "" {
 			return nil, fmt.Errorf("The default project for the provider must be set when using the `{name}` id format.")
 		}
-		if config.Region == "" {
+		if region == "" {
 			return nil, fmt.Errorf("The default region for the provider must be set when using the `{name}` id format.")
 		}
 
 		return &computeAddressId{
-			Project: config.Project,
-			Region:  config.Region,
+			Project: project,
+			Region:  region,
 			Name:    parts[0],
 		}, nil
 	}

--- a/google/resource_compute_address_test.go
+++ b/google/resource_compute_address_test.go
@@ -19,6 +19,8 @@ func TestComputeAddressIdParsing(t *testing.T) {
 		ExpectedError       bool
 		ExpectedCanonicalId string
 		Config              *Config
+		Project             string
+		Region              string
 	}{
 		"id is a full self link": {
 			ImportId:            "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/addresses/test-address",
@@ -39,13 +41,14 @@ func TestComputeAddressIdParsing(t *testing.T) {
 			ImportId:            "us-central1/test-address",
 			ExpectedError:       false,
 			ExpectedCanonicalId: "projects/default-project/regions/us-central1/addresses/test-address",
-			Config:              &Config{Project: "default-project"},
+			Project:             "default-project",
 		},
 		"id is address": {
 			ImportId:            "test-address",
 			ExpectedError:       false,
 			ExpectedCanonicalId: "projects/default-project/regions/us-east1/addresses/test-address",
-			Config:              &Config{Project: "default-project", Region: "us-east1"},
+			Project:             "default-project",
+			Region:              "us-east1",
 		},
 		"id has invalid format": {
 			ImportId:      "i/n/v/a/l/i/d",
@@ -54,7 +57,7 @@ func TestComputeAddressIdParsing(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		addressId, err := parseComputeAddressId(tc.ImportId, tc.Config)
+		addressId, err := parseComputeAddressId(tc.ImportId, tc.Project, tc.Region)
 
 		if tc.ExpectedError && err == nil {
 			t.Fatalf("bad: %s, expected an error", tn)
@@ -150,7 +153,7 @@ func testAccCheckComputeAddressDestroy(s *terraform.State) error {
 			continue
 		}
 
-		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+		addressId, err := parseComputeAddressId(rs.Primary.ID, "", "")
 
 		_, err = config.clientCompute.Addresses.Get(
 			config.Project, addressId.Region, addressId.Name).Do()
@@ -175,7 +178,7 @@ func testAccCheckComputeAddressExists(n string, addr *compute.Address) resource.
 
 		config := testAccProvider.Meta().(*Config)
 
-		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+		addressId, err := parseComputeAddressId(rs.Primary.ID, "", "")
 
 		found, err := config.clientCompute.Addresses.Get(
 			config.Project, addressId.Region, addressId.Name).Do()
@@ -206,7 +209,7 @@ func testAccCheckComputeBetaAddressExists(n string, addr *computeBeta.Address) r
 
 		config := testAccProvider.Meta().(*Config)
 
-		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+		addressId, err := parseComputeAddressId(rs.Primary.ID, "", "")
 
 		found, err := config.clientComputeBeta.Addresses.Get(
 			config.Project, addressId.Region, addressId.Name).Do()


### PR DESCRIPTION
If the project or region fields are specified in the compute address resource use them as the fallback for parseComputeAddressId(). 

The current implementation ignored the project and region fields and used whatever was in the config as defaults.