### PR TITLE
Fix order of getting project for storage notification topic

### DIFF
--- a/google/resource_storage_notification.go
+++ b/google/resource_storage_notification.go
@@ -79,12 +79,15 @@ func resourceStorageNotificationCreate(d *schema.ResourceData, meta interface{})
 
 	bucket := d.Get("bucket").(string)
 
-	project, err := getProject(d, config)
-	if err != nil {
-		return err
+	topicName := d.Get("topic").(string)
+	computedTopicName := getComputedTopicName("", topicName)
+	if computedTopicName != topicName {
+		project, err := getProject(d, config)
+		if err != nil {
+			return err
+		}
+		computedTopicName = getComputedTopicName(project, topicName)
 	}
-
-	computedTopicName := getComputedTopicName(project, d.Get("topic").(string))
 
 	storageNotification := &storage.Notification{
 		CustomAttributes: expandStringMap(d, "custom_attributes"),

--- a/website/docs/r/storage_notification.html.markdown
+++ b/website/docs/r/storage_notification.html.markdown
@@ -60,8 +60,10 @@ The following arguments are supported:
 
 * `payload_format` - (Required) The desired content of the Payload. One of `"JSON_API_V1"` or `"NONE"`.
 
-* `topic` - (Required) The Cloud PubSub topic to which this subscription publishes.
-
+* `topic` - (Required) The Cloud PubSub topic to which this subscription publishes. Expects either the 
+    topic name, assumed to belong to the default GCP provider project, or the project-level name, 
+    i.e. `projects/my-gcp-project/topics/my-topic` or `my-topic`.
+    
 - - -
 
 * `custom_attributes` - (Optional)  A set of key/value attribute pairs to attach to each Cloud PubSub message published for this notification subscription

--- a/website/docs/r/storage_notification.html.markdown
+++ b/website/docs/r/storage_notification.html.markdown
@@ -44,7 +44,7 @@ resource "google_storage_notification" "notification" {
 	bucket            = "${google_storage_bucket.bucket.name}"
 	payload_format    = "JSON_API_V1"
 	topic             = "${google_pubsub_topic.topic.id}"
-	event_types       = ["%s","%s"]
+	event_types       = ["OBJECT_FINALIZE", "OBJECT_METADATA_UPDATE"]
 	custom_attributes {
 		new-attribute = "new-attribute-value"
 	}


### PR DESCRIPTION
Fixes #1486.

* See if the topic includes the project name before checking config.  
* Also, make documentation use actual constants rather than '%s', since it might be confusing 

Should I add a project field for the topic as well? Worried that if I add it, it will get confused with a project associated with the bucket/notification. 