### PR TITLE
Fixed region_backend_service to calc hash using relative path

### DIFF
--- a/google/resource_compute_backend_service_migrate.go
+++ b/google/resource_compute_backend_service_migrate.go
@@ -99,8 +99,12 @@ func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	group, _ := getRelativePath(m["group"].(string))
-	buf.WriteString(fmt.Sprintf("%s-", group))
+	if group, err := getRelativePath(m["group"].(string)); err != nil {
+		log.Printf("[WARN] Error on retrieving relative path of instance group: %s", err)
+		buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	} else {
+		buf.WriteString(fmt.Sprintf("%s-", group))
+	}
 
 	if v, ok := m["balancing_mode"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -331,7 +331,8 @@ func resourceGoogleComputeRegionBackendServiceBackendHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	group, _ := getRelativePath(m["group"].(string))
+	buf.WriteString(fmt.Sprintf("%s-", group))
 
 	if v, ok := m["description"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -331,8 +331,12 @@ func resourceGoogleComputeRegionBackendServiceBackendHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	group, _ := getRelativePath(m["group"].(string))
-	buf.WriteString(fmt.Sprintf("%s-", group))
+	if group, err := getRelativePath(m["group"].(string)); err != nil {
+		log.Printf("[WARN] Error on retrieving relative path of instance group: %s", err)
+		buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	} else {
+		buf.WriteString(fmt.Sprintf("%s-", group))
+	}
 
 	if v, ok := m["description"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))


### PR DESCRIPTION
Along the change on region_backend_service.backend[].group to use DiffSuppressFunc (#1487), we also need to change hash function, as [pointed out](https://github.com/terraform-providers/terraform-provider-google/pull/1487#issuecomment-389000239).

Fixed this in a same way regular backend services do.
https://github.com/terraform-providers/terraform-provider-google/blob/v1.12.0/google/resource_compute_backend_service_migrate.go#L102-L103