### PR TITLE
Implement multiple version in instance group manager

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -40,7 +40,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"version": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -337,14 +336,14 @@ func flattenVersions(versions []*computeBeta.InstanceGroupManagerVersion) []map[
 		versionMap := make(map[string]interface{})
 		versionMap["name"] = version.Name
 		versionMap["instance_template"] = ConvertSelfLinkToV1(version.InstanceTemplate)
-		versionMap["target_size"] = flattendFixedOrPercent(version.TargetSize)
+		versionMap["target_size"] = flattenFixedOrPercent(version.TargetSize)
 		result = append(result, versionMap)
 	}
 
 	return result
 }
 
-func flattendFixedOrPercent(fixedOrPercent *computeBeta.FixedOrPercent) map[string]interface{} {
+func flattenFixedOrPercent(fixedOrPercent *computeBeta.FixedOrPercent) map[string]interface{} {
 	result := make(map[string]interface{})
 	if value := fixedOrPercent.Percent; value > 0 {
 		result["percent"] = value

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -1246,7 +1246,9 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 	version {
 		name = "canary"
 		instance_template = "${google_compute_instance_template.igm-canary.self_link}"
-		target_size_fixed = 1
+		target_size {
+			fixed = 1
+		}
 	}
 }
 	`, primaryTemplate, canaryTemplate, igm)

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -269,6 +269,36 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	})
 }
 
+func TestAccInstanceGroupManager_versions(t *testing.T) {
+	t.Parallel()
+
+	var manager computeBeta.InstanceGroupManager
+
+	primaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	canaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceGroupManagerBetaExists("google_compute_instance_group_manager.igm-basic", &manager),
+					testAccCheckInstanceGroupManagerVersions("google_compute_instance_group_manager.igm-basic", primaryTemplate, canaryTemplate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
@@ -486,6 +516,42 @@ func testAccCheckInstanceGroupManagerNamedPorts(n string, np map[string]int64, i
 			if !found {
 				return fmt.Errorf("named port incorrect")
 			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckInstanceGroupManagerVersions(n string, primaryTemplate string, canaryTemplate string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		manager, err := config.clientComputeBeta.InstanceGroupManagers.Get(config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if len(manager.Versions) != 2 {
+			return fmt.Errorf("Expected # of versions to be 2, got %d", len(manager.Versions))
+		}
+
+		primaryVersion := manager.Versions[0]
+		if !strings.Contains(primaryVersion.InstanceTemplate, primaryTemplate) {
+			return fmt.Errorf("Expected string \"%s\" to appear in \"%s\"", primaryTemplate, primaryVersion.InstanceTemplate)
+		}
+
+		canaryVersion := manager.Versions[1]
+		if !strings.Contains(canaryVersion.InstanceTemplate, canaryTemplate) {
+			return fmt.Errorf("Expected string \"%s\" to appear in \"%s\"", canaryTemplate, canaryVersion.InstanceTemplate)
 		}
 
 		return nil
@@ -1119,6 +1185,71 @@ resource "google_compute_http_health_check" "zero" {
 	timeout_sec        = 1
 }
 	`, template, target, igm, hck)
+}
+
+func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance_template" "igm-primary" {
+	name = "%s"
+	machine_type = "n1-standard-1"
+	can_ip_forward = false
+	tags = ["foo", "bar"]
+	disk {
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		auto_delete = true
+		boot = true
+	}
+	network_interface {
+		network = "default"
+	}
+	metadata {
+		foo = "bar"
+	}
+	service_account {
+		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+	}
+}
+
+resource "google_compute_instance_template" "igm-canary" {
+	name = "%s"
+	machine_type = "n1-standard-1"
+	can_ip_forward = false
+	tags = ["foo", "bar"]
+	disk {
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		auto_delete = true
+		boot = true
+	}
+	network_interface {
+		network = "default"
+	}
+	metadata {
+		foo = "bar"
+	}
+	service_account {
+		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+	}
+}
+
+resource "google_compute_instance_group_manager" "igm-basic" {
+	description = "Terraform test instance group manager"
+	name = "%s"
+	base_instance_name = "igm-basic"
+	zone = "us-central1-c"
+	target_size = 2
+
+	version {
+		name = "primary"
+		instance_template = "${google_compute_instance_template.igm-primary.self_link}"
+	}
+
+	version {
+		name = "canary"
+		instance_template = "${google_compute_instance_template.igm-canary.self_link}"
+		target_size_fixed = 1
+	}
+}
+	`, primaryTemplate, canaryTemplate, igm)
 }
 
 // This test is to make sure that a single version resource can link to a versioned resource

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -15,7 +15,7 @@ and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupMa
 
 ~> **Note:** Use [google_compute_region_instance_group_manager](/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
 
-## Example Usage
+## Example Usage with top level instance template
 
 ```hcl
 resource "google_compute_health_check" "autohealing" {
@@ -54,6 +54,44 @@ resource "google_compute_instance_group_manager" "appserver" {
 }
 ```
 
+## Example Usage with multiple Versions
+```hcl
+resource "google_compute_instance_group_manager" "appserver" {
+  name = "appserver-igm"
+
+  base_instance_name = "app"
+  update_strategy    = "NONE"
+  zone               = "us-central1-a"
+
+  target_pools = ["${google_compute_target_pool.appserver.self_link}"]
+  target_size  = 5
+
+  version {
+    instance_template  = "${google_compute_instance_template.appserver.self_link}"
+  }
+
+  version {
+    instance_template  = "${google_compute_instance_template.appserver-canary.self_link}"
+    target_size_fixed  = 1
+  }
+
+  named_port {
+    name = "customHTTP"
+    port = 8888
+  }
+
+  auto_healing_policies {
+    health_check      = "${google_compute_health_check.autohealing.self_link}"
+    initial_delay_sec = 300
+  }
+}
+```
+
+Beware that exactly one version must not specify a target size (through target_size_fixed
+or target_size_percent fields). It means that versions with a target size will respect
+the setting, and the one without target size will be applied to all remaining Instances
+(top level target_size - each version target_size).
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -65,8 +103,12 @@ The following arguments are supported:
     appending a hyphen and a random four-character string to the base instance
     name.
 
-* `instance_template` - (Required) The full URL to an instance template from
-    which all new instances will be created.
+* `instance_template` - (Optional) The full URL to an instance template from
+    which all new instances will be created. Conflicts with `version` (see [documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups#relationship_between_instancetemplate_properties_for_a_managed_instance_group))
+
+* `version` - (Optional) Application versions managed by this instance group. each
+    version deals with a specific instance template, allowing canary release scenarios.
+    Conflicts with `instance_template`. Structure is documented below.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
     characters long and comply with
@@ -153,6 +195,32 @@ The **auto_healing_policies** block supports:
 
 * `initial_delay_sec` - (Required) The number of seconds that the managed instance group waits before
  it applies autohealing policies to new instances or recently recreated instances. Between 0 and 3600.
+
+The **version** block supports:
+
+```hcl
+version {
+ name = "appserver-canary"
+ instance_template = "${google_compute_instance_template.appserver-canary.self_link}"
+ target_size_fixed = 1
+}
+```
+
+```hcl
+version {
+ name = "appserver-canary"
+ instance_template = "${google_compute_instance_template.appserver-canary.self_link}"
+ target_size_percent = 20
+}
+```
+
+* `name` - (Required) - Version name.
+
+* `instance_template` - (Required) - The full URL to an instance template from which all new instances of this version will be created.
+
+* `target_size_fixed` - (Optional), The number of instances which will be managed for this version. Conflicts with `target_size_percent`.
+
+* `target_size_percent` - (Optional), The number of instances (calculated as percentage) which are managed for this version. Conflicts with `target_size_fixed`.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -54,6 +54,30 @@ resource "google_compute_instance_group_manager" "appserver" {
 }
 ```
 
+## Example Usage with multiple Versions
+```hcl
+resource "google_compute_instance_group_manager" "appserver" {
+  name = "appserver-igm"
+
+  base_instance_name = "app"
+  update_strategy    = "NONE"
+  zone               = "us-central1-a"
+
+  target_size  = 5
+
+  version {
+    instance_template  = "${google_compute_instance_template.appserver.self_link}"
+  }
+
+  version {
+    instance_template  = "${google_compute_instance_template.appserver-canary.self_link}"
+    target_size {
+      fixed = 1
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -167,7 +191,9 @@ The **version** block supports:
 version {
  name = "appserver-canary"
  instance_template = "${google_compute_instance_template.appserver-canary.self_link}"
- target_size_fixed = 1
+ target_size {
+   fixed = 1
+ }
 }
 ```
 
@@ -175,30 +201,9 @@ version {
 version {
  name = "appserver-canary"
  instance_template = "${google_compute_instance_template.appserver-canary.self_link}"
- target_size_percent = 20
-}
-```
-## Example Usage with multiple Versions
-```hcl
-resource "google_compute_instance_group_manager" "appserver" {
-  name = "appserver-igm"
-
-  base_instance_name = "app"
-  update_strategy    = "NONE"
-  zone               = "us-central1-a"
-
-  target_size  = 5
-
-  version {
-    instance_template  = "${google_compute_instance_template.appserver.self_link}"
-  }
-
-  version {
-    instance_template  = "${google_compute_instance_template.appserver-canary.self_link}"
-    target_size {
-      fixed = 1
-    }
-  }
+ target_size {
+   percent = 20
+ }
 }
 ```
 


### PR DESCRIPTION
Hi there,

Here is an attempt to implement canary releases ( #1252 ). This is the first time I write golang and make a terraform contribution, I opened the PR to obtain feedback and advices so please let me know how I can improve this code!

In addition I used `make fmt` to format the code but left some lines bigger than 80 characters, do I need to split them ?

I tested the feature against a project with the following configuration:
```
resource "google_compute_health_check" "mikael-hackathon-healthcheck" {
  name                = "mikael-hackathon-healthcheck"
  check_interval_sec  = 1
  timeout_sec         = 1
  healthy_threshold   = 2
  unhealthy_threshold = 10

  http_health_check {
    request_path = "/"
    port         = "80"
  }
}

resource "google_compute_instance_template" "mikael-hackaton-template" {
  name_prefix = "mikael-hackaton-"
  description = "This template is used to create app server instances."

  tags = ["loadbalanced", "internal-web", "hackaton"]

  labels = {
    environment = "hackaton"
  }

  instance_description = "Hackaton demo rolling upgrade"
  machine_type         = "n1-standard-1"
  can_ip_forward       = false

  scheduling {
    automatic_restart   = true
    on_host_maintenance = "MIGRATE"
  }

  disk {
    source_image = "debian-cloud/debian-9"
    disk_type    = "pd-standard"
    disk_size_gb = 20
    auto_delete  = true
    boot         = true
  }

  network_interface {
    network       = "default"
    access_config = {}
  }

  service_account {
    email  = "${google_service_account.mikael-hackaton.email}"
    scopes = ["cloud-platform"]
  }

  lifecycle {
    create_before_destroy = true
  }

  metadata_startup_script = "apt-get update && apt-get install -y apache2 && echo I am stable version at $(hostname) > /var/www/html/index.html"
}

resource "google_compute_instance_template" "mikael-hackaton-template-canary" {
  name_prefix = "mikael-hackaton-canary"
  description = "This template is used to create app server instances."

  tags = ["loadbalanced", "internal-web", "hackaton"]

  labels = {
    environment = "hackaton"
  }

  instance_description = "Hackaton demo rolling upgrade"
  machine_type         = "n1-standard-1"
  can_ip_forward       = false

  scheduling {
    automatic_restart   = true
    on_host_maintenance = "MIGRATE"
  }

  disk {
    source_image = "debian-cloud/debian-9"
    disk_type    = "pd-standard"
    disk_size_gb = 20
    auto_delete  = true
    boot         = true
  }

  network_interface {
    network       = "default"
    access_config = {}
  }

  service_account {
    email  = "${google_service_account.mikael-hackaton.email}"
    scopes = ["cloud-platform"]
  }

  lifecycle {
    create_before_destroy = true
  }

  metadata_startup_script = "apt-get update && apt-get install -y apache2 && echo I am a canary at $(hostname) > /var/www/html/index.html"
}

resource "google_compute_target_pool" "mikael-hackaton-target-pool" {
  name = "mikael-hackaton-target-pool"
}

resource "google_compute_instance_group_manager" "mikael-hackaton-manager" {
  name = "mikael-hackaton-manager"
  base_instance_name = "mikael-hackaton"
  #instance_template = "${google_compute_instance_template.mikael-hackaton-template.self_link}"
  update_strategy   = "ROLLING_UPDATE"
  zone              = "${var.zone}"
  target_pools = ["${google_compute_target_pool.mikael-hackaton-target-pool.self_link}"]
  target_size  = 5

  version {
    name = "primary"
    instance_template = "${google_compute_instance_template.mikael-hackaton-template.self_link}"
  }

  version {
    name = "canary"
    instance_template = "${google_compute_instance_template.mikael-hackaton-template-canary.self_link}"
    target_size_fixed = 1
  }

  named_port {
    name = "http"
    port = 80
  }

  auto_healing_policies {
    health_check      = "${google_compute_health_check.mikael-hackathon-healthcheck.self_link}"
    initial_delay_sec = 10
  }

  rolling_update_policy {
    type                    = "PROACTIVE"
    minimal_action          = "REPLACE"
    max_surge_percent       = 100
    max_unavailable_percent = 50
    min_ready_sec           = 5
  }
}
```