### PR TITLE
website/docs/d/datasource_client_config: makes docs use datasource

### DIFF
--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -33,9 +33,9 @@ data "google_container_cluster" "my_cluster" {
 provider "kubernetes" {
   load_config_file = false
 
-  host = "https://${google_container_cluster.my_cluster.endpoint}"
+  host = "https://${data.google_container_cluster.my_cluster.endpoint}"
   token = "${data.google_client_config.default.access_token}"
-  cluster_ca_certificate = "${base64decode(google_container_cluster.my_cluster.master_auth.0.cluster_ca_certificate)}"
+  cluster_ca_certificate = "${base64decode(data.google_container_cluster.my_cluster.master_auth.0.cluster_ca_certificate)}"
 }
 ```
 


### PR DESCRIPTION
The docs currently don't use the datasource version of 'google_client_config'. This PR just prefixes 'data.' to 'google_client_config' in the datasource docs.