### PR TITLE
Add basic update for `google_kms_crypto_key` resource

### DIFF
--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -120,7 +120,7 @@ func resourceKmsCryptoKeyUpdate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	key := cloudkms.CryptoKey{Purpose: "ENCRYPT_DECRYPT"}
+	key := cloudkms.CryptoKey{}
 
 	if d.HasChange("rotation_period") && d.Get("rotation_period") != "" {
 		rotationPeriod := d.Get("rotation_period").(string)

--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -16,6 +16,7 @@ func resourceKmsCryptoKey() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceKmsCryptoKeyCreate,
 		Read:   resourceKmsCryptoKeyRead,
+		Update: resourceKmsCryptoKeyUpdate,
 		Delete: resourceKmsCryptoKeyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -36,7 +37,7 @@ func resourceKmsCryptoKey() *schema.Resource {
 			"rotation_period": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
+				ForceNew:     false,
 				ValidateFunc: validateKmsCryptoKeyRotationPeriod,
 			},
 		},
@@ -105,6 +106,46 @@ func resourceKmsCryptoKeyCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Created CryptoKey %s", cryptoKey.Name)
+
+	d.SetId(cryptoKeyId.cryptoKeyId())
+
+	return resourceKmsCryptoKeyRead(d, meta)
+}
+
+func resourceKmsCryptoKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	cryptoKeyId, err := parseKmsCryptoKeyId(d.Id(), config)
+	if err != nil {
+		return err
+	}
+
+	key := cloudkms.CryptoKey{Purpose: "ENCRYPT_DECRYPT"}
+
+	if d.HasChange("rotation_period") && d.Get("rotation_period") != "" {
+		rotationPeriod := d.Get("rotation_period").(string)
+		nextRotation, err := kmsCryptoKeyNextRotation(time.Now(), rotationPeriod)
+
+		if err != nil {
+			return fmt.Errorf("Error setting CryptoKey rotation period: %s", err.Error())
+		}
+
+		key.NextRotationTime = nextRotation
+		key.RotationPeriod = rotationPeriod
+	}
+
+	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Patch(
+		cryptoKeyId.cryptoKeyId(),
+		&key,
+	).
+		UpdateMask("rotation_period,next_rotation_time").
+		Do()
+
+	if err != nil {
+		return fmt.Errorf("Error updating CryptoKey: %s", err.Error())
+	}
+
+	log.Printf("[DEBUG] Updated CryptoKey %s", cryptoKey.Name)
 
 	d.SetId(cryptoKeyId.cryptoKeyId())
 

--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -37,7 +37,6 @@ func resourceKmsCryptoKey() *schema.Resource {
 			"rotation_period": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     false,
 				ValidateFunc: validateKmsCryptoKeyRotationPeriod,
 			},
 		},

--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -134,12 +134,7 @@ func resourceKmsCryptoKeyUpdate(d *schema.ResourceData, meta interface{}) error 
 		key.RotationPeriod = rotationPeriod
 	}
 
-	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Patch(
-		cryptoKeyId.cryptoKeyId(),
-		&key,
-	).
-		UpdateMask("rotation_period,next_rotation_time").
-		Do()
+	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Patch(cryptoKeyId.cryptoKeyId(), &key).UpdateMask("rotation_period,next_rotation_time").Do()
 
 	if err != nil {
 		return fmt.Errorf("Error updating CryptoKey: %s", err.Error())

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -146,6 +146,7 @@ func TestAccKmsCryptoKey_rotation(t *testing.T) {
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	rotationPeriod := "100000s"
+	updatedRotationPeriod := "7776000s"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -156,6 +157,20 @@ func TestAccKmsCryptoKey_rotation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleKmsCryptoKeyExists("google_kms_crypto_key.crypto_key"),
 					testAccCheckGoogleKmsCryptoKeyHasRotationParams(rotationPeriod, "google_kms_crypto_key.crypto_key"),
+				),
+			},
+			resource.TestStep{
+				Config: testGoogleKmsCryptoKey_rotation(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, updatedRotationPeriod),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyExists("google_kms_crypto_key.crypto_key"),
+					testAccCheckGoogleKmsCryptoKeyHasRotationParams(updatedRotationPeriod, "google_kms_crypto_key.crypto_key"),
+				),
+			},
+			resource.TestStep{
+				Config: testGoogleKmsCryptoKey_rotationRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyExists("google_kms_crypto_key.crypto_key"),
+					testAccCheckGoogleKmsCryptoKeyHasRotationParams("", "google_kms_crypto_key.crypto_key"),
 				),
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
@@ -355,6 +370,36 @@ resource "google_kms_crypto_key" "crypto_key" {
 	rotation_period = "%s"
 }
 	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod)
+}
+
+func testGoogleKmsCryptoKey_rotationRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_services" "acceptance" {
+	project = "${google_project.acceptance.project_id}"
+
+	services = [
+	  "cloudkms.googleapis.com",
+	]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = "${google_project_services.acceptance.project}"
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name            = "%s"
+	key_ring        = "${google_kms_key_ring.key_ring.id}"
+}
+	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
 
 func testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName string) string {

--- a/google/resource_kms_crypto_key_test.go
+++ b/google/resource_kms_crypto_key_test.go
@@ -252,6 +252,10 @@ func testAccCheckGoogleKmsCryptoKeyHasRotationParams(rotationPeriod, resourceNam
 			return fmt.Errorf("Expected rotation period %s to match input %s", getCryptoKeyResponse.RotationPeriod, rotationPeriod)
 		}
 
+		if getCryptoKeyResponse.NextRotationTime == "" {
+			return nil
+		}
+
 		_, err = time.Parse(time.RFC3339Nano, getCryptoKeyResponse.NextRotationTime)
 
 		if err != nil {


### PR DESCRIPTION
Prior to this commit, any changes to `rotation_period` would
force a new resource as no `Update` was defined for the resource.
This commit introduces a basic `Update` through calling the
`Patch` service method. It only modifies the `rotation_period`,
and `next_rotation_time` at the moment, but this is reflective
of what is "allowed" on https://console.cloud.google.com/security/kms.