### PR TITLE
Ignore role_entity order in storage_bucket_acl

### DIFF
--- a/google/resource_storage_bucket_acl.go
+++ b/google/resource_storage_bucket_acl.go
@@ -38,9 +38,10 @@ func resourceStorageBucketAcl() *schema.Resource {
 			},
 
 			"role_entity": &schema.Schema{
-				Type:          schema.TypeList,
+				Type:          schema.TypeSet,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
 				ConflictsWith: []string{"predefined_acl"},
 			},
 		},
@@ -79,7 +80,7 @@ func resourceStorageBucketAclCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("role_entity"); ok {
-		role_entity = v.([]interface{})
+		role_entity = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("default_acl"); ok {
@@ -199,7 +200,7 @@ func resourceStorageBucketAclUpdate(d *schema.ResourceData, meta interface{}) er
 
 		project := strconv.FormatUint(bkt.ProjectNumber, 10)
 		o, n := d.GetChange("role_entity")
-		old_re, new_re := o.([]interface{}), n.([]interface{})
+		old_re, new_re := o.(*schema.Set).List(), n.(*schema.Set).List()
 
 		old_re_map := make(map[string]string)
 		for _, v := range old_re {
@@ -284,7 +285,7 @@ func resourceStorageBucketAclDelete(d *schema.ResourceData, meta interface{}) er
 	}
 	project := strconv.FormatUint(bkt.ProjectNumber, 10)
 
-	re_local := d.Get("role_entity").([]interface{})
+	re_local := d.Get("role_entity").(*schema.Set).List()
 	for _, v := range re_local {
 		res, err := getRoleEntityPair(v.(string))
 		if err != nil {

--- a/google/resource_storage_bucket_acl_test.go
+++ b/google/resource_storage_bucket_acl_test.go
@@ -46,6 +46,27 @@ func TestAccStorageBucketAcl_basic(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucketAcl_unsorted(t *testing.T) {
+	t.Parallel()
+
+	bucketName := testBucketName()
+	skipIfEnvNotSet(t, "GOOGLE_PROJECT_NUMBER")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageBucketAclDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleStorageBucketsAclBasicUnsorted(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageBucketAcl(bucketName, roleEntityBasic2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStorageBucketAcl_upgrade(t *testing.T) {
 	t.Parallel()
 
@@ -203,6 +224,19 @@ resource "google_storage_bucket_acl" "acl" {
 	role_entity = ["%s", "%s", "%s", "%s", "%s"]
 }
 `, bucketName, roleEntityOwners, roleEntityEditors, roleEntityViewers, roleEntityBasic1, roleEntityBasic2)
+}
+
+func testGoogleStorageBucketsAclBasicUnsorted(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+	name = "%s"
+}
+
+resource "google_storage_bucket_acl" "acl" {
+	bucket = "${google_storage_bucket.bucket.name}"
+	role_entity = ["%s", "%s", "%s", "%s", "%s"]
+}
+`, bucketName, roleEntityBasic2, roleEntityViewers, roleEntityEditors, roleEntityBasic1, roleEntityOwners)
 }
 
 func testGoogleStorageBucketsAclBasic2(bucketName string) string {


### PR DESCRIPTION
When you set `role_entity` in `storage_bucket_acl`, it will be sorted in the following order: project-owners, project-editors, project-viewers and rest.

Therefore, a diff persists after `apply` if you don't set `role_entity` in the right order.

```hcl
resource "google_storage_bucket_acl" "foo" {
  bucket = "${google_storage_bucket.foo.name}"

  role_entity = [
    "OWNER:user-${google_service_account.bar.email}",
    "READER:project-viewers-${data.google_project.this.number}",
    "OWNER:project-editors-${data.google_project.this.number}",
    "OWNER:user-${google_service_account.baz.email}",
    "OWNER:project-owners-${data.google_project.this.number}",
  ]
}
```

With this configuration, following diff appears every time even after `apply`.

```
  ~ google_storage_bucket_acl.foo
      role_entity.0:  "OWNER:user-bar@myproject.iam.gserviceaccount.com" => "OWNER:project-owners-0123456789"
      role_entity.1:  "READER:project-viewers-0123456789" => "OWNER:project-editors-0123456789"
      role_entity.2:  "OWNER:project-editors-0123456789" => "READER:project-viewers-0123456789"
      role_entity.3:  "OWNER:user-baz@myproject.iam.gserviceaccount.com" => "OWNER:user-bar@myproject.iam.gserviceaccount.com"
      role_entity.4:  "OWNER:project-owners-0123456789" => "OWNER:user-baz@myproject.iam.gserviceaccount.com"
```

However, its order doesn't matter in the sense of access control.

To suppress this annoying diff, I changed the type of `role_entity` argument from `schema.TypeList` to `schema.TypeSet`.

Note: issue #892 looks related, but may be different problem.