### PR TITLE
#936 adding support for AuditLogConfigs in IAM Policies

### DIFF
--- a/google/iam.go
+++ b/google/iam.go
@@ -154,3 +154,67 @@ func rolesToMembersMap(bindings []*cloudresourcemanager.Binding) map[string]map[
 	}
 	return bm
 }
+
+// Merge multiple Audit Configs such that configs with the same service result in
+// a single exemption list with combined members
+func mergeAuditConfigs(audit_configs []*cloudresourcemanager.AuditConfig) []*cloudresourcemanager.AuditConfig {
+	am := auditConfigToServiceMap(audit_configs)
+	ac := make([]*cloudresourcemanager.AuditConfig, 0)
+
+	for service, audit_log_configs := range am {
+		var a cloudresourcemanager.AuditConfig
+		a.Service = service
+		a.AuditLogConfigs = make([]*cloudresourcemanager.AuditLogConfig, 0)
+
+		for k, v := range audit_log_configs {
+
+			var alc cloudresourcemanager.AuditLogConfig
+			alc.LogType = k
+			for member, _ := range v {
+				alc.ExemptedMembers = append(alc.ExemptedMembers, member)
+			}
+
+			a.AuditLogConfigs = append(a.AuditLogConfigs, &alc)
+		}
+
+		if len(a.AuditLogConfigs) > 0 {
+			ac = append(ac, &a)
+		}
+	}
+
+	return ac
+}
+
+// Build a service map with the log_type and bindings below it
+func auditConfigToServiceMap(audit_config []*cloudresourcemanager.AuditConfig) map[string]map[string]map[string]bool {
+	ac := make(map[string]map[string]map[string]bool)
+
+	// Get each config
+	for _, c := range audit_config {
+
+		// Initialize service map
+		if _, ok := ac[c.Service]; !ok {
+			ac[c.Service] = make(map[string]map[string]bool)
+		}
+
+		// loop through audit log configs
+		for _, lc := range c.AuditLogConfigs {
+
+			// Initialize service map
+			if _, ok := ac[c.Service][lc.LogType]; !ok {
+				ac[c.Service][lc.LogType] = make(map[string]bool)
+			}
+
+			// Get each member (user/principal) for the binding
+			for _, m := range lc.ExemptedMembers {
+				// Add the member
+				if _, ok := ac[c.Service][lc.LogType][m]; !ok {
+					ac[c.Service][lc.LogType][m] = true
+				}
+
+			}
+		}
+	}
+
+	return ac
+}

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -98,7 +98,9 @@ func resourceGoogleProjectIamPolicyCreate(d *schema.ResourceData, meta interface
 
 		// Merge the policies together
 		mb := mergeBindings(append(p.Bindings, rp.Bindings...))
+		mc := mergeAuditConfigs(append(p.AuditConfigs, rp.AuditConfigs...))
 		ep.Bindings = mb
+		ep.AuditConfigs = mc
 		if err = setProjectIamPolicy(ep, config, pid); err != nil {
 			return fmt.Errorf("Error applying IAM policy to project: %v", err)
 		}
@@ -134,7 +136,7 @@ func resourceGoogleProjectIamPolicyRead(d *schema.ResourceData, meta interface{}
 		bindings = p.Bindings
 	}
 	// we only marshal the bindings, because only the bindings get set in the config
-	pBytes, err := json.Marshal(&cloudresourcemanager.Policy{Bindings: bindings})
+	pBytes, err := json.Marshal(&cloudresourcemanager.Policy{Bindings: bindings, AuditConfigs: p.AuditConfigs})
 	if err != nil {
 		return fmt.Errorf("Error marshaling IAM policy: %v", err)
 	}
@@ -203,7 +205,9 @@ func resourceGoogleProjectIamPolicyUpdate(d *schema.ResourceData, meta interface
 
 		// Merge the policies together
 		mb := mergeBindings(append(p.Bindings, rp.Bindings...))
+		mc := mergeAuditConfigs(append(p.AuditConfigs, rp.AuditConfigs...))
 		ep.Bindings = mb
+		ep.AuditConfigs = mc
 		if err = setProjectIamPolicy(ep, config, pid); err != nil {
 			return fmt.Errorf("Error applying IAM policy to project: %v", err)
 		}
@@ -243,6 +247,7 @@ func resourceGoogleProjectIamPolicyDelete(d *schema.ResourceData, meta interface
 			return fmt.Errorf("Error retrieving previous version of changed project IAM policy: %v", err)
 		}
 		ep.Bindings = rp.Bindings
+		ep.AuditConfigs = rp.AuditConfigs
 	}
 	if err = setProjectIamPolicy(ep, config, pid); err != nil {
 		return fmt.Errorf("Error applying IAM policy to project: %v", err)

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -300,7 +300,7 @@ func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pi
 	pbytes, _ := json.Marshal(policy)
 	log.Printf("[DEBUG] Setting policy %#v for project: %s", string(pbytes), pid)
 	_, err := config.clientResourceManager.Projects.SetIamPolicy(pid,
-		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy}).Do()
+		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy, UpdateMask: "bindings,etag,auditConfigs"}).Do()
 
 	if err != nil {
 		return errwrap.Wrapf(fmt.Sprintf("Error applying IAM policy for project %q. Policy is %#v, error is {{err}}", pid, policy), err)

--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -88,7 +88,7 @@ each accept the following arguments:
   	* `audit_log_configs` (Required) A nested block that defines the operations you'd like to log.
   	  * `log_type` (Required) Defines the logging level. `DATA_READ`, `DATA_WRITE` and `ADMIN_READ` capture different types of events. See [the audit configuration documentation](https://cloud.google.com/resource-manager/reference/rest/Shared.Types/AuditConfig) for more details.
   	  * `exempted_members` (Optional) Specifies the identities that are exempt from these types of logging operations. Follows the same format of the `members` array for `binding`.
-  	  * 
+
 ## Attributes Reference
 
 The following attribute is exported:

--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -29,6 +29,25 @@ data "google_iam_policy" "admin" {
       "user:jane@example.com",
     ]
   }
+  
+  audit_config {
+    service = "cloudkms.googleapis.com"
+    audit_log_configs = [
+      {
+        log_type = "DATA_READ",
+        exempted_members = [
+          "user:you@domain.com",
+        ]
+      },
+      {
+        "logType": "DATA_WRITE",
+      },
+      {
+        "logType": "ADMIN_READ",
+      }
+    ]
+  }
+  
 }
 ```
 
@@ -64,6 +83,12 @@ each accept the following arguments:
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
   * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
 
+* `audit_config` (Optional) - A nested configuration block that defines logging additional configuration for your project.
+  	* `service` (Required) Defines a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services.
+  	* `audit_log_configs` (Required) A nested block that defines the operations you'd like to log.
+  	  * `log_type` (Required) Defines the logging level. `DATA_READ`, `DATA_WRITE` and `ADMIN_READ` capture different types of events. See [the audit configuration documentation](https://cloud.google.com/resource-manager/reference/rest/Shared.Types/AuditConfig) for more details.
+  	  * `exempted_members` (Optional) Specifies the identities that are exempt from these types of logging operations. Follows the same format of the `members` array for `binding`.
+  	  * 
 ## Attributes Reference
 
 The following attribute is exported:


### PR DESCRIPTION
Hi,

We have a use case for accessing [AuditConfigLogs](https://cloud.google.com/kms/docs/logging#enabling_data_access_logs) at Etsy. This PR addresses #936 and adds support for AuditLogConfigs through a `google_iam_policy` data block. 

See below for an example:

```
resource "google_project_iam_policy" "project" {
  project     = "${google_project.project.id}"
  policy_data = "${data.google_iam_policy.audit_config.policy_data}"
}

data "google_iam_policy" "audit_config" {
  binding {
    role = "roles/owner"

    members = [
      "user:you@domain.com",
    ]
  }

  audit_config {
    service = "cloudkms.googleapis.com"
    audit_log_configs = [
      {
        log_type = "DATA_READ",
        exempted_members = [
          "user:you@domain.com,
        ]
      },
    ]
  }

}
```

Please let me know how I can improve this PR to make it easier to merge.

Best,

Adam