### PR TITLE
Adding attributes in google_container_cluster documentation

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -368,6 +368,10 @@ exported:
 * `master_auth.0.cluster_ca_certificate` - Base64 encoded public certificate
     that is the root of trust for the cluster.
 
+* `master_auth.0.username` - The username used for Kubernetes master endpoint
+
+* `master_auth.0.password` - The password used for Kubernetes master endpoint.
+
 * `master_version` - The current version of the master in the cluster. This may
     be different than the `min_master_version` set in the config if the master
     has been updated by GKE.


### PR DESCRIPTION
We can use this attributes in a google_container_cluster resource.

https://github.com/terraform-providers/terraform-provider-google/blob/master/google/resource_container_cluster.go#L254