### PR TITLE
Add support for Stackdriver Monitoring on GKE clusters

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -219,7 +219,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"logging.googleapis.com", "none"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"logging.googleapis.com", "logging.googleapis.com/kubernetes", "none"}, false),
 			},
 
 			"maintenance_policy": {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -722,6 +722,12 @@ func TestAccContainerCluster_withLogging(t *testing.T) {
 			{
 				Config: testAccContainerCluster_updateLogging(clusterName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_logging", "logging_service", "logging.googleapis.com/kubernetes"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_updateLogging(clusterName),
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_logging", "logging_service", "none"),
 				),
 			},
@@ -756,6 +762,12 @@ func TestAccContainerCluster_withMonitoring(t *testing.T) {
 				ImportStateIdPrefix: "us-central1-a/",
 				ImportState:         true,
 				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateMonitoring(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_monitoring", "monitoring_service", "monitoring.googleapis.com/kubernetes"),
+				),
 			},
 			{
 				Config: testAccContainerCluster_updateMonitoring(clusterName),


### PR DESCRIPTION
Using Strackdriver to monitor GKE clusters is currently available in beta ([see docs](https://cloud.google.com/monitoring/kubernetes-engine/)) and I've done some attempts at letting us provision GKE clusters with this enabled via Terraform.

This PR solves that by allowing you to set the following properties:

```
logging_service = "logging.googleapis.com/kubernetes"
monitoring_service = "monitoring.googleapis.com/kubernetes"
```

It does, however, come with some caveats:

- `google_container_cluster.min_master_version` must be set to `1.10.2-gke.1` or higher, or the API call fails with a validation error (`googleapi: Error 400: Stackdriver kubernetes resource model is not supported for cluster version 1.8.10-gke.0; version 1.10.2 or newer is required., badRequest`).
- The `logging_service` and `monitoring_service` changes can only take place when creating a new cluster. Attempting to update these on an already running cluster (even if it satisfies the version requirement) yields this error: `googleapi: Error 400: desired_monitoring_service was "monitoring.googleapis.com/kubernetes" but must be one of "", "none", or "monitoring.googleapis.com"., badRequest`. According to [the migration docs](https://cloud.google.com/monitoring/kubernetes-engine/migration), it's for the time being only possible to enable this when creating a new cluster.

I'm not sure how this should be handled on a Terraform level. I'm not terribly familiar with Terraform internals but I'm happy to contribute if someone has some idea of to solve this.

This PR is also related to #1541.