### PR TITLE
Remove label from bucket

### DIFF
--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -378,6 +378,15 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		if len(sb.Labels) == 0 {
 			sb.NullFields = append(sb.NullFields, "Labels")
 		}
+
+		// When using PATCH for this resource, in order to delete a label, we
+		// have to explicitly set its value to null
+		old, _ := d.GetChange("labels")
+		for k := range old.(map[string]interface{}) {
+			if _, ok := sb.Labels[k]; !ok {
+				sb.NullFields = append(sb.NullFields, fmt.Sprintf("Labels.%s", k))
+			}
+		}
 	}
 
 	res, err := config.clientStorage.Buckets.Patch(d.Get("name").(string), sb).Do()
@@ -392,6 +401,7 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 	d.Set("self_link", res.SelfLink)
 	d.SetId(res.Id)
 
+	//return resourceStorageBucketRead(d, meta)
 	return nil
 }
 

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -558,14 +558,7 @@ func TestAccStorageBucket_labels(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccStorageBucket_labels(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketHasLabel(&bucket, "my-label", "my-label-value"),
-				),
-			},
+			// Going from to labels
 			resource.TestStep{
 				Config: testAccStorageBucket_updateLabels(bucketName),
 				Check: resource.ComposeTestCheckFunc(
@@ -576,12 +569,37 @@ func TestAccStorageBucket_labels(t *testing.T) {
 				),
 			},
 			resource.TestStep{
+				ResourceName:      "google_storage_bucket.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Down to only one label
+			resource.TestStep{
+				Config: testAccStorageBucket_labels(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
+					testAccCheckStorageBucketHasLabel(&bucket, "my-label", "my-label-value"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_storage_bucket.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// And make sure deleting all labels work
+			resource.TestStep{
 				Config: testAccStorageBucket_basic(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					testAccCheckStorageBucketHasNoLabels(&bucket),
 				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_storage_bucket.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #1350 

In order to remove a label from a bucket using the `patch` method, you have to set the label value explicitly to `null` for the label key you want to remove.