### PR TITLE
Suppress diff for ipv6 shortening in dns record

### DIFF
--- a/google/resource_dns_record_set_test.go
+++ b/google/resource_dns_record_set_test.go
@@ -9,6 +9,31 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestIpv6AddressDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New       string
+		ShouldSuppress bool
+	}{
+		"compact form should suppress diff": {
+			Old:            "2a03:b0c0:1:e0::29b:8001",
+			New:            "2a03:b0c0:0001:00e0:0000:0000:029b:8001",
+			ShouldSuppress: true,
+		},
+		"different address should not suppress diff": {
+			Old:            "2a03:b0c0:1:e00::29b:8001",
+			New:            "2a03:b0c0:0001:00e0:0000:0000:029b:8001",
+			ShouldSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		shouldSuppress := ipv6AddressDiffSuppress("", tc.Old, tc.New, nil)
+		if shouldSuppress != tc.ShouldSuppress {
+			t.Errorf("%s: expected %t", tn, tc.ShouldSuppress)
+		}
+	}
+}
+
 func TestAccDnsRecordSet_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #1546.

The Google API always return the compact version of an ipv6 address for a dns record:
"2a03:b0c0:0001:00e0:0000:0000:029b:8001" is shortened to "2a03:b0c0:1:e0::29b:8001". This creates a diff in terraform. However, both refers to the same address.

This PR adds a DiffSupressFunc to handle this case.