### PR TITLE
Use the project defined in the trigger_template when creating trigger

### DIFF
--- a/google/resource_cloudbuild_build_trigger.go
+++ b/google/resource_cloudbuild_build_trigger.go
@@ -191,7 +191,7 @@ func expandCloudbuildBuildTriggerTemplate(d *schema.ResourceData, project string
 		return nil
 	}
 	tmpl := &cloudbuild.RepoSource{}
-	if v, ok := d.GetOk("project"); ok {
+	if v, ok := d.GetOk("trigger_template.0.project"); ok {
 		tmpl.ProjectId = v.(string)
 	} else {
 		tmpl.ProjectId = project


### PR DESCRIPTION
When creating a trigger by using the project defined in the schema we
enforce that the repo must be in that same project. We should be looking
at the project defined in the trigger_template data and falling back to
that first project if not found.

Closes: #1555