### PR TITLE
Add "server_ca_cert" Attribute reference

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -231,6 +231,17 @@ when the resource is configured with a `count`.
 
 * `settings.version` - Used to make sure changes to the `settings` block are
     atomic.
+    
+* `server_ca_cert.0.cert` - The CA Certificate used to connect to the SQL Instance via SSL
+
+* `server_ca_cert.0.common_name` - The CN of the SQL Instance CA Cert
+
+* `server_ca_cert.0.create_time` - Creation time of the SQL Instance CA Cert
+
+* `server_ca_cert.0.expiration_time` - Expiration time of the SQL Instance CA Cert
+
+* `server_ca_cert.0.sha1_fingerprint` - SHA Fingerprint of the SQL Instance CA Cert
+
 
 ## Timeouts
 

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -232,15 +232,15 @@ when the resource is configured with a `count`.
 * `settings.version` - Used to make sure changes to the `settings` block are
     atomic.
     
-* `server_ca_cert.0.cert` - The CA Certificate used to connect to the SQL Instance via SSL
+* `server_ca_cert.0.cert` - The CA Certificate used to connect to the SQL Instance via SSL.
 
-* `server_ca_cert.0.common_name` - The CN of the SQL Instance CA Cert
+* `server_ca_cert.0.common_name` - The CN valid for the CA Cert.
 
-* `server_ca_cert.0.create_time` - Creation time of the SQL Instance CA Cert
+* `server_ca_cert.0.create_time` - Creation time of the CA Cert.
 
-* `server_ca_cert.0.expiration_time` - Expiration time of the SQL Instance CA Cert
+* `server_ca_cert.0.expiration_time` - Expiration time of the CA Cert.
 
-* `server_ca_cert.0.sha1_fingerprint` - SHA Fingerprint of the SQL Instance CA Cert
+* `server_ca_cert.0.sha1_fingerprint` - SHA Fingerprint of the CA Cert.
 
 
 ## Timeouts


### PR DESCRIPTION
Documents the addition of the `server_ca_cert` attribute for use in configuring SSL with GCP SQL Instances - added in PR #1020