### PR TITLE
Add link to sidebar for liens.

### DIFF
--- a/website/google.erb
+++ b/website/google.erb
@@ -207,6 +207,9 @@
       <li<%= sidebar_current("docs-google-project-usage-export-bucket") %>>
         <a href="/docs/providers/google/r/usage_export_bucket.html">google_project_usage_export_bucket</a>
       </li>
+      <li<%= sidebar_current("docs-google-resourcemanager-lien") %>>
+        <a href="/docs/providers/google/r/resourcemanager_lien.html">google_resourcemanager_lien</a>
+      </li>
       <li<%= sidebar_current("docs-google-service-account-x") %>>
         <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
       </li>


### PR DESCRIPTION
When we added lien support, we forgot to add a link to the docs in the sidebar navigation. This adds that link.