### PR TITLE
update auth docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -35,9 +35,9 @@ resource "google_compute_instance" "default" {
 The following keys can be used to configure the provider.
 
 * `credentials` - (Optional) Contents of a file that contains your service
-  account private key in JSON format. You can download this file from the
-  [Google Cloud Console](https://console.cloud.google.com/apis/credentials/serviceaccountkey)
-  by picking an existing service account or creating a new one for Terraform.
+  account private key in JSON format. You can download your existing
+  [Google Cloud service account file]
+  from the Google Cloud Console, or you can create a new one from the same page.
 
   Credentials can also be specified using any of the following environment
   variables (listed in order of precedence):
@@ -46,21 +46,21 @@ The following keys can be used to configure the provider.
     * `GOOGLE_CLOUD_KEYFILE_JSON`
     * `GCLOUD_KEYFILE_JSON`
 
-  The [`GOOGLE_APPLICATION_CREDENTIALS`](https://developers.google.com/identity/protocols/application-default-credentials#howtheywork)
+  The [`GOOGLE_APPLICATION_CREDENTIALS`][adc]
   environment variable can also contain the path of a file to obtain credentials
   from.
 
   If no credentials are specified, the provider will fall back to using the
-  [Google Application Default
-  Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+  [Google Application Default Credentials][adc].
   If you are running Terraform from a GCE instance, see [Creating and Enabling
-  Service Accounts for
-  Instances](https://cloud.google.com/compute/docs/authentication) for
-  details. On your computer, if you have made your identity available as the
+  Service Accounts for Instances][gce-service-account] for details.
+
+  On your computer, if you have made your identity available as the
   Application Default Credentials by running [`gcloud auth application-default
-  login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login),
-  the provider will use your identity. However, this method is not guaranteed to
-  work for all APIs, and service accounts or GCE metadata should be used if possible.
+  login`][gcloud adc], the provider will use your identity.
+
+  ~> **Warning:** The gcloud method is not guaranteed to work for all APIs, and
+  [service accounts] or [GCE metadata] should be used if possible.
 
 * `project` - (Optional) The ID of the project to apply any resources to.  This
   can also be specified using any of the following environment variables (listed
@@ -98,3 +98,10 @@ is publicly announced, and is when they generally become publicly available.
 Terraform resources that support beta features will always use the Beta APIs to provision
 the resource. Importing a resource that supports beta features will always import those
 features, even if the resource was created in a matter that was not explicitly beta.
+
+[Google Cloud service account file]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[adc]: https://cloud.google.com/docs/authentication/production
+[gce-service-account]: https://cloud.google.com/compute/docs/authentication
+[gcloud adc]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+[service accounts]: https://cloud.google.com/docs/authentication/getting-started
+[GCE metadata]: https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -36,7 +36,8 @@ The following keys can be used to configure the provider.
 
 * `credentials` - (Optional) Contents of a file that contains your service
   account private key in JSON format. You can download this file from the
-  Google Cloud Console. More details on retrieving this file are below.
+  [Google Cloud Console](https://console.cloud.google.com/apis/credentials/serviceaccountkey)
+  by picking an existing service account or creating a new one for Terraform.
 
   Credentials can also be specified using any of the following environment
   variables (listed in order of precedence):
@@ -58,7 +59,8 @@ The following keys can be used to configure the provider.
   details. On your computer, if you have made your identity available as the
   Application Default Credentials by running [`gcloud auth application-default
   login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login),
-  the provider will use your identity.
+  the provider will use your identity. However, this method is not guaranteed to
+  work for all APIs, and service accounts or GCE metadata should be used if possible.
 
 * `project` - (Optional) The ID of the project to apply any resources to.  This
   can also be specified using any of the following environment variables (listed
@@ -85,25 +87,6 @@ The following keys can be used to configure the provider.
     * `GCLOUD_ZONE`
     * `CLOUDSDK_COMPUTE_ZONE`
 
-## Authentication JSON File
-
-Authenticating with Google Cloud services requires a JSON
-file which we call the _account file_.
-
-This file is downloaded directly from the
-[Google Developers Console](https://console.developers.google.com). To make
-the process more straightforwarded, it is documented here:
-
-1. Log into the [Google Developers Console](https://console.developers.google.com)
-   and select a project.
-
-2. The API Manager view should be selected, click on "Credentials" on the left,
-   then "Create credentials", and finally "Service account key".
-
-3. Select "Compute Engine default service account" in the "Service account"
-   dropdown, and select "JSON" as the key type.
-
-4. Clicking "Create" will download your `credentials`.
 
 ## Beta Features
 


### PR DESCRIPTION
* Added a link to the console page where you can download a file
* Removed instructions on how to get to that page, since now you can just click on the link
* Added caveat for application default credentials

@sethvargo @theacodes @kimcam let me know if this seems reasonable / you have any suggestions!