### PR TITLE
Fix network_tier tests.

### DIFF
--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -69,6 +69,7 @@ func resourceComputeAddress() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 			},
 
@@ -155,9 +156,9 @@ func resourceComputeAddressRead(d *schema.ResourceData, meta interface{}) error 
 	if addr.AddressType == "" {
 		d.Set("address_type", addressTypeExternal)
 	}
-	d.Set("subnetwork", addr.Subnetwork)
+	d.Set("subnetwork", ConvertSelfLinkToV1(addr.Subnetwork))
 	d.Set("address", addr.Address)
-	d.Set("self_link", addr.SelfLink)
+	d.Set("self_link", ConvertSelfLinkToV1(addr.SelfLink))
 	d.Set("name", addr.Name)
 	d.Set("network_tier", addr.NetworkTier)
 	d.Set("project", addressId.Project)

--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -79,6 +79,7 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 			},
 
@@ -248,7 +249,7 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("name", frule.Name)
 	d.Set("target", frule.Target)
-	d.Set("backend_service", frule.BackendService)
+	d.Set("backend_service", ConvertSelfLinkToV1(frule.BackendService))
 	d.Set("description", frule.Description)
 	d.Set("load_balancing_scheme", frule.LoadBalancingScheme)
 	d.Set("network", frule.Network)
@@ -260,7 +261,7 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	d.Set("subnetwork", frule.Subnetwork)
 	d.Set("ip_address", frule.IPAddress)
 	d.Set("ip_protocol", frule.IPProtocol)
-	d.Set("self_link", frule.SelfLink)
+	d.Set("self_link", ConvertSelfLinkToV1(frule.SelfLink))
 	return nil
 }
 

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -358,6 +358,7 @@ func resourceComputeInstance() *schema.Resource {
 									"network_tier": &schema.Schema{
 										Type:         schema.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 									},
 

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -241,6 +241,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 									"network_tier": &schema.Schema{
 										Type:         schema.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 									},
 									// Instance templates will never have an


### PR DESCRIPTION
Make network_tier computed, so when it's not specified we don't get a
permadiff.

Always store v1 self_links, so we don't get a permadiff.