### PR TITLE
Make App Engine applications updatable

### DIFF
--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -105,15 +105,6 @@ func appEngineResource() *schema.Resource {
 	return &schema.Resource{
 		CustomizeDiff: resourceGoogleProjectAppEngineCustomizeDiff,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"url_dispatch_rule": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     appEngineURLDispatchRuleResource(),
-			},
 			"auth_domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -137,10 +128,6 @@ func appEngineResource() *schema.Resource {
 					"australia-southeast1",
 				}, false),
 			},
-			"code_bucket": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"serving_status": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -150,6 +137,26 @@ func appEngineResource() *schema.Resource {
 					"USER_DISABLED",
 					"SYSTEM_DISABLED",
 				}, false),
+				Computed: true,
+			},
+			"feature_settings": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     appEngineFeatureSettingsResource(),
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"url_dispatch_rule": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     appEngineURLDispatchRuleResource(),
+			},
+			"code_bucket": &schema.Schema{
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"default_hostname": &schema.Schema{
@@ -163,13 +170,6 @@ func appEngineResource() *schema.Resource {
 			"gcr_domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"feature_settings": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem:     appEngineFeatureSettingsResource(),
 			},
 		},
 	}

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -103,7 +103,6 @@ func resourceGoogleProject() *schema.Resource {
 
 func appEngineResource() *schema.Resource {
 	return &schema.Resource{
-		CustomizeDiff: resourceGoogleProjectAppEngineCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"auth_domain": &schema.Schema{
 				Type:     schema.TypeString,
@@ -214,10 +213,6 @@ func resourceGoogleProjectCustomizeDiff(diff *schema.ResourceDiff, meta interfac
 		// if location_id wasn't set, don't force a new value, as we're just enabling app engine
 		return diff.ForceNew("app_engine.0.location_id")
 	}
-	return nil
-}
-
-func resourceGoogleProjectAppEngineCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
 	return nil
 }
 

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -523,6 +523,7 @@ func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error
 				}
 				log.Printf("[DEBUG] Updated App Engine App")
 			}
+			d.SetPartial("app_engine")
 		}
 	}
 

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -103,6 +103,7 @@ func resourceGoogleProject() *schema.Resource {
 
 func appEngineResource() *schema.Resource {
 	return &schema.Resource{
+		CustomizeDiff: resourceGoogleProjectAppEngineCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -209,8 +210,20 @@ func resourceGoogleProjectCustomizeDiff(diff *schema.ResourceDiff, meta interfac
 	if old, new := diff.GetChange("app_engine.#"); old != nil && new != nil && old.(int) > 0 && new.(int) < 1 {
 		diff.ForceNew("app_engine")
 	}
-	if old, new := diff.GetChange("app_engine.0.location_id"); diff.HasChange("app_engine.0.location_id") && old != nil && new != nil && old.(string) != "" {
-		diff.ForceNew("app_engine.0.location_id")
+	return nil
+}
+
+func resourceGoogleProjectAppEngineCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
+	old, _ := diff.GetChange("app_engine.0.location_id")
+	if !diff.HasChange("app_engine.0.location_id") {
+		log.Printf("[DEBUG] No location change")
+	} else if old == nil {
+		log.Printf("[DEBUG] old location is nil")
+	} else if old.(string) == "" {
+		log.Printf("[DEBUG] old location is empty")
+	} else {
+		log.Printf("[DEBUG] location changed, forcing new project")
+		diff.ForceNew("location_id")
 	}
 	return nil
 }

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -199,7 +199,6 @@ func TestAccProject_appEngineBasic(t *testing.T) {
 			{
 				Config: testAccProject_appEngineBasic(pid, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.name"),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.url_dispatch_rule.#"),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.code_bucket"),
@@ -234,7 +233,6 @@ func TestAccProject_appEngineUpdate(t *testing.T) {
 			{
 				Config: testAccProject_appEngineBasic(pid, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.name"),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.url_dispatch_rule.#"),
 					resource.TestCheckResourceAttrSet("google_project.acceptance", "app_engine.0.code_bucket"),
@@ -249,9 +247,6 @@ func TestAccProject_appEngineUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccProject_appEngineUpdate(pid, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
-				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_project.acceptance",
@@ -273,9 +268,6 @@ func TestAccProject_appEngineFeatureSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProject_appEngineFeatureSettings(pid, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
-				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_project.acceptance",
@@ -284,9 +276,6 @@ func TestAccProject_appEngineFeatureSettings(t *testing.T) {
 			},
 			{
 				Config: testAccProject_appEngineFeatureSettingsUpdate(pid, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
-				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_project.acceptance",

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -417,8 +417,8 @@ func testAccProject_labels(pid, name, org string, labels map[string]string) stri
 	r := fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
-    name = "%s"
-    org_id = "%s"
+    name       = "%s"
+    org_id     = "%s"
 	labels {`, pid, name, org)
 
 	l := ""
@@ -433,11 +433,11 @@ resource "google_project" "acceptance" {
 func testAccProject_deleteDefaultNetwork(pid, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
-	billing_account = "%s" # requires billing to enable compute API
-	auto_create_network = false
+  project_id          = "%s"
+  name                = "%s"
+  org_id              = "%s"
+  billing_account     = "%s"  # requires billing to enable compute API
+  auto_create_network = false
 }`, pid, name, org, billing)
 }
 
@@ -463,8 +463,8 @@ func testAccProject_appEngineNoApp(pid, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
-  name = "%s"
-  org_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 }`, pid, pid, org)
 }
 
@@ -472,12 +472,12 @@ func testAccProject_appEngineBasic(pid, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
-  name = "%s"
-  org_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 
   app_engine {
-    auth_domain = "hashicorptest.com"
-    location_id = "us-central"
+    auth_domain    = "hashicorptest.com"
+    location_id    = "us-central"
     serving_status = "SERVING"
   }
 }`, pid, pid, org)
@@ -487,12 +487,12 @@ func testAccProject_appEngineUpdate(pid, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
-  name = "%s"
-  org_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 
   app_engine {
-    auth_domain = "tf-test.club"
-    location_id = "us-central"
+    auth_domain    = "tf-test.club"
+    location_id    = "us-central"
     serving_status = "USER_DISABLED"
   }
 }`, pid, pid, org)
@@ -502,11 +502,12 @@ func testAccProject_appEngineFeatureSettings(pid, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
-  name = "%s"
-  org_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 
   app_engine {
     location_id = "us-central"
+
     feature_settings {
       "split_health_checks" = true
     }
@@ -518,11 +519,12 @@ func testAccProject_appEngineFeatureSettingsUpdate(pid, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
   project_id = "%s"
-  name = "%s"
-  org_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
 
   app_engine {
     location_id = "us-central"
+
     feature_settings {
       "split_health_checks" = false
     }


### PR DESCRIPTION
No longer ForceNew on every little change to an App Engine application. Now adding an App Engine application to a project doesn't force a new project, only removing an application from a project forces a new project. Also, updating the location_id forces a new project, but all other fields can be updated in place.

This depends on #1620 and should only be merged after that is.