### PR TITLE
Undeprecate name_prefix for ssl_certificate.

### DIFF
--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -37,10 +37,11 @@ func resourceComputeSslCertificate() *schema.Resource {
 			},
 
 			"name_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://cloud.google.com/compute/docs/reference/latest/sslCertificates#resource
 					// uuid is 26 characters, limit the prefix to 37.
@@ -51,8 +52,6 @@ func resourceComputeSslCertificate() *schema.Resource {
 					}
 					return
 				},
-				Deprecated: "Use the random provider instead. See migration instructions at " +
-					"https://github.com/terraform-providers/terraform-provider-google/issues/1054#issuecomment-377390209",
 			},
 
 			"private_key": &schema.Schema{

--- a/website/docs/r/compute_ssl_certificate.html.markdown
+++ b/website/docs/r/compute_ssl_certificate.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `name` - (Optional) A unique name for the SSL certificate. If you leave
   this blank, Terraform will auto-generate a unique name.
 
-* `name_prefix` - (Deprecated, Optional) Creates a unique name beginning with the specified
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.
 
 * `description` - (Optional) An optional description of this resource.


### PR DESCRIPTION
As discussed in #1326, we're not going to remove name_prefix for
compute_ssl_certificate, because it makes the common use case more
ergonomic by a good amount, and the only cost is it's harder to maintain
the autogenerated code, and we've decided the benefits outweigh the
costs in this circumstance.