### PR TITLE
Check for done operations before waiting on them

### DIFF
--- a/google/appengine_operation.go
+++ b/google/appengine_operation.go
@@ -59,6 +59,13 @@ func appEngineOperationWait(client *appengine.APIService, op *appengine.Operatio
 }
 
 func appEngineOperationWaitTime(client *appengine.APIService, op *appengine.Operation, appId, activity string, timeoutMin int) error {
+	if op.Done {
+		if op.Error != nil {
+			return AppEngineOperationError(*op.Error)
+		}
+		return nil
+	}
+
 	w := &AppEngineOperationWaiter{
 		Service: client,
 		Op:      op,

--- a/google/cloudfunctions_operation.go
+++ b/google/cloudfunctions_operation.go
@@ -47,6 +47,13 @@ func cloudFunctionsOperationWait(client *cloudfunctions.Service,
 
 func cloudFunctionsOperationWaitTime(client *cloudfunctions.Service, op *cloudfunctions.Operation,
 	activity string, timeoutMin int) error {
+	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf(op.Error.Message)
+		}
+		return nil
+	}
+
 	w := &CloudFunctionsOperationWaiter{
 		Service: client,
 		Op:      op,

--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -67,6 +67,13 @@ func computeOperationWait(client *compute.Service, op *compute.Operation, projec
 }
 
 func computeOperationWaitTime(client *compute.Service, op *compute.Operation, project, activity string, timeoutMin int) error {
+	if op.Status == "DONE" {
+		if op.Error != nil {
+			return ComputeOperationError(*op.Error)
+		}
+		return nil
+	}
+
 	w := &ComputeOperationWaiter{
 		Service: client,
 		Op:      op,

--- a/google/container_operation.go
+++ b/google/container_operation.go
@@ -80,6 +80,13 @@ func (w *ContainerBetaOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
 }
 
 func containerOperationWait(config *Config, op *container.Operation, project, zone, activity string, timeoutMinutes, minTimeoutSeconds int) error {
+	if op.Status == "DONE" {
+		if op.StatusMessage != "" {
+			return fmt.Errorf(op.StatusMessage)
+		}
+		return nil
+	}
+
 	w := &ContainerOperationWaiter{
 		Service: config.clientContainer,
 		Op:      op,
@@ -92,6 +99,13 @@ func containerOperationWait(config *Config, op *container.Operation, project, zo
 }
 
 func containerBetaOperationWait(config *Config, op *containerBeta.Operation, project, location, activity string, timeoutMinutes, minTimeoutSeconds int) error {
+	if op.Status == "DONE" {
+		if op.StatusMessage != "" {
+			return fmt.Errorf(op.StatusMessage)
+		}
+		return nil
+	}
+
 	w := &ContainerBetaOperationWaiter{
 		Service:  config.clientContainerBeta,
 		Op:       op,

--- a/google/dataproc_cluster_operation.go
+++ b/google/dataproc_cluster_operation.go
@@ -37,6 +37,13 @@ func (w *DataprocClusterOperationWaiter) RefreshFunc() resource.StateRefreshFunc
 }
 
 func dataprocClusterOperationWait(config *Config, op *dataproc.Operation, activity string, timeoutMinutes, minTimeoutSeconds int) error {
+	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return nil
+	}
+
 	w := &DataprocClusterOperationWaiter{
 		Service: config.clientDataproc,
 		Op:      op,

--- a/google/dns_operation.go
+++ b/google/dns_operation.go
@@ -2,10 +2,11 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
-	"google.golang.org/api/dns/v1beta2"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/dns/v1beta2"
 )
 
 type DnsOperationWaiter struct {
@@ -48,6 +49,10 @@ func dnsOperationWait(service *dns.Service, op *dns.Operation, project, activity
 }
 
 func dnsOperationWaitTime(service *dns.Service, op *dns.Operation, project, activity string, timeoutMin int) error {
+	if op.Status == "done" {
+		return nil
+	}
+
 	w := &DnsOperationWaiter{
 		Service: service.ManagedZoneOperations,
 		Op:      op,

--- a/google/resourcemanager_operation.go
+++ b/google/resourcemanager_operation.go
@@ -42,6 +42,13 @@ func resourceManagerOperationWait(service *cloudresourcemanager.Service, op *clo
 }
 
 func resourceManagerOperationWaitTime(service *cloudresourcemanager.Service, op *cloudresourcemanager.Operation, activity string, timeoutMin int) error {
+	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return nil
+	}
+
 	w := &ResourceManagerOperationWaiter{
 		Service: service,
 		Op:      op,

--- a/google/serviceman_operation.go
+++ b/google/serviceman_operation.go
@@ -45,6 +45,13 @@ func serviceManagementOperationWait(config *Config, op *servicemanagement.Operat
 }
 
 func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Operation, activity string, timeoutMin int) (googleapi.RawMessage, error) {
+	if op.Done {
+		if op.Error != nil {
+			return nil, fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return op.Response, nil
+	}
+
 	w := &ServiceManagementOperationWaiter{
 		Service: config.clientServiceMan,
 		Op:      op,

--- a/google/serviceusage_operation.go
+++ b/google/serviceusage_operation.go
@@ -45,6 +45,13 @@ func serviceUsageOperationWait(config *Config, op *serviceusage.Operation, activ
 }
 
 func serviceUsageOperationWaitTime(config *Config, op *serviceusage.Operation, activity string, timeoutMin int) (googleapi.RawMessage, error) {
+	if op.Done {
+		if op.Error != nil {
+			return nil, fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return op.Response, nil
+	}
+
 	w := &serviceUsageOperationWaiter{
 		Service: config.clientServiceUsage,
 		Op:      op,

--- a/google/spanner_database_operation.go
+++ b/google/spanner_database_operation.go
@@ -38,6 +38,13 @@ func (w *SpannerDatabaseOperationWaiter) RefreshFunc() resource.StateRefreshFunc
 }
 
 func spannerDatabaseOperationWait(config *Config, op *spanner.Operation, activity string, timeoutMin int) error {
+	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return nil
+	}
+
 	w := &SpannerDatabaseOperationWaiter{
 		Service: config.clientSpanner,
 		Op:      op,

--- a/google/spanner_instance_operation.go
+++ b/google/spanner_instance_operation.go
@@ -38,6 +38,13 @@ func (w *SpannerInstanceOperationWaiter) RefreshFunc() resource.StateRefreshFunc
 }
 
 func spannerInstanceOperationWait(config *Config, op *spanner.Operation, activity string, timeoutMin int) error {
+	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+		}
+		return nil
+	}
+
 	w := &SpannerInstanceOperationWaiter{
 		Service: config.clientSpanner,
 		Op:      op,

--- a/google/sqladmin_operation.go
+++ b/google/sqladmin_operation.go
@@ -61,6 +61,13 @@ func sqladminOperationWait(config *Config, op *sqladmin.Operation, project, acti
 }
 
 func sqladminOperationWaitTime(config *Config, op *sqladmin.Operation, project, activity string, timeoutMinutes int) error {
+	if op.Status == "DONE" {
+		if op.Error != nil {
+			return SqlAdminOperationError(*op.Error)
+		}
+		return nil
+	}
+
 	w := &SqlAdminOperationWaiter{
 		Service: config.clientSqlAdmin,
 		Op:      op,


### PR DESCRIPTION
For #1630. This does all of them except redis, which I'll prepare separately since that code is copied over from magic-modules.

I'm also going to go ahead and guess that this fixes #1579. Without more context it's hard to know why the error was occurring, but this definitely fixes a 403 that occurs when enabling a previously-enabled service.