### PR TITLE
update sql user docs/comments

### DIFF
--- a/google/resource_sql_user.go
+++ b/google/resource_sql_user.go
@@ -87,7 +87,7 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 			"user %s into instance %s: %s", name, instance, err)
 	}
 
-	// This will include a double-slash (//) for 2nd generation instances,
+	// This will include a double-slash (//) for postgres instances,
 	// for which user.Host is an empty string.  That's okay.
 	d.SetId(fmt.Sprintf("%s/%s/%s", user.Name, user.Host, user.Instance))
 
@@ -125,7 +125,7 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	var user *sqladmin.User
 	for _, currentUser := range users.Items {
-		// The second part of this conditional is irrelevant for 2nd generation instances because
+		// The second part of this conditional is irrelevant for postgres instances because
 		// host and currentUser.Host will always both be empty.
 		if currentUser.Name == name && currentUser.Host == host {
 			user = currentUser
@@ -235,7 +235,7 @@ func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schem
 		d.Set("host", parts[1])
 		d.Set("name", parts[2])
 	} else {
-		return nil, fmt.Errorf("Invalid specifier. Expecting {instance}/{name} for 2nd generation instance and {instance}/{host}/{name} for 1st generation instance")
+		return nil, fmt.Errorf("Invalid specifier. Expecting {instance}/{name} for postgres instance and {instance}/{host}/{name} for MySQL instance")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/google/resource_sql_user_test.go
+++ b/google/resource_sql_user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccSqlUser_firstGen(t *testing.T) {
+func TestAccSqlUser_mysql(t *testing.T) {
 	t.Parallel()
 
 	instance := acctest.RandomWithPrefix("i")
@@ -19,7 +19,7 @@ func TestAccSqlUser_firstGen(t *testing.T) {
 		CheckDestroy: testAccSqlUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleSqlUser_firstGen(instance, "password"),
+				Config: testGoogleSqlUser_mysql(instance, "password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists("google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists("google_sql_user.user2"),
@@ -27,7 +27,7 @@ func TestAccSqlUser_firstGen(t *testing.T) {
 			},
 			resource.TestStep{
 				// Update password
-				Config: testGoogleSqlUser_firstGen(instance, "new_password"),
+				Config: testGoogleSqlUser_mysql(instance, "new_password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists("google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists("google_sql_user.user2"),
@@ -44,7 +44,7 @@ func TestAccSqlUser_firstGen(t *testing.T) {
 	})
 }
 
-func TestAccSqlUser_secondGen(t *testing.T) {
+func TestAccSqlUser_postgres(t *testing.T) {
 	t.Parallel()
 
 	instance := acctest.RandomWithPrefix("i")
@@ -54,14 +54,14 @@ func TestAccSqlUser_secondGen(t *testing.T) {
 		CheckDestroy: testAccSqlUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleSqlUser_secondGen(instance, "password"),
+				Config: testGoogleSqlUser_postgres(instance, "password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists("google_sql_user.user"),
 				),
 			},
 			resource.TestStep{
 				// Update password
-				Config: testGoogleSqlUser_secondGen(instance, "new_password"),
+				Config: testGoogleSqlUser_postgres(instance, "new_password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists("google_sql_user.user"),
 				),
@@ -130,7 +130,7 @@ func testAccSqlUserDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGoogleSqlUser_firstGen(instance, password string) string {
+func testGoogleSqlUser_mysql(instance, password string) string {
 	return fmt.Sprintf(`
 	resource "google_sql_database_instance" "instance" {
 		name = "%s"
@@ -156,7 +156,7 @@ func testGoogleSqlUser_firstGen(instance, password string) string {
 	`, instance, password)
 }
 
-func testGoogleSqlUser_secondGen(instance, password string) string {
+func testGoogleSqlUser_postgres(instance, password string) string {
 	return fmt.Sprintf(`
 	resource "google_sql_database_instance" "instance" {
 		name = "%s"

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -50,8 +50,8 @@ The following arguments are supported:
 - - -
 
 * `host` - (Optional) The host the user can connect from. This is only supported
-    for first generation SQL instances. Don't set this field for second generation
-    SQL instances. Can be an IP address. Changing this forces a new resource to be created.
+    for MySQL instances. Don't set this field for PostgreSQL instances.
+    Can be an IP address. Changing this forces a new resource to be created.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -62,13 +62,13 @@ Only the arguments listed above are exposed as attributes.
 
 ## Import
 
-SQL users for 1st generation databases can be imported using the `instance`, `host` and `name`, e.g.
+SQL users for MySQL databases can be imported using the `instance`, `host` and `name`, e.g.
 
 ```
 $ terraform import google_sql_user.users master-instance/my-domain.com/me
 ```
 
-SQL users for 2nd generation databases can be imported using the `instance` and `name`, e.g.
+SQL users for PostgreSQL databases can be imported using the `instance` and `name`, e.g.
 
 ```
 $ terraform import google_sql_user.users master-instance/me


### PR DESCRIPTION
It's not 2nd generation instances whose users don't have hosts, but postgres ones. Fixes #1611.