### PR TITLE
Add project to container_node_pool import name

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -386,19 +386,33 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 
 func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("Invalid container cluster specifier. Expecting {zone}/{cluster}/{name}")
-	}
 
-	location := parts[0]
-	if isZone(location) {
-		d.Set("zone", location)
-	} else {
-		d.Set("region", location)
-	}
+	switch len(parts) {
+	case 3:
+		location := parts[0]
+		if isZone(location) {
+			d.Set("zone", location)
+		} else {
+			d.Set("region", location)
+		}
 
-	d.Set("cluster", parts[1])
-	d.Set("name", parts[2])
+		d.Set("cluster", parts[1])
+		d.Set("name", parts[2])
+	case 4:
+		d.Set("project", parts[0])
+
+		location := parts[1]
+		if isZone(location) {
+			d.Set("zone", location)
+		} else {
+			d.Set("region", location)
+		}
+
+		d.Set("cluster", parts[2])
+		d.Set("name", parts[3])
+	default:
+		return nil, fmt.Errorf("Invalid container cluster specifier. Expecting {zone}/{cluster}/{name} or {project}/{zone}/{cluster}/{name}")
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -163,8 +163,11 @@ The `management` block supports:
 
 ## Import
 
-Node pools can be imported using the `zone`, `cluster` and `name`, e.g.
+Node pools can be imported using the `project`, `zone`, `cluster` and `name`. If
+the project is omitted, the default provider value will be used. Examples:
 
 ```
+$ terraform import google_container_node_pool.mainpool my-gcp-project/us-east1-a/my-cluster/main-pool
+
 $ terraform import google_container_node_pool.mainpool us-east1-a/my-cluster/main-pool
 ```


### PR DESCRIPTION
## What

As well as https://github.com/terraform-providers/terraform-provider-google/pull/1282 , make `resource_container_node_pool` importer accept `{project}/{zone}/{cluster}/{name}` format to specify the project where the node pool belongs to actually.

## Why

Sometimes I want to import container pool in different project from default SA's. However, currently there is no way to specify project the target node pool belongs to, Terraform tries to retrieve node pool from SA's project, then it fails due to `You cannot import non-existent resources using Terraform import.` error.
