### PR TITLE
service_account_key: regression fix for v1.14

### DIFF
--- a/google/data_source_google_service_account.go
+++ b/google/data_source_google_service_account.go
@@ -43,15 +43,10 @@ func dataSourceGoogleServiceAccount() *schema.Resource {
 func dataSourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	// Get the project from the resource or fallback to the project
-	// in the provider configuration
-	project, err := getProject(d, config)
+	serviceAccountName, err := serviceAccountFQN(d.Get("account_id").(string), d, config)
 	if err != nil {
 		return err
 	}
-
-	// Get the service account as a fully qualified name
-	serviceAccountName := serviceAccountFQN(d.Get("account_id").(string), project)
 
 	sa, err := config.clientIAM.Projects.ServiceAccounts.Get(serviceAccountName).Do()
 	if err != nil {

--- a/google/data_source_google_service_account_key.go
+++ b/google/data_source_google_service_account_key.go
@@ -46,15 +46,10 @@ func dataSourceGoogleServiceAccountKey() *schema.Resource {
 func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	// Get the project from the resource or fallback to the project
-	// in the provider configuration
-	project, err := getProject(d, config)
+	serviceAccountName, err := serviceAccountFQN(d.Get("service_account_id").(string), d, config)
 	if err != nil {
 		return err
 	}
-
-	// Get the service account as the fully qualified name
-	serviceAccountName := serviceAccountFQN(d.Get("service_account_id").(string), project)
 
 	publicKeyType := d.Get("public_key_type").(string)
 

--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -87,14 +87,10 @@ func resourceGoogleServiceAccountKey() *schema.Resource {
 func resourceGoogleServiceAccountKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	// Get the project from the resource or fallback to the project
-	// in the provider configuration
-	project, err := getProject(d, config)
+	serviceAccountName, err := serviceAccountFQN(d.Get("service_account_id").(string), d, config)
 	if err != nil {
 		return err
 	}
-
-	serviceAccountName := serviceAccountFQN(d.Get("service_account_id").(string), project)
 
 	r := &iam.CreateServiceAccountKeyRequest{
 		KeyAlgorithm:   d.Get("key_algorithm").(string),

--- a/google/utils_test.go
+++ b/google/utils_test.go
@@ -465,7 +465,12 @@ func TestServiceAccountFQN(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		serviceAccountName := serviceAccountFQN(tc.serviceAccount, tc.project)
+		config := &Config{Project: tc.project}
+		d := &schema.ResourceData{}
+		serviceAccountName, err := serviceAccountFQN(tc.serviceAccount, d, config)
+		if err != nil {
+			t.Fatalf("unexpected error for service account FQN: %s", err)
+		}
 		if serviceAccountName != serviceAccountExpected {
 			t.Errorf("bad: %s, expected '%s' but returned '%s", tn, serviceAccountExpected, serviceAccountName)
 		}


### PR DESCRIPTION
Commit 8f31fec introduced a bug for the 'service_account_key' resource
where it required a project be set either in the provider or in the
resource for 'service_account_key', but a project isn't required if the
service account is a service account fully qualified name or a service
account email.

This PR relaxes the requirement that a project needs to be set for the
'service_account_key' resource, 'service_account' datasource and
'service_account_key' datasource, but will error if we try to build a
fully qualified name from a service account id when no project can be
found.

This also cleans up 'serviceAccountFQN' so it is slightly easier to
follow and return an error if there is no project but we need one to
build the service account fully qualified name.

Fixes: #1655