### PR TITLE
container_cluster: added disk_type node configuration

### DIFF
--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -1382,7 +1382,7 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 	network_policy {
 		enabled = true
 		provider = "CALICO"
-	}	
+	}
 	addons_config {
 		network_policy_config {
 			disabled = false
@@ -1631,6 +1631,7 @@ resource "google_container_cluster" "with_node_config" {
 	node_config {
 		machine_type = "n1-standard-1"
 		disk_size_gb = 15
+		disk_type = "pd-ssd"
 		local_ssd_count = 1
 		oauth_scopes = [
 			"https://www.googleapis.com/auth/monitoring",

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -100,7 +100,7 @@ output "cluster_ca_certificate" {
     When enabled, identities in the system, including service accounts, nodes, and controllers,
     will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
     Defaults to `false`
-    
+
 * `initial_node_count` - (Optional) The number of nodes to create in this
     cluster (not including the Kubernetes master). Must be set if `node_pool` is not set.
 
@@ -133,7 +133,7 @@ output "cluster_ca_certificate" {
     official release (which is not necessarily the latest version).
 
 * `monitoring_service` - (Optional) The monitoring service that the cluster
-    should write metrics to. 
+    should write metrics to.
     Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API.
     VM metrics will be collected by Google Compute Engine regardless of this setting
     Available options include
@@ -179,10 +179,10 @@ The `addons_config` block supports:
 
 * `horizontal_pod_autoscaling` - (Optional) The status of the Horizontal Pod Autoscaling
     addon, which increases or decreases the number of replica pods a replication controller
-    has based on the resource usage of the existing pods. 
+    has based on the resource usage of the existing pods.
     It ensures that a Heapster pod is running in the cluster, which is also used by the Cloud Monitoring service.
     It is enabled by default;
-    set `disabled = true` to disable. 
+    set `disabled = true` to disable.
 * `http_load_balancing` - (Optional) The status of the HTTP (L7) load balancing
     controller addon, which makes it easy to set up HTTP load balancers for services in a
     cluster. It is enabled by default; set `disabled = true` to disable.
@@ -267,7 +267,10 @@ The `node_config` block supports:
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
 
-* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. 
+* `disk_type` - (Optional) Type of the disk attached to each node
+    (e.g. 'pd-standard' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'
+
+* `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance.
     Structure documented below.
 
 * `image_type` - (Optional) The image type to use for this node.


### PR DESCRIPTION
Added node config 'disk_type' which can either be 'pd-standard' or
'pd-ssd', if left blank 'pd-standard' will be the default used by google
cloud.

Attempted fix for https://github.com/terraform-providers/terraform-provider-google/issues/1656