### PR TITLE
Allow functions to be updated

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -129,7 +129,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"source_archive_object": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 
 			"description": {
@@ -437,6 +437,13 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 			}
 		}
 		updateMaskArr = append(updateMaskArr, "eventTrigger.failurePolicy.retry")
+	}
+
+	if d.HasChange("source_archive_object") {
+		sourceArchiveBucket := d.Get("source_archive_bucket").(string)
+		sourceArchiveObj := d.Get("source_archive_object").(string)
+		function.SourceArchiveUrl = fmt.Sprintf("gs://%v/%v", sourceArchiveBucket, sourceArchiveObj)
+		updateMaskArr = append(updateMaskArr, "sourceArchiveUrl")
 	}
 
 	if len(updateMaskArr) > 0 {


### PR DESCRIPTION
## Overview

Adds the ability to update Google Functions archive URLs, instead of forcing the resource to be deleted and recreated resulting in downtime of the function.