### PR TITLE
Add project variable for GCS service account datasource

### DIFF
--- a/google/data_source_google_storage_project_service_account.go
+++ b/google/data_source_google_storage_project_service_account.go
@@ -7,6 +7,14 @@ import (
 func dataSourceGoogleStorageProjectServiceAccount() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGoogleStorageProjectServiceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
 	}
 }
 
@@ -22,6 +30,8 @@ func dataSourceGoogleStorageProjectServiceAccountRead(d *schema.ResourceData, me
 	if err != nil {
 		return handleNotFoundError(err, d, "GCS service account not found")
 	}
+
+	d.Set("project", project)
 
 	d.SetId(serviceAccount.EmailAddress)
 

--- a/website/docs/d/google_storage_project_service_account.html.markdown
+++ b/website/docs/d/google_storage_project_service_account.html.markdown
@@ -27,7 +27,9 @@ resource "google_pubsub_topic_iam_binding" "binding" {
 
 ## Argument Reference
 
-There are no arguments available for this data source.
+The following arguments are supported:
+
+* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Hi,

This PR is a small improvement on #1110 allowing to change the project used by this datasource.
It is required when the provider project is not the same as the bucket.

Here is an example : 
```hcl
resource "google_project" "project" {
  name = "test-project"
  project_id = "test-project"
  org_id     = "1234567"
}

data "google_storage_project_service_account" "gcs_account" {
  project = "${google_project.project.project_id}"
}

// Bucket and PubSub topic definitions
// ...
```
I can provide more explanation if needed.

Best,
Bastien
