### PR TITLE
Update to private clusters

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -164,7 +164,7 @@ output "cluster_ca_certificate" {
 
 * `private_cluster` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) If true, a
     [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) will be created, which makes
-    the master inaccessible from the public internet and nodes do not get public IP addresses either. It is mandatory to specify
+    the worker nodes inaccessible from the public internet and nodes do not get public IP addresses either. It is mandatory to specify
     `master_ipv4_cidr_block` and `ip_allocation_policy` with this option.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -163,9 +163,9 @@ output "cluster_ca_certificate" {
     Structure is documented below.
 
 * `private_cluster` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) If true, a
-    [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) will be created, which makes
-    the worker nodes inaccessible from the public internet and nodes do not get public IP addresses either. It is mandatory to specify
-    `master_ipv4_cidr_block` and `ip_allocation_policy` with this option.
+    [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) will be created, meaning
+    nodes do not get public IP addresses. It is mandatory to specify `master_ipv4_cidr_block` and 
+    `ip_allocation_policy` with this option.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.


### PR DESCRIPTION
Private clusters maintain a public IP address for kubectl to communicate with the master, the workers are internal IP addresses only.