### PR TITLE
Make alternative location id computable for redis instances

### DIFF
--- a/google/resource_redis_instance.go
+++ b/google/resource_redis_instance.go
@@ -57,6 +57,7 @@ func resourceRedisInstance() *schema.Resource {
 			"alternative_location_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"authorized_network": {


### PR DESCRIPTION
If not set, Google will set a value for alternative_location_id

Fixes #1669