### PR TITLE
Fix failing test for storage ACLs.

### DIFF
--- a/google/resource_storage_bucket_acl.go
+++ b/google/resource_storage_bucket_acl.go
@@ -212,6 +212,11 @@ func resourceStorageBucketAclRead(d *schema.ResourceData, meta interface{}) erro
 
 		d.Set("role_entity", entities)
 	} else {
+		// if we don't set `role_entity` to nil (effectively setting it
+		// to empty in Terraform state), because it's computed now,
+		// Terraform will think it's missing from state, is supposed
+		// to be there, and throw up a diff for role_entity.#. So it
+		// must always be set in state.
 		d.Set("role_entity", nil)
 	}
 

--- a/google/resource_storage_bucket_acl.go
+++ b/google/resource_storage_bucket_acl.go
@@ -130,6 +130,7 @@ func resourceStorageBucketAclCreate(d *schema.ResourceData, meta interface{}) er
 		}
 
 	}
+
 	if len(role_entity) > 0 {
 		current, err := config.clientStorage.BucketAccessControls.List(bucket).Do()
 		if err != nil {
@@ -210,6 +211,8 @@ func resourceStorageBucketAclRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		d.Set("role_entity", entities)
+	} else {
+		d.Set("role_entity", nil)
 	}
 
 	return nil


### PR DESCRIPTION
When using predefined storage ACLs, you'd get a permadiff, because the
role_entities list was computed, but was never set in state. So it would
be read as empty in the config, and not present in state, so Terraform
would want to pull it down and sync it. This is probably, technically
speaking, a bug in Terraform, but we can work around it by just setting
role_entities to an empty value on every read.