### PR TITLE
Retry creation of Cloud IoT registry

### DIFF
--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -225,7 +225,10 @@ func resourceCloudIoTRegistryCreate(d *schema.ResourceData, meta interface{}) er
 	registryId := fmt.Sprintf("%s/registries/%s", parent, deviceRegistry.Id)
 	d.SetId(registryId)
 
-	_, err = config.clientCloudIoT.Projects.Locations.Registries.Create(parent, deviceRegistry).Do()
+	err = retryTime(func() error {
+		_, err := config.clientCloudIoT.Projects.Locations.Registries.Create(parent, deviceRegistry).Do()
+		return err
+	}, 5)
 	if err != nil {
 		d.SetId("")
 		return err


### PR DESCRIPTION
This can fail with 503, which is a transient error.

I've tested this with an internal configuration - v1.15 fails fairly reliably on the first invocation, whereas with this patch it succeeded.