### PR TITLE
Implement 'licenses' field in compute_image resource

### DIFF
--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -106,6 +106,13 @@ func resourceComputeImage() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"licenses": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"label_fingerprint": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -156,6 +163,11 @@ func resourceComputeImageCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if _, ok := d.GetOk("labels"); ok {
 		image.Labels = expandLabels(d)
+	}
+
+	// Load up the licenses for this image if specified
+	if _, ok := d.GetOk("licenses"); ok {
+		image.Licenses = licenses(d)
 	}
 
 	// Read create timeout
@@ -213,6 +225,7 @@ func resourceComputeImageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("family", image.Family)
 	d.Set("self_link", image.SelfLink)
 	d.Set("labels", image.Labels)
+	d.Set("licenses", image.Licenses)
 	d.Set("label_fingerprint", image.LabelFingerprint)
 	d.Set("project", project)
 
@@ -286,4 +299,13 @@ func resourceComputeImageDelete(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId("")
 	return nil
+}
+
+func licenses(d *schema.ResourceData) []string {
+	licensesCount := d.Get("licenses.#").(int)
+	data := make([]string, licensesCount)
+	for i := 0; i < licensesCount; i++ {
+		data[i] = d.Get(fmt.Sprintf("licenses.%d", i)).(string)
+	}
+	return data
 }

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -29,6 +29,32 @@ func TestAccComputeImage_basic(t *testing.T) {
 					testAccCheckComputeImageFamily(&image, "family-test"),
 					testAccCheckComputeImageContainsLabel(&image, "my-label", "my-label-value"),
 					testAccCheckComputeImageContainsLabel(&image, "empty-label", ""),
+					testAccCheckComputeImageHasComputedFingerprint(&image, "google_compute_image.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeImage_withLicense(t *testing.T) {
+	t.Parallel()
+
+	var image compute.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeImageDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeImage_license("image-test-" + acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeImageExists(
+						"google_compute_image.foobar", &image),
+					testAccCheckComputeImageDescription(&image, "description-test"),
+					testAccCheckComputeImageFamily(&image, "family-test"),
+					testAccCheckComputeImageContainsLabel(&image, "my-label", "my-label-value"),
+					testAccCheckComputeImageContainsLabel(&image, "empty-label", ""),
 					testAccCheckComputeImageContainsLicense(&image, "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"),
 					testAccCheckComputeImageHasComputedFingerprint(&image, "google_compute_image.foobar"),
 				),
@@ -253,6 +279,23 @@ resource "google_compute_image" "foobar" {
 		my-label = "my-label-value"
 		empty-label = ""
 	}
+}`, name)
+}
+
+func testAccComputeImage_license(name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "foobar" {
+	name = "%s"
+	description = "description-test"
+	family = "family-test"
+	raw_disk {
+	  source = "https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz"
+	}
+	create_timeout = 5
+	labels = {
+		my-label = "my-label-value"
+		empty-label = ""
+	}
 	licenses = [
 		"https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx",
 	]
@@ -273,9 +316,6 @@ resource "google_compute_image" "foobar" {
 		empty-label = "oh-look-theres-a-label-now"
 		new-field = "only-shows-up-when-updated"
 	}
-	licenses = [
-		"https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx",
-	]
 }`, name)
 }
 

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -29,6 +29,7 @@ func TestAccComputeImage_basic(t *testing.T) {
 					testAccCheckComputeImageFamily(&image, "family-test"),
 					testAccCheckComputeImageContainsLabel(&image, "my-label", "my-label-value"),
 					testAccCheckComputeImageContainsLabel(&image, "empty-label", ""),
+					testAccCheckComputeImageContainsLicense(&image, "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"),
 					testAccCheckComputeImageHasComputedFingerprint(&image, "google_compute_image.foobar"),
 				),
 			},
@@ -184,6 +185,19 @@ func testAccCheckComputeImageContainsLabel(image *compute.Image, key string, val
 	}
 }
 
+func testAccCheckComputeImageContainsLicense(image *compute.Image, expectedLicense string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		for _, thisLicense := range image.Licenses {
+			if thisLicense == expectedLicense {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Expected license '%s' was not found", expectedLicense)
+	}
+}
+
 func testAccCheckComputeImageDoesNotContainLabel(image *compute.Image, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if v, ok := image.Labels[key]; ok {
@@ -239,6 +253,9 @@ resource "google_compute_image" "foobar" {
 		my-label = "my-label-value"
 		empty-label = ""
 	}
+	licenses = [
+		"https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx",
+	]
 }`, name)
 }
 
@@ -256,6 +273,9 @@ resource "google_compute_image" "foobar" {
 		empty-label = "oh-look-theres-a-label-now"
 		new-field = "only-shows-up-when-updated"
 	}
+	licenses = [
+		"https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx",
+	]
 }`, name)
 }
 

--- a/website/docs/r/compute_image.html.markdown
+++ b/website/docs/r/compute_image.html.markdown
@@ -22,6 +22,10 @@ resource "google_compute_image" "bootable-image" {
   raw_disk {
     source = "https://storage.googleapis.com/my-bucket/my-disk-image-tarball.tar.gz"
   }
+
+  licenses = [
+    "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx",
+  ]
 }
 
 resource "google_compute_instance" "vm" {
@@ -66,6 +70,9 @@ The following arguments are supported: (Note that one of either source_disk or
 * `raw_disk` - (Optional) The raw disk that will be used as the source of the image.
     Changing this forces a new resource to be created. Structure is documented
     below.
+
+* `licenses` - (Optional) A list of license URIs to apply to this image. Changing this
+    forces a new resource to be created.
 
 * `create_timeout` - (Deprecated) Configurable timeout in minutes for creating images. Default is 4 minutes.
 


### PR DESCRIPTION
This PR implements the `licenses` field for GCP images in this provider (already exists in the Google API, just needed to be plumbed through).

Terraform users can now use this provider to create images for [nested virtualization](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances), as well as other use cases for setting licenses on an image.

Closes https://github.com/terraform-providers/terraform-provider-google/issues/1045