### PR TITLE
Clarify regional backend service docs.

### DIFF
--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -12,6 +12,9 @@ A Region Backend Service defines a regionally-scoped group of virtual machines t
 For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/internal/)
 and [API](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices).
 
+~> **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
+  [`google_compute_backend_service`](compute_backend_service.html) instead.
+
 ## Example Usage
 
 ```hcl
@@ -84,7 +87,7 @@ The following arguments are supported:
     is not provided, the provider project is used.
 
 * `protocol` - (Optional) The protocol for incoming requests. Defaults to
-    `HTTP`.
+    `TCP`.
 
 * `session_affinity` - (Optional) How to distribute load. Options are `NONE` (no
     affinity), `CLIENT_IP`, `CLIENT_IP_PROTO`, or `CLIENT_IP_PORT_PROTO`.


### PR DESCRIPTION
Make it clear that regional backend services are only for internal load
balancing, and fix the default for protocol. It's not HTTP, as the API
docs claim, but is TCP instead.

Fixes #532 