### PR TITLE
Add the capability to pass an empty string to the "additional_zones" attribute on creating/updating a container_cluster resource.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -540,6 +540,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		if locationsSet.Contains(location) {
 			return fmt.Errorf("additional_zones should not contain the original 'zone'")
 		}
+		// Remove empty string
+		if locationsSet.Contains("") {
+			locationsSet.Remove("")
+		}
 		if isZone(location) {
 			// GKE requires a full list of locations (including the original zone),
 			// but our schema only asks for additional zones, so append the original.
@@ -730,6 +734,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 
 	locations := schema.NewSet(schema.HashString, convertStringArrToInterface(cluster.Locations))
 	locations.Remove(cluster.Zone) // Remove the original zone since we only store additional zones
+	locations.Remove("")           // Remove empty string
 	d.Set("additional_zones", locations)
 
 	d.Set("endpoint", cluster.Endpoint)
@@ -954,6 +959,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		azSetOld := azSetOldI.(*schema.Set)
 		if azSetNew.Contains(location) {
 			return fmt.Errorf("additional_zones should not contain the original 'zone'")
+		}
+		// Remove empty string
+		if azSetNew.Contains("") {
+			azSetNew.Remove("")
 		}
 		// Since we can't add & remove zones in the same request, first add all the
 		// zones, then remove the ones we aren't using anymore.


### PR DESCRIPTION
Every empty string passed through "additional_zones" array will be removed.
If you pass an array containing just an empty string the effects are the same as the "additional_zones" was not declared.
It can be used on creating or updating the cluster. 
It is useful in creating a module that creates additional_zones by evaluating some variable or if you just want to pass an empty string ( in the array) to remove the additional_zones previously set.

Example:

resource "google_container_cluster" "primary" {
  name               = "marcellus-wallace"
  zone               = "us-central1-a"
  initial_node_count = 3

  additional_zones = [""]
...

With the modification performed in this PR, the snippet above has the same behavior as:

resource "google_container_cluster" "primary" {
  name               = "marcellus-wallace"
  zone               = "us-central1-a"
  initial_node_count = 3
...
 
Or you can use it evaluating some variable:

variable "environment" {
     default = "production"
}

variable "add_zone" {
    default = "us-central1-b"
}
resource "google_container_cluster" "primary" {
  name               = "marcellus-wallace"
  zone               = "us-central1-a"
  initial_node_count = 3

additional_zones = ["${var.environment == "production" ? var.add_zone : "" }"]
...

https://www.terraform.io/docs/configuration/interpolation.html#conditionals
https://www.terraform.io/docs/providers/google/r/container_cluster.html


