### PR TITLE
Fix instance group manager rolling-updates

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -489,7 +489,7 @@ func performUpdate(config *Config, id string, updateStrategy string, rollingUpda
 	}
 
 	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
+		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Update` calls.
 		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
 		// expect those values to be provided by user as part of the call
 		// or provide their own defaults without respecting what was previously set on UpdateManager.
@@ -499,7 +499,7 @@ func performUpdate(config *Config, id string, updateStrategy string, rollingUpda
 			Versions:     versions,
 		}
 
-		op, err := config.clientComputeBeta.InstanceGroupManagers.Patch(project, zone, id, manager).Do()
+		op, err := config.clientComputeBeta.InstanceGroupManagers.Update(project, zone, id, manager).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating managed group instances: %s", err)
 		}


### PR DESCRIPTION
Currently, the InstanceGroupManager rolling-update API expects a PUT (`regionInstanceGroupManager.update()`) instead of a PATCH (`regionInstanceGroupManager.patch()`) call.

Using `patch()`, the specified `PROACTIVE` policy is ignored for `OPPORTUNISTIC`,  immediate rolling updates (as specified with the `update_strategy = "ROLLING_UPDATE"` compute_instance_group_manager attribute) are never triggered, and the API returns a warning:

```
[DEBUG]: ---[ REQUEST ]---------------------------------------
[DEBUG]: POST /compute/beta/projects/mycompany-myapp-staging/regions/europe-west3/instanceGroupManagers/myapp-server/setInstanceTemplate?alt=json HTTP/1.1
....
[DEBUG]: ---[ RESPONSE ]--------------------------------------
...
[DEBUG]:  "warnings": [
[DEBUG]:   {
[DEBUG]:    "code": "FIELD_VALUE_OVERRIDEN",
[DEBUG]:    "message": "Update policy type was set to OPPORTUNISTIC. Please use regionInstanceGroupManager.update() to preserve the policy."
[DEBUG]:   }
```

refs:
https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch
https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/update

Fix #1506