### PR TITLE
Container cluster delete timeout to 30 min.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -54,7 +54,7 @@ func resourceContainerCluster() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		SchemaVersion: 1,


### PR DESCRIPTION
Matches Create operation timeout. Should reduce timeouts when deleting regional clusters.

Fixes #1744 