### PR TITLE
prereqs for regional disks

### DIFF
--- a/google/disk_type.go
+++ b/google/disk_type.go
@@ -1,12 +1,23 @@
 package google
 
 import (
+	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
 // readDiskType finds the disk type with the given name.
 func readDiskType(c *Config, zone *compute.Zone, project, name string) (*compute.DiskType, error) {
 	diskType, err := c.clientCompute.DiskTypes.Get(project, zone.Name, name).Do()
+	if err == nil && diskType != nil && diskType.SelfLink != "" {
+		return diskType, nil
+	} else {
+		return nil, err
+	}
+}
+
+// readDiskType finds the disk type with the given name.
+func readRegionDiskType(c *Config, region *compute.Region, project, name string) (*computeBeta.DiskType, error) {
+	diskType, err := c.clientComputeBeta.RegionDiskTypes.Get(project, region.Name, name).Do()
 	if err == nil && diskType != nil && diskType.SelfLink != "" {
 		return diskType, nil
 	} else {

--- a/google/disk_type.go
+++ b/google/disk_type.go
@@ -15,7 +15,7 @@ func readDiskType(c *Config, zone *compute.Zone, project, name string) (*compute
 	}
 }
 
-// readDiskType finds the disk type with the given name.
+// readRegionDiskType finds the disk type with the given name.
 func readRegionDiskType(c *Config, region *compute.Region, project, name string) (*computeBeta.DiskType, error) {
 	diskType, err := c.clientComputeBeta.RegionDiskTypes.Get(project, region.Name, name).Do()
 	if err == nil && diskType != nil && diskType.SelfLink != "" {

--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -46,6 +46,10 @@ func ParseDiskFieldValue(disk string, d TerraformResourceData, config *Config) (
 	return parseZonalFieldValue("disks", disk, "project", "zone", d, config, false)
 }
 
+func ParseRegionDiskFieldValue(disk string, d TerraformResourceData, config *Config) (*RegionalFieldValue, error) {
+	return parseRegionalFieldValue("disks", disk, "project", "region", "zone", d, config, false)
+}
+
 func ParseOrganizationCustomRoleName(role string) (*OrganizationFieldValue, error) {
 	return parseOrganizationFieldValue("roles", role, false)
 }

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -206,7 +206,8 @@ The `disk` block supports:
     read-write mode.
 
 * `source` - (Required if source_image not set) The name of the disk (such as
-    those managed by `google_compute_disk`) to attach.
+    those managed by `google_compute_disk`) to attach. This cannot be a regional
+    disk.
 
 * `disk_type` - (Optional) The GCE disk type. Can be either `"pd-ssd"`,
     `"local-ssd"`, or `"pd-standard"`.


### PR DESCRIPTION
In testing an upcoming `google_compute_region_disk` resource, I had to make these changes. Checking them in separately so that when the magician runs, these changes will already be a part of TF.