### PR TITLE
Make licenses field of images computed.

### DIFF
--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -111,6 +111,7 @@ func resourceComputeImage() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 			},
 
 			"label_fingerprint": &schema.Schema{


### PR DESCRIPTION
Images now have a licenses field, which lets users specify licenses to
use on an image. But official images already have licenses on them, adn
so Terraform is reading those as a diff. To preserve backwards
compatiblity and avoid a breaking change that would require all
`google_compute_image` users to update their configs, I've set the field
to computed. This means that if no licenses are set in the config, there
can be licenses in the config without prompting a diff. Obviously, this
isn't ideal, as it means you can't ever remove all the licenses from an
image, but I think the benefits here outweigh the drawbacks.