### PR TITLE
Revert "Fix instance group manager rolling-updates"

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -489,7 +489,7 @@ func performUpdate(config *Config, id string, updateStrategy string, rollingUpda
 	}
 
 	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Update` calls.
+		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
 		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
 		// expect those values to be provided by user as part of the call
 		// or provide their own defaults without respecting what was previously set on UpdateManager.
@@ -499,7 +499,7 @@ func performUpdate(config *Config, id string, updateStrategy string, rollingUpda
 			Versions:     versions,
 		}
 
-		op, err := config.clientComputeBeta.InstanceGroupManagers.Update(project, zone, id, manager).Do()
+		op, err := config.clientComputeBeta.InstanceGroupManagers.Patch(project, zone, id, manager).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating managed group instances: %s", err)
 		}


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-google#1742

After using the `Update` method, it looks like future calls to `Get` don't return the rolling update strategy information anymore, which is super puzzling. We should definitely do #1742, but it's blocking a release right now, so let's roll it back until we can figure out how to resolve this weird bug.