### PR TITLE
Add stackdriverprovisioning to ignored APIs.

### DIFF
--- a/google/resource_google_project_services.go
+++ b/google/resource_google_project_services.go
@@ -47,9 +47,10 @@ func resourceGoogleProjectServices() *schema.Resource {
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.
 var ignoreProjectServices = map[string]struct{}{
-	"containeranalysis.googleapis.com": struct{}{},
-	"dataproc-control.googleapis.com":  struct{}{},
-	"source.googleapis.com":            struct{}{},
+	"containeranalysis.googleapis.com":       struct{}{},
+	"dataproc-control.googleapis.com":        struct{}{},
+	"source.googleapis.com":                  struct{}{},
+	"stackdriverprovisioning.googleapis.com": struct{}{},
 }
 
 func resourceGoogleProjectServicesCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Add stackdriverprovisioning.googleapis.com to our list of APIs that are
automateically enabled that Terraform can't act on.