### PR TITLE
Fix crash when updating container cluster resource labels.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1145,7 +1145,11 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("resource_labels") {
-		resourceLabels := d.Get("resource_labels").(map[string]string)
+		resourceLabelsI := d.Get("resource_labels").(map[string]interface{})
+		resourceLabels := make(map[string]string, len(resourceLabelsI))
+		for k, v := range resourceLabelsI {
+			resourceLabels[k] = v.(string)
+		}
 
 		req := &containerBeta.SetLabelsRequest{
 			ResourceLabels: resourceLabels,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1145,14 +1145,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("resource_labels") {
-		resourceLabelsI := d.Get("resource_labels").(map[string]interface{})
-		resourceLabels := make(map[string]string, len(resourceLabelsI))
-		for k, v := range resourceLabelsI {
-			resourceLabels[k] = v.(string)
-		}
-
+		resourceLabels := d.Get("resource_labels").(map[string]interface{})
 		req := &containerBeta.SetLabelsRequest{
-			ResourceLabels: resourceLabels,
+			ResourceLabels: convertStringMap(resourceLabels),
 		}
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -1183,6 +1183,32 @@ func TestAccContainerCluster_withResourceLabels(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withResourceLabelsUpdate(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withoutResourceLabels(clusterName),
+			},
+			{
+				Config: testAccContainerCluster_withResourceLabels(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_resource_labels",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckContainerClusterDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -2252,6 +2278,16 @@ resource "google_container_cluster" "shared_vpc_cluster" {
 		"google_compute_subnetwork_iam_member.service_network_gke_user"
 	]
 }`, projectName, org, billingId, projectName, org, billingId, acctest.RandString(10), acctest.RandString(10), name)
+}
+
+func testAccContainerCluster_withoutResourceLabels(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_resource_labels" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+}
+`, clusterName)
 }
 
 func testAccContainerCluster_withResourceLabels(clusterName string) string {


### PR DESCRIPTION
We had a bad type coercion in the code to update container cluster
resource labels. This fixes the coercion.

We didn't notice this because there was no test exercising the update
code path. I've added the test, which reproduced the panic before this
PR was applied and passes successfully now that the coercion is fixed.

Fixes #1767.