### PR TITLE
Add support for updating function code in place

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -123,13 +123,11 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"source_archive_bucket": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"source_archive_object": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"description": {
@@ -410,6 +408,13 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 		availableMemoryMb := d.Get("available_memory_mb").(int)
 		function.AvailableMemoryMb = int64(availableMemoryMb)
 		updateMaskArr = append(updateMaskArr, "availableMemoryMb")
+	}
+
+	if d.HasChange("source_archive_bucket") || d.HasChange("source_archive_object") {
+		sourceArchiveBucket := d.Get("source_archive_bucket").(string)
+		sourceArchiveObj := d.Get("source_archive_object").(string)
+		function.SourceArchiveUrl = fmt.Sprintf("gs://%v/%v", sourceArchiveBucket, sourceArchiveObj)
+		updateMaskArr = append(updateMaskArr, "sourceArchiveUrl")
 	}
 
 	if d.HasChange("description") {

--- a/google/resource_cloudfunctions_function_test.go
+++ b/google/resource_cloudfunctions_function_test.go
@@ -23,6 +23,7 @@ const (
 )
 
 const testHTTPTriggerPath = "./test-fixtures/cloudfunctions/http_trigger.js"
+const testHTTPTriggerUpdatePath = "./test-fixtures/cloudfunctions/http_trigger_update.js"
 const testPubSubTriggerPath = "./test-fixtures/cloudfunctions/pubsub_trigger.js"
 const testBucketTriggerPath = "./test-fixtures/cloudfunctions/bucket_trigger.js"
 
@@ -85,6 +86,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 	functionName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 	zipFilePath, err := createZIPArchiveForIndexJs(testHTTPTriggerPath)
+	zipFileUpdatePath, err := createZIPArchiveForIndexJs(testHTTPTriggerUpdatePath)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -105,7 +107,7 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFilePath),
+				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudFunctionsFunctionExists(
 						funcResourceName, &function),
@@ -420,7 +422,7 @@ resource "google_storage_bucket" "bucket" {
 }
 
 resource "google_storage_bucket_object" "archive" {
-  name   = "index.zip"
+  name   = "index_update.zip"
   bucket = "${google_storage_bucket.bucket.name}"
   source = "%s"
 }

--- a/google/test-fixtures/cloudfunctions/http_trigger_update.js
+++ b/google/test-fixtures/cloudfunctions/http_trigger_update.js
@@ -1,0 +1,9 @@
+/**
+ * HTTP Cloud Function.
+ *
+ * @param {Object} req Cloud Function request context.
+ * @param {Object} res Cloud Function response context.
+ */
+exports.helloGET = function helloGET (req, res) {
+    res.send("Goodbye ${req.body.name || 'World'}!");
+};


### PR DESCRIPTION
Remove `ForceNew` from the source inputs on function resources, and add support for updating the function in place from a new source bucket+object.

This is similar to #1666, but includes test coverage and removes `ForceNew` from both `source_archive_bucket` and `source_archive_object`.

Tests:

```
$ /usr/local/bin/go test -v -timeout 1h github.com/terraform-providers/terraform-provider-google/google -run ^TestAccCloudFunctionsFunction
=== RUN   TestAccCloudFunctionsFunction_basic
=== RUN   TestAccCloudFunctionsFunction_update
=== RUN   TestAccCloudFunctionsFunction_pubsub
=== RUN   TestAccCloudFunctionsFunction_bucket
--- PASS: TestAccCloudFunctionsFunction_basic (34.82s)
--- PASS: TestAccCloudFunctionsFunction_pubsub (41.58s)
--- PASS: TestAccCloudFunctionsFunction_update (60.10s)
--- PASS: TestAccCloudFunctionsFunction_bucket (60.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 60.233s
```