### PR TITLE
make additional zones block removable

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -111,7 +111,6 @@ func resourceContainerCluster() *schema.Resource {
 			"additional_zones": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 


### PR DESCRIPTION
This was originally set to be computed because the list returned from GCP contains the original zone, but since we remove that from the list it doesn't actually need to be computed. Fixes #1710.