### PR TITLE
use customizediff to allow all role-entity pairs to be unordered

### DIFF
--- a/google/resource_storage_bucket_acl.go
+++ b/google/resource_storage_bucket_acl.go
@@ -17,7 +17,7 @@ func resourceStorageBucketAcl() *schema.Resource {
 		Read:          resourceStorageBucketAclRead,
 		Update:        resourceStorageBucketAclUpdate,
 		Delete:        resourceStorageBucketAclDelete,
-		CustomizeDiff: resourceStorageBucketAclCustomizeDiff,
+		CustomizeDiff: resourceStorageRoleEntityCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{
@@ -49,7 +49,7 @@ func resourceStorageBucketAcl() *schema.Resource {
 	}
 }
 
-func resourceStorageBucketAclCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
+func resourceStorageRoleEntityCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
 	keys := diff.GetChangedKeysPrefix("role_entity")
 	if len(keys) < 1 {
 		return nil

--- a/google/resource_storage_default_object_acl.go
+++ b/google/resource_storage_default_object_acl.go
@@ -10,10 +10,11 @@ import (
 
 func resourceStorageDefaultObjectAcl() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceStorageDefaultObjectAclCreate,
-		Read:   resourceStorageDefaultObjectAclRead,
-		Update: resourceStorageDefaultObjectAclUpdate,
-		Delete: resourceStorageDefaultObjectAclDelete,
+		Create:        resourceStorageDefaultObjectAclCreate,
+		Read:          resourceStorageDefaultObjectAclRead,
+		Update:        resourceStorageDefaultObjectAclUpdate,
+		Delete:        resourceStorageDefaultObjectAclDelete,
+		CustomizeDiff: resourceStorageRoleEntityCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{
@@ -24,7 +25,8 @@ func resourceStorageDefaultObjectAcl() *schema.Resource {
 
 			"role_entity": &schema.Schema{
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				MinItems: 1,
 			},

--- a/google/resource_storage_object_acl.go
+++ b/google/resource_storage_object_acl.go
@@ -11,10 +11,11 @@ import (
 
 func resourceStorageObjectAcl() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceStorageObjectAclCreate,
-		Read:   resourceStorageObjectAclRead,
-		Update: resourceStorageObjectAclUpdate,
-		Delete: resourceStorageObjectAclDelete,
+		Create:        resourceStorageObjectAclCreate,
+		Read:          resourceStorageObjectAclRead,
+		Update:        resourceStorageObjectAclUpdate,
+		Delete:        resourceStorageObjectAclDelete,
+		CustomizeDiff: resourceStorageRoleEntityCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"bucket": &schema.Schema{
@@ -38,6 +39,7 @@ func resourceStorageObjectAcl() *schema.Resource {
 			"role_entity": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},


### PR DESCRIPTION
Fixes #1678 