### PR TITLE
CloudBuild Trigger substitutions

### DIFF
--- a/google/resource_cloudbuild_build_trigger_test.go
+++ b/google/resource_cloudbuild_build_trigger_test.go
@@ -239,10 +239,10 @@ resource "google_cloudbuild_trigger" "filename_build_trigger" {
     project     = "${google_project_services.acceptance.project}"
     repo_name   = "some-repo"
   }
-	substitutions {
-		foo = "bar"
-		baz = "qux"
-	}
+  substitutions {
+    _FOO = "bar"
+    _BAZ = "qux"
+  }
   filename = "cloudbuild.yaml"
 }
   `, projectID, projectID, projectOrg, projectBillingAccount)

--- a/google/resource_cloudbuild_build_trigger_test.go
+++ b/google/resource_cloudbuild_build_trigger_test.go
@@ -29,6 +29,12 @@ func TestAccCloudBuildTrigger_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
+				ResourceName:        "google_cloudbuild_trigger.build_trigger",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", projectID),
+			},
+			resource.TestStep{
 				Config: testGoogleCloudBuildTrigger_removed(projectID, projectOrg, projectBillingAccount),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleCloudBuildTriggerWasRemovedFromState("google_cloudbuild_trigger.build_trigger"),
@@ -233,6 +239,10 @@ resource "google_cloudbuild_trigger" "filename_build_trigger" {
     project     = "${google_project_services.acceptance.project}"
     repo_name   = "some-repo"
   }
+	substitutions {
+		foo = "bar"
+		baz = "qux"
+	}
   filename = "cloudbuild.yaml"
 }
   `, projectID, projectID, projectOrg, projectBillingAccount)

--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -78,6 +78,22 @@ will be expanded when the build is created:
 in the Git repo. This is mutually exclusive with `build`. This is typically
 `cloudbuild.yaml` however it can be specified by the user.
 
+* `substitutions`: (Optional) User-defined substitutions.
+User-defined substitutions must conform to the following rules:
+  *  Substitutions must begin with an underscore (`_`) and use only
+     uppercase-letters and numbers (respecting the regular expression 
+     `_[A-Z0-9_]+`). This prevents conflicts with built-in substitutions.
+  *  Unmatched keys in the template will cause an error (for example, if a build
+     request includes `$_FOO` and the substitutions map doesn’t define `_FOO`).
+  *  Unmatched keys in the parameters list will result in an error (for example,
+     if a substitutions map defines `_FOO` but the build request doesn't include `$_FOO`).
+  *  To include a literal `$_VARIABLE` in the template, you must escape with `$$`.
+  *  You can explicitly denote variable expansion using the `${_VAR}` syntax. This prevents
+     ambiguity in cases like `${_FOO}BAR`, where `$_FOO` is a variable.
+  *  The number of parameters is limited to 100 parameters.
+  *  The length of a parameter key and the length of a parameter value
+     are limited to 100 characters.
+
 ---
 
 The `trigger_template` block supports:


### PR DESCRIPTION
Adds substitutions to Cloud Build Triggers, fixes #1802.  Also adds project-imports so that you can import it even if it's not using the provider-default project (whoops) and adds that to the tests.