### PR TITLE
Add google_project_services data source

### DIFF
--- a/google/data_source_google_project_services.go
+++ b/google/data_source_google_project_services.go
@@ -1,0 +1,30 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleProjectServices() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(resourceGoogleProjectServices().Schema)
+
+	// Set 'Optional' schema elements
+	addOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleProjectServicesRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleProjectServicesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	d.SetId(project)
+
+	return resourceGoogleProjectServicesRead(d, meta)
+}

--- a/google/data_source_google_project_services_test.go
+++ b/google/data_source_google_project_services_test.go
@@ -1,0 +1,82 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceGoogleProjectServices_basic(t *testing.T) {
+	t.Parallel()
+	org := getTestOrgFromEnv(t)
+	project := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectServicesConfig(project, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleProjectServicesCheck("data.google_project_services.project_services", "google_project_services.project_services"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleProjectServicesCheck(dataSourceName string, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", dataSourceName)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName)
+		}
+
+		dsAttr := ds.Primary.Attributes
+		rsAttr := rs.Primary.Attributes
+
+		projectAttrToCheck := []string{
+			"project",
+			"services",
+		}
+
+		for _, attr := range projectAttrToCheck {
+			if dsAttr[attr] != rsAttr[attr] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attr,
+					dsAttr[attr],
+					rsAttr[attr],
+				)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectServicesConfig(project, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+	project_id = "%s"
+	name = "%s"
+	org_id = "%s"
+}
+
+resource "google_project_services" "project_services" {
+	project = "${google_project.project.id}"
+	services = ["admin.googleapis.com"]
+}
+
+data "google_project_services" "project_services" {
+	project = "${google_project.project.id}"
+}`, project, project, org)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -73,6 +73,7 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_lb_ip_ranges":            dataSourceGoogleComputeLbIpRanges(),
 			"google_compute_network":                 dataSourceGoogleComputeNetwork(),
 			"google_project":                         dataSourceGoogleProject(),
+			"google_project_services":                dataSourceGoogleProjectServices(),
 			"google_compute_subnetwork":              dataSourceGoogleComputeSubnetwork(),
 			"google_compute_zones":                   dataSourceGoogleComputeZones(),
 			"google_compute_instance_group":          dataSourceGoogleComputeInstanceGroup(),

--- a/website/docs/d/google_project_services.html.markdown
+++ b/website/docs/d/google_project_services.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "google"
+page_title: "Google: google_project_services"
+sidebar_current: "docs-google-datasource-project-services"
+description: |-
+  Retrieve enabled of API services for a Google Cloud Platform project
+---
+
+# google\_project\_services
+
+Use this data source to get details on the enabled project services.
+
+For a list of services available, visit the
+[API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
+
+## Example Usage
+
+```hcl
+data "google_project_services" "project" {
+  project = "your-project-id"
+}
+
+output "project_services" {
+  value = "${join(",", data.google_project_services.project.services)}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The project ID.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+See [google_project_services](https://www.terraform.io/docs/providers/google/r/google_project_services.html) resource for details of the available attributes.

--- a/website/google.erb
+++ b/website/google.erb
@@ -43,6 +43,9 @@
       <li<%= sidebar_current("docs-google-datasource-project") %>>
         <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-project-services") %>>
+        <a href="/docs/providers/google/d/google_project_services.html">google_project_services</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-regions") %>>
       <a href="/docs/providers/google/d/google_compute_regions.html">google_compute_regions</a>
       </li>


### PR DESCRIPTION
Been awhile since I contributed, so please let me know if I've missed something.

This should add a `google_project_services` data source, to view the enabled service on a GCP project.

Acceptance Test:
```
$ make testacc TESTARGS="-run TestAccDataSourceGoogleProjectServices_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourceGoogleProjectServices_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-google        [no test files]
=== RUN   TestAccDataSourceGoogleProjectServices_basic
=== PAUSE TestAccDataSourceGoogleProjectServices_basic
=== CONT  TestAccDataSourceGoogleProjectServices_basic
--- PASS: TestAccDataSourceGoogleProjectServices_basic (41.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 41.136s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-google/scripts        (cached) [no tests to run]
```