### PR TITLE
Strengthen warning in google_project_services.

### DIFF
--- a/website/docs/r/google_project_services.html.markdown
+++ b/website/docs/r/google_project_services.html.markdown
@@ -15,9 +15,10 @@ in the config will be removed.
 For a list of services available, visit the
 [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
 
-~> **Note:** This resource attempts to be the authoritative source on which APIs are enabled, which can
-	lead to conflicts when certain APIs or actions enable other APIs. To just ensure that a specific
-	API is enabled, use the [google_project_service](google_project_service.html) resource.
+~> **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
+	leads to conflicts when certain actions enable other APIs. If you do not need to ensure that
+	*exclusively* a particular set of APIs are enabled, you should most likely use the
+	[google_project_service](google_project_service.html) resource, one resource per API.
 
 ## Example Usage
 


### PR DESCRIPTION
A stronger warning would have prevented any confusion, ref: https://github.com/terraform-providers/terraform-provider-google/issues/1818.  :)