### PR TITLE
Add k8s support to shared vpc service project.

### DIFF
--- a/google/resource_compute_shared_vpc_service_project.go
+++ b/google/resource_compute_shared_vpc_service_project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/compute/v1"
 
 	"log"
@@ -32,6 +33,14 @@ func resourceComputeSharedVpcServiceProject() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"kubernetes_subnetwork_access": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -52,12 +61,39 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
+	d.SetId(fmt.Sprintf("%s/%s", hostProject, serviceProject))
 	if err = computeOperationWait(config.clientCompute, op, hostProject, "Enabling Shared VPC Resource"); err != nil {
 		return err
 	}
-
-	d.SetId(fmt.Sprintf("%s/%s", hostProject, serviceProject))
-
+	// k8s subnetwork access is configured through the cloud console on the same page as
+	// shared VPC project links, so to meet user expectations, we're adding it here.
+	// Behind the scenes, a k8s subnetwork access request just adds two service accounts
+	// with the roles/compute.networkUser to the subnetworks in question.  This is
+	// acheivable using the existing iam code, mostly.
+	if v, ok := d.GetOk("kubernetes_subnetwork_access"); ok {
+		proj, err := config.clientResourceManager.Projects.Get(serviceProject).Do()
+		if err != nil {
+			return err
+		}
+		b := &cloudresourcemanager.Binding{
+			Members: []string{fmt.Sprintf("serviceAccount:%d@cloudservices.gserviceaccount.com", proj.ProjectNumber),
+				fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", proj.ProjectNumber)},
+			Role: "roles/compute.networkUser",
+		}
+		for _, subnet := range v.([]interface{}) {
+			iamUpdater, err := getUpdater(subnet.(string), d, config)
+			if err != nil {
+				return err
+			}
+			err = iamPolicyReadModifyWrite(iamUpdater, func(ep *cloudresourcemanager.Policy) error {
+				ep.Bindings = mergeBindings(append(ep.Bindings, b))
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -85,6 +121,38 @@ func resourceComputeSharedVpcServiceProjectRead(d *schema.ResourceData, meta int
 		return nil
 	}
 
+	// We don't want to iterate through all subnetworks, checking to see which
+	// ones have k8s access.  In that sense, this resource isn't 'authoritative'.
+	// Instead, we just check to make sure that the ones that are listed are still
+	// enabled and working, catching out of band changes to those.
+	if v, ok := d.GetOk("kubernetes_subnetwork_access"); ok {
+		k8s_subnets := make([]string, 0, len(v.([]interface{})))
+		proj, err := config.clientResourceManager.Projects.Get(serviceProject).Do()
+		if err != nil {
+			return err
+		}
+		for _, subnet := range v.([]interface{}) {
+			iamUpdater, err := getUpdater(subnet.(string), d, config)
+			if err != nil {
+				return err
+			}
+			p, err := iamUpdater.GetResourceIamPolicy()
+			if err == nil {
+				for _, b := range p.Bindings {
+					if b.Role == "roles/compute.networkUser" {
+						for _, m := range b.Members {
+							if m == fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", proj.ProjectNumber) {
+								k8s_subnets = append(k8s_subnets, subnet.(string))
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+		d.Set("kubernetes_subnetwork_access", k8s_subnets)
+	}
+
 	d.Set("host_project", hostProject)
 	d.Set("service_project", serviceProject)
 
@@ -102,7 +170,49 @@ func resourceComputeSharedVpcServiceProjectDelete(d *schema.ResourceData, meta i
 			return fmt.Errorf("Error disabling Shared VPC Resource %q: %s", serviceProject, err)
 		}
 	}
+	if v, ok := d.GetOk("kubernetes_subnetwork_access"); ok {
+		proj, err := config.clientResourceManager.Projects.Get(serviceProject).Do()
+		if err != nil {
+			return err
+		}
+		for _, subnet := range v.([]interface{}) {
+			iamUpdater, err := getUpdater(subnet.(string), d, config)
+			if err != nil {
+				// Try to avoid failing if possible - ignore the error if, for instance, the subnet
+				// has already been deleted.
+				continue
+			}
 
+			err = iamPolicyReadModifyWrite(iamUpdater, func(ep *cloudresourcemanager.Policy) error {
+				bindings := make([]*cloudresourcemanager.Binding, 0)
+				for _, binding := range ep.Bindings {
+					if binding.Role == "roles/compute.networkUser" {
+						b := &cloudresourcemanager.Binding{
+							Role:    binding.Role,
+							Members: make([]string, 0),
+						}
+						for _, m := range binding.Members {
+							if m == fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", proj.ProjectNumber) {
+								continue
+							} else if m == fmt.Sprintf("serviceAccount:%d@cloudservices.gserviceaccount.com", proj.ProjectNumber) {
+								continue
+							} else {
+								b.Members = append(b.Members, m)
+							}
+						}
+						bindings = append(bindings, b)
+					} else {
+						bindings = append(bindings, binding)
+					}
+				}
+				ep.Bindings = mergeBindings(bindings)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -130,4 +240,18 @@ func isDisabledXpnResourceError(err error) bool {
 		}
 	}
 	return false
+}
+
+func getUpdater(subnet string, d *schema.ResourceData, config *Config) (*ComputeSubnetworkIamUpdater, error) {
+	region, err := getRegionFromResourceReference(subnet, d, config)
+	if err != nil {
+		return nil, err
+	}
+	resourceIdParts := strings.Split(subnet, "/")
+	return &ComputeSubnetworkIamUpdater{
+		project:    d.Get("host_project").(string),
+		region:     region,
+		resourceId: resourceIdParts[len(resourceIdParts)-1],
+		Config:     config,
+	}, nil
 }

--- a/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -37,6 +37,14 @@ The following arguments are expected:
 
 * `service_project` - (Required) The ID of the project that will serve as a Shared VPC service project.
 
+- - -
+
+* `kubernetes_subnetwork_access` - (Optional) A list of strings.  Each string is the self link (or partial self-link)
+  of a subnetwork on the host project that should be accessible by Google Kubernetes Engine on the service project.
+  The supported formats are full self link, relative self link, `project/region/name`, `region/name`, or `name` (with
+  default region or zone in the provider).  Note: this feature is not importable - you should expect to see a diff
+  after import, which will be resolved after the first apply.
+
 ## Import
 
 Google Compute Engine Shared VPC service project feature can be imported using the `host_project` and `service_project`, e.g.


### PR DESCRIPTION
This PR adds support for kubernetes subnetwork access to `google_compute_shared_vpc_service_project`.  The APIs aren't very related, but the cloud console allows it.  See here: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#enabling_shared_vpc_and_granting_roles.

Fixes #1819, but let me say I'm not very attached to this as an interface - suggestions very welcome.