### PR TITLE
provider: Ensures schema.TypeMap elements are schema.Schema

### DIFF
--- a/google/data_source_storage_object_signed_url.go
+++ b/google/data_source_storage_object_signed_url.go
@@ -62,7 +62,7 @@ func dataSourceGoogleSignedUrl() *schema.Resource {
 			"extension_headers": &schema.Schema{
 				Type:         schema.TypeMap,
 				Optional:     true,
-				Elem:         schema.TypeString,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 				ValidateFunc: validateExtensionHeaders,
 			},
 			"http_method": &schema.Schema{

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -76,7 +76,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"local_ssd_count": {
@@ -98,7 +98,7 @@ var schemaNodeConfig = &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"min_cpu_platform": {

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -105,7 +105,7 @@ func resourceBigQueryDataset() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			// SelfLink: [Output-only] A URL that can be used to access the resource

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -78,7 +78,7 @@ func resourceBigQueryTable() *schema.Resource {
 			"labels": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			// Schema: [Optional] Describes the schema of this table.

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -405,7 +405,7 @@ func resourceComputeInstance() *schema.Resource {
 			"metadata": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"metadata_startup_script": &schema.Schema{

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -19,9 +19,9 @@ func resourceComputeProjectMetadata() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": &schema.Schema{
-				Elem:     schema.TypeString,
 				Type:     schema.TypeMap,
 				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"project": &schema.Schema{

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -466,7 +466,7 @@ func resourceContainerCluster() *schema.Resource {
 			"resource_labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -77,7 +77,7 @@ func resourceDataprocCluster() *schema.Resource {
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				// GCP automatically adds two labels
 				//    'goog-dataproc-cluster-uuid'
 				//    'goog-dataproc-cluster-name'
@@ -186,7 +186,7 @@ func resourceDataprocCluster() *schema.Resource {
 									"metadata": &schema.Schema{
 										Type:     schema.TypeMap,
 										Optional: true,
-										Elem:     schema.TypeString,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 										ForceNew: true,
 									},
 								},
@@ -265,7 +265,7 @@ func resourceDataprocCluster() *schema.Resource {
 										Type:     schema.TypeMap,
 										Optional: true,
 										ForceNew: true,
-										Elem:     schema.TypeString,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 
 									"properties": {

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -61,7 +61,7 @@ func resourcePubsubSubscription() *schema.Resource {
 						"attributes": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
 						"push_endpoint": &schema.Schema{


### PR DESCRIPTION
Issue Reference:  [hashicorp/terraform#18544](https://github.com/hashicorp/terraform/issues/18544)
AWS Equivalent: [terraform-providers/terraform-provider-aws](https://github.com/terraform-providers/terraform-provider-aws/pull/5350)

Changes proposed in this pull request:

-   Manually correct 'invalid' schema until 0.12 validation tests are in place.

Acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccBigQueryDataset_basic\|TestAccComputeInstance_basic1\|TestAccPubsubSubscription_basic\|TestAccContainerNodePool_basic\|TestAccDataprocCluster_basic\|TestAccContainerCluster_basic\|TestAccContainerClusterDatasource_zonal\|TestAccStorageSignedUrl_basic -timeout 120m
? github.com/terraform-providers/terraform-provider-google  [no test files]
=== RUN TestAccContainerClusterDatasource_zonal
=== PAUSE TestAccContainerClusterDatasource_zonal
=== RUN TestAccStorageSignedUrl_basic
=== PAUSE TestAccStorageSignedUrl_basic
=== RUN TestAccBigQueryDataset_basic
=== PAUSE TestAccBigQueryDataset_basic
=== RUN TestAccComputeInstance_basic1
=== PAUSE TestAccComputeInstance_basic1
=== RUN TestAccContainerCluster_basic
=== PAUSE TestAccContainerCluster_basic
=== RUN TestAccContainerNodePool_basic
=== PAUSE TestAccContainerNodePool_basic
=== RUN TestAccDataprocCluster_basic
=== PAUSE TestAccDataprocCluster_basic
=== RUN TestAccDataprocCluster_basicWithInternalIpOnlyTrue
=== PAUSE TestAccDataprocCluster_basicWithInternalIpOnlyTrue
=== RUN TestAccDataprocCluster_basicWithMetadata
=== PAUSE TestAccDataprocCluster_basicWithMetadata
=== RUN TestAccPubsubSubscription_basic
=== PAUSE TestAccPubsubSubscription_basic
=== CONT  TestAccContainerClusterDatasource_zonal
=== CONT  TestAccDataprocCluster_basic
=== CONT  TestAccBigQueryDataset_basic
=== CONT  TestAccComputeInstance_basic1
=== CONT  TestAccContainerCluster_basic
=== CONT  TestAccContainerNodePool_basic
=== CONT  TestAccDataprocCluster_basicWithMetadata
=== CONT  TestAccPubsubSubscription_basic
=== CONT  TestAccStorageSignedUrl_basic
--- PASS: TestAccBigQueryDataset_basic (3.88s)
--- PASS: TestAccStorageSignedUrl_basic (0.06s)
=== CONT  TestAccDataprocCluster_basicWithInternalIpOnlyTrue
--- PASS: TestAccPubsubSubscription_basic (5.54s)
--- PASS: TestAccComputeInstance_basic1 (122.09s)
--- PASS: TestAccDataprocCluster_basicWithMetadata (181.84s)
--- PASS: TestAccDataprocCluster_basic (232.14s)
--- PASS: TestAccDataprocCluster_basicWithInternalIpOnlyTrue (278.19s)
--- PASS: TestAccContainerCluster_basic (296.84s)
--- PASS: TestAccContainerClusterDatasource_zonal (297.34s)
--- PASS: TestAccContainerNodePool_basic (614.45s)
PASS
ok  github.com/terraform-providers/terraform-provider-google/google  614.548s
testing: warning: no tests to run
PASS
ok  github.com/terraform-providers/terraform-provider-google/scripts  (cached) [no tests to run]