### PR TITLE
add hash function for self link name

### DIFF
--- a/google/self_link_helpers.go
+++ b/google/self_link_helpers.go
@@ -60,6 +60,12 @@ func getRelativePath(selfLink string) (string, error) {
 	return "projects/" + stringParts[1], nil
 }
 
+// Hash the name path of a self link.
+func selfLinkNameHash(selfLink interface{}) int {
+	name := GetResourceNameFromSelfLink(selfLink.(string))
+	return hashcode.String(name)
+}
+
 func ConvertSelfLinkToV1(link string) string {
 	reg := regexp.MustCompile("/compute/[a-zA-Z0-9]*/projects/")
 	return reg.ReplaceAllString(link, "/compute/v1/projects/")

--- a/google/self_link_helpers_test.go
+++ b/google/self_link_helpers_test.go
@@ -86,3 +86,27 @@ func TestGetResourceNameFromSelfLink(t *testing.T) {
 		}
 	}
 }
+
+func TestSelfLinkNameHash(t *testing.T) {
+	cases := map[string]struct {
+		SelfLink, Name string
+		Expect         bool
+	}{
+		"same": {
+			SelfLink: "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			Name:     "a-network",
+			Expect:   true,
+		},
+		"different": {
+			SelfLink: "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			Name:     "another-network",
+			Expect:   false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if (selfLinkNameHash(tc.SelfLink) == selfLinkNameHash(tc.Name)) != tc.Expect {
+			t.Errorf("%s: expected %t for whether hashes matched for self link = %q, name = %q", tn, tc.Expect, tc.SelfLink, tc.Name)
+		}
+	}
+}


### PR DESCRIPTION
To be used in an upcoming generated resource, which will have sets of potentially link-shaped values (projects/{project}/thing/{name} or {name})