### PR TITLE
Link to the detailed test guide in project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,4 @@ $ $GOPATH/bin/terraform-provider-google
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
-
-```sh
-$ make test
-```
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```sh
-$ make testacc
-```
+In order to test the Google provider, see the [Tests section of the contribution guidelines](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests).


### PR DESCRIPTION
Right now, we have a detailed guide to running acceptance tests in [CONTRIBUTING.MD](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) while this file has the one-size-fits-all guideline of running `make test` and `make testacc` with no arguments. 

Instead, we can link to the detailed, provider specific guide so that we properly surface the required arguments/environment variables for `make testacc`, and don't incorrectly introduce `make test` as the primary means of testing the Google provider.