### PR TITLE
Add support for boot_disk_type to google_dataproc_cluster

### DIFF
--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -356,6 +356,14 @@ func instanceConfigSchema() *schema.Schema {
 								ForceNew:     true,
 								ValidateFunc: validation.IntAtLeast(10),
 							},
+
+							"boot_disk_type": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice([]string{"pd-standard", "pd-ssd", ""}, false),
+								Default:      "pd-standard",
+							},
 						},
 					},
 				},
@@ -600,6 +608,9 @@ func expandInstanceGroupConfig(cfg map[string]interface{}) *dataproc.InstanceGro
 			if v, ok := dcfg["num_local_ssds"]; ok {
 				icg.DiskConfig.NumLocalSsds = int64(v.(int))
 			}
+			if v, ok := dcfg["boot_disk_type"]; ok {
+				icg.DiskConfig.BootDiskType = v.(string)
+			}
 		}
 	}
 	return icg
@@ -813,6 +824,7 @@ func flattenInstanceGroupConfig(d *schema.ResourceData, icg *dataproc.InstanceGr
 		if icg.DiskConfig != nil {
 			disk["boot_disk_size_gb"] = icg.DiskConfig.BootDiskSizeGb
 			disk["num_local_ssds"] = icg.DiskConfig.NumLocalSsds
+			disk["boot_disk_type"] = icg.DiskConfig.BootDiskType
 		}
 	}
 

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -111,6 +111,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.num_instances", "1"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.disk_config.0.boot_disk_size_gb"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.disk_config.0.num_local_ssds"),
+					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.disk_config.0.boot_disk_type"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.machine_type"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.0.instance_names.#", "1"),
 
@@ -119,6 +120,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.num_instances", "2"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.disk_config.0.boot_disk_size_gb"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.disk_config.0.num_local_ssds"),
+					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.disk_config.0.boot_disk_type"),
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.machine_type"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.worker_config.0.instance_names.#", "2"),
 
@@ -132,7 +134,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataprocCluster_basicWithInternalIpOnlyTrue(t *testing.T) {
+func TestAccDataprocCluster_withInternalIpOnlyTrue(t *testing.T) {
 	t.Parallel()
 
 	var cluster dataproc.Cluster
@@ -143,7 +145,7 @@ func TestAccDataprocCluster_basicWithInternalIpOnlyTrue(t *testing.T) {
 		CheckDestroy: testAccCheckDataprocClusterDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basicWithInternalIpOnlyTrue(rnd),
+				Config: testAccDataprocCluster_withInternalIpOnlyTrue(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.basic", &cluster),
 
@@ -155,7 +157,7 @@ func TestAccDataprocCluster_basicWithInternalIpOnlyTrue(t *testing.T) {
 	})
 }
 
-func TestAccDataprocCluster_basicWithMetadata(t *testing.T) {
+func TestAccDataprocCluster_withMetadata(t *testing.T) {
 	t.Parallel()
 
 	var cluster dataproc.Cluster
@@ -166,7 +168,7 @@ func TestAccDataprocCluster_basicWithMetadata(t *testing.T) {
 		CheckDestroy: testAccCheckDataprocClusterDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basicWithMetadata(rnd),
+				Config: testAccDataprocCluster_withMetadata(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.basic", &cluster),
 
@@ -534,12 +536,14 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.master_config.0.num_instances", "3", strconv.Itoa(int(cluster.Config.MasterConfig.NumInstances))},
 			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_size_gb", "10", strconv.Itoa(int(cluster.Config.MasterConfig.DiskConfig.BootDiskSizeGb))},
 			{"cluster_config.0.master_config.0.disk_config.0.num_local_ssds", "0", strconv.Itoa(int(cluster.Config.MasterConfig.DiskConfig.NumLocalSsds))},
+			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_type", "pd-ssd", cluster.Config.MasterConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.master_config.0.machine_type", "n1-standard-1", GetResourceNameFromSelfLink(cluster.Config.MasterConfig.MachineTypeUri)},
 			{"cluster_config.0.master_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.MasterConfig.InstanceNames))},
 
 			{"cluster_config.0.worker_config.0.num_instances", "3", strconv.Itoa(int(cluster.Config.WorkerConfig.NumInstances))},
 			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_size_gb", "11", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.BootDiskSizeGb))},
 			{"cluster_config.0.worker_config.0.disk_config.0.num_local_ssds", "1", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.NumLocalSsds))},
+			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_type", "pd-standard", cluster.Config.WorkerConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.worker_config.0.machine_type", "n1-standard-1", GetResourceNameFromSelfLink(cluster.Config.WorkerConfig.MachineTypeUri)},
 			{"cluster_config.0.worker_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.WorkerConfig.InstanceNames))},
 
@@ -626,7 +630,7 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_basicWithInternalIpOnlyTrue(rnd string) string {
+func testAccDataprocCluster_withInternalIpOnlyTrue(rnd string) string {
 	return fmt.Sprintf(`
 variable subnetwork_cidr {
 	default = "10.0.0.0/16"
@@ -692,7 +696,7 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd, rnd, rnd)
 }
 
-func testAccDataprocCluster_basicWithMetadata(rnd string) string {
+func testAccDataprocCluster_withMetadata(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
 	name   = "dproc-cluster-test-%s"
@@ -740,6 +744,7 @@ resource "google_dataproc_cluster" "with_config_overrides" {
 			num_instances     = 3
 			machine_type      = "n1-standard-1"
 			disk_config {
+				boot_disk_type    = "pd-ssd"
 				boot_disk_size_gb = 10
 			}
 		}
@@ -748,6 +753,7 @@ resource "google_dataproc_cluster" "with_config_overrides" {
 			num_instances     = 3
 			machine_type      = "n1-standard-1"
 			disk_config {
+				boot_disk_type    = "pd-standard"
 				boot_disk_size_gb = 11
 				num_local_ssds    = 1
 			}

--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -543,7 +543,7 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.worker_config.0.num_instances", "3", strconv.Itoa(int(cluster.Config.WorkerConfig.NumInstances))},
 			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_size_gb", "11", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.BootDiskSizeGb))},
 			{"cluster_config.0.worker_config.0.disk_config.0.num_local_ssds", "1", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.NumLocalSsds))},
-			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_type", "pd-standard", cluster.Config.WorkerConfig.DiskConfig.BootDiskType},
+			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_type", "pd-standard", cluster.Config.WorkerConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.worker_config.0.machine_type", "n1-standard-1", GetResourceNameFromSelfLink(cluster.Config.WorkerConfig.MachineTypeUri)},
 			{"cluster_config.0.worker_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.WorkerConfig.InstanceNames))},
 

--- a/vendor/google.golang.org/api/dataproc/v1/dataproc-api.json
+++ b/vendor/google.golang.org/api/dataproc/v1/dataproc-api.json
@@ -1,639 +1,769 @@
 {
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        }
+      }
+    }
+  },
+  "basePath": "",
+  "baseUrl": "https://dataproc.googleapis.com/",
+  "batchPath": "batch",
+  "canonicalName": "Dataproc",
+  "description": "Manages Hadoop-based clusters and jobs on Google Cloud Platform.",
+  "discoveryVersion": "v1",
+  "documentationLink": "https://cloud.google.com/dataproc/",
+  "fullyEncodeReservedExpansion": true,
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "id": "dataproc:v1",
+  "kind": "discovery#restDescription",
+  "name": "dataproc",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "parameters": {
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "access_token": {
+      "description": "OAuth access token.",
+      "location": "query",
+      "type": "string"
+    },
+    "alt": {
+      "default": "json",
+      "description": "Data format for response.",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "callback": {
+      "description": "JSONP",
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "location": "query",
+      "type": "string"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
   "resources": {
     "projects": {
       "resources": {
         "regions": {
           "resources": {
-            "operations": {
+            "clusters": {
               "methods": {
-                "cancel": {
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "parameterOrder": [
-                    "name"
-                  ],
+                "create": {
+                  "description": "Creates a cluster in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters",
                   "httpMethod": "POST",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "name": {
-                      "description": "The name of the operation resource to be cancelled.",
-                      "type": "string",
-                      "required": true,
-                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$",
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}:cancel",
-                  "id": "dataproc.projects.regions.operations.cancel",
-                  "path": "v1/{+name}:cancel",
-                  "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns google.rpc.Code.UNIMPLEMENTED. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to Code.CANCELLED."
-                },
-                "delete": {
-                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}",
-                  "id": "dataproc.projects.regions.operations.delete",
-                  "path": "v1/{+name}",
-                  "description": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns google.rpc.Code.UNIMPLEMENTED.",
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "httpMethod": "DELETE",
+                  "id": "dataproc.projects.regions.clusters.create",
                   "parameterOrder": [
-                    "name"
-                  ],
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
+                    "projectId",
+                    "region"
                   ],
                   "parameters": {
-                    "name": {
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
                       "location": "path",
-                      "description": "The name of the operation resource to be deleted.",
-                      "type": "string",
                       "required": true,
-                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$"
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "description": "Optional. A unique id used to identify the request. If the server receives two CreateClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+                      "location": "query",
+                      "type": "string"
                     }
-                  }
-                },
-                "get": {
-                  "description": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
-                  "httpMethod": "GET",
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters",
+                  "request": {
+                    "$ref": "Cluster"
+                  },
                   "response": {
                     "$ref": "Operation"
                   },
-                  "parameterOrder": [
-                    "name"
-                  ],
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "name": {
-                      "description": "The name of the operation resource.",
-                      "type": "string",
-                      "required": true,
-                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$",
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}",
-                  "path": "v1/{+name}",
-                  "id": "dataproc.projects.regions.operations.get"
+                  ]
                 },
-                "list": {
-                  "response": {
-                    "$ref": "ListOperationsResponse"
-                  },
+                "delete": {
+                  "description": "Deletes a cluster in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "httpMethod": "DELETE",
+                  "id": "dataproc.projects.regions.clusters.delete",
                   "parameterOrder": [
-                    "name"
+                    "projectId",
+                    "region",
+                    "clusterName"
                   ],
-                  "httpMethod": "GET",
                   "parameters": {
-                    "pageToken": {
-                      "location": "query",
-                      "description": "The standard list page token.",
+                    "clusterName": {
+                      "description": "Required. The cluster name.",
+                      "location": "path",
+                      "required": true,
                       "type": "string"
                     },
-                    "name": {
-                      "pattern": "^projects/[^/]+/regions/[^/]+/operations$",
+                    "clusterUuid": {
+                      "description": "Optional. Specifying the cluster_uuid means the RPC should fail (with error NOT_FOUND) if cluster with specified UUID does not exist.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
                       "location": "path",
-                      "description": "The name of the operation's parent resource.",
-                      "type": "string",
-                      "required": true
+                      "required": true,
+                      "type": "string"
                     },
-                    "pageSize": {
-                      "format": "int32",
-                      "description": "The standard list page size.",
-                      "type": "integer",
-                      "location": "query"
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
                     },
-                    "filter": {
-                      "description": "The standard list filter.",
-                      "type": "string",
-                      "location": "query"
+                    "requestId": {
+                      "description": "Optional. A unique id used to identify the request. If the server receives two DeleteClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+                      "location": "query",
+                      "type": "string"
                     }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "response": {
+                    "$ref": "Operation"
                   },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "diagnose": {
+                  "description": "Gets cluster diagnostic information. After the operation completes, the Operation.response field contains DiagnoseClusterOutputLocation.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}:diagnose",
+                  "httpMethod": "POST",
+                  "id": "dataproc.projects.regions.clusters.diagnose",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "clusterName"
                   ],
-                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations",
-                  "id": "dataproc.projects.regions.operations.list",
-                  "path": "v1/{+name}",
-                  "description": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns UNIMPLEMENTED.NOTE: the name binding allows API services to override the binding to use different resource name schemes, such as users/*/operations. To override the binding, API services can add a binding such as \"/v1/{name=users/*}/operations\" to their service configuration. For backwards compatibility, the default name includes the operations collection id, however overriding users must ensure the name binding is the parent resource, without the operations collection id."
+                  "parameters": {
+                    "clusterName": {
+                      "description": "Required. The cluster name.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}:diagnose",
+                  "request": {
+                    "$ref": "DiagnoseClusterRequest"
+                  },
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "get": {
+                  "description": "Gets the resource representation for a cluster in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.clusters.get",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "clusterName"
+                  ],
+                  "parameters": {
+                    "clusterName": {
+                      "description": "Required. The cluster name.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "response": {
+                    "$ref": "Cluster"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "list": {
+                  "description": "Lists all regions/{region}/clusters in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters",
+                  "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.clusters.list",
+                  "parameterOrder": [
+                    "projectId",
+                    "region"
+                  ],
+                  "parameters": {
+                    "filter": {
+                      "description": "Optional. A filter constraining the clusters to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is one of status.state, clusterName, or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be one of the following: ACTIVE, INACTIVE, CREATING, RUNNING, ERROR, DELETING, or UPDATING. ACTIVE contains the CREATING, UPDATING, and RUNNING states. INACTIVE contains the DELETING and ERROR states. clusterName is the name of the cluster provided at creation time. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND clusterName = mycluster AND labels.env = staging AND labels.starred = *",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "description": "Optional. The standard List page size.",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    },
+                    "pageToken": {
+                      "description": "Optional. The standard List page token.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters",
+                  "response": {
+                    "$ref": "ListClustersResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "patch": {
+                  "description": "Updates a cluster in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "httpMethod": "PATCH",
+                  "id": "dataproc.projects.regions.clusters.patch",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "clusterName"
+                  ],
+                  "parameters": {
+                    "clusterName": {
+                      "description": "Required. The cluster name.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "gracefulDecommissionTimeout": {
+                      "description": "Optional. Timeout for graceful YARN decomissioning. Graceful decommissioning allows removing nodes from the cluster without interrupting jobs in progress. Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs). Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day.Only supported on Dataproc image versions 1.2 and higher.",
+                      "format": "google-duration",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project the cluster belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "description": "Optional. A unique id used to identify the request. If the server receives two UpdateClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "updateMask": {
+                      "description": "Required. Specifies the path, relative to Cluster, of the field to update. For example, to change the number of workers in a cluster to 5, the update_mask parameter would be specified as config.worker_config.num_instances, and the PATCH request body would specify the new value, as follows:\n{\n  \"config\":{\n    \"workerConfig\":{\n      \"numInstances\":\"5\"\n    }\n  }\n}\nSimilarly, to change the number of preemptible workers in a cluster to 5, the update_mask parameter would be config.secondary_worker_config.num_instances, and the PATCH request body would be set as follows:\n{\n  \"config\":{\n    \"secondaryWorkerConfig\":{\n      \"numInstances\":\"5\"\n    }\n  }\n}\n\u003cstrong\u003eNote:\u003c/strong\u003e Currently, only the following fields can be updated:\u003ctable\u003e  \u003ctbody\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003eMask\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003e\u003cstrong\u003ePurpose\u003c/strong\u003e\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003elabels\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eUpdate labels\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003econfig.worker_config.num_instances\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eResize primary worker group\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003econfig.secondary_worker_config.num_instances\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eResize secondary worker group\u003c/td\u003e  \u003c/tr\u003e  \u003c/tbody\u003e  \u003c/table\u003e",
+                      "format": "google-fieldmask",
+                      "location": "query",
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
+                  "request": {
+                    "$ref": "Cluster"
+                  },
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
                 }
               }
             },
             "jobs": {
               "methods": {
-                "patch": {
-                  "response": {
-                    "$ref": "Job"
-                  },
+                "cancel": {
+                  "description": "Starts a job cancellation request. To access the job resource after cancellation, call regions/{region}/jobs.list or regions/{region}/jobs.get.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}:cancel",
+                  "httpMethod": "POST",
+                  "id": "dataproc.projects.regions.jobs.cancel",
                   "parameterOrder": [
                     "projectId",
                     "region",
                     "jobId"
                   ],
-                  "httpMethod": "PATCH",
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
                   "parameters": {
                     "jobId": {
-                      "location": "path",
                       "description": "Required. The job ID.",
-                      "type": "string",
-                      "required": true
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
                     },
                     "projectId": {
-                      "location": "path",
                       "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "updateMask": {
-                      "format": "google-fieldmask",
-                      "description": "Required. Specifies the path, relative to \u003ccode\u003eJob\u003c/code\u003e, of the field to update. For example, to update the labels of a Job the \u003ccode\u003eupdate_mask\u003c/code\u003e parameter would be specified as \u003ccode\u003elabels\u003c/code\u003e, and the PATCH request body would specify the new value. \u003cstrong\u003eNote:\u003c/strong\u003e Currently, \u003ccode\u003elabels\u003c/code\u003e is the only field that can be updated.",
-                      "type": "string",
-                      "location": "query"
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
                     },
                     "region": {
                       "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
+                      "location": "path",
                       "required": true,
-                      "location": "path"
+                      "type": "string"
                     }
                   },
+                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}:cancel",
+                  "request": {
+                    "$ref": "CancelJobRequest"
+                  },
+                  "response": {
+                    "$ref": "Job"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "delete": {
+                  "description": "Deletes the job from the project. If the job is active, the delete fails, and the response returns FAILED_PRECONDITION.",
                   "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
+                  "httpMethod": "DELETE",
+                  "id": "dataproc.projects.regions.jobs.delete",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "jobId"
+                  ],
+                  "parameters": {
+                    "jobId": {
+                      "description": "Required. The job ID.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "get": {
+                  "description": "Gets the resource representation for a job in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
+                  "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.jobs.get",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "jobId"
+                  ],
+                  "parameters": {
+                    "jobId": {
+                      "description": "Required. The job ID.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
+                  "response": {
+                    "$ref": "Job"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "list": {
+                  "description": "Lists regions/{region}/jobs in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs",
+                  "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.jobs.list",
+                  "parameterOrder": [
+                    "projectId",
+                    "region"
+                  ],
+                  "parameters": {
+                    "clusterName": {
+                      "description": "Optional. If set, the returned jobs list includes only jobs that were submitted to the named cluster.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "filter": {
+                      "description": "Optional. A filter constraining the jobs to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is status.state or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be either ACTIVE or NON_ACTIVE. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND labels.env = staging AND labels.starred = *",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "jobStateMatcher": {
+                      "description": "Optional. Specifies enumerated categories of jobs to list. (default = match ALL jobs).If filter is provided, jobStateMatcher will be ignored.",
+                      "enum": [
+                        "ALL",
+                        "ACTIVE",
+                        "NON_ACTIVE"
+                      ],
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "description": "Optional. The number of results to return in each response.",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    },
+                    "pageToken": {
+                      "description": "Optional. The page token, returned by a previous call, to request the next page of results.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/jobs",
+                  "response": {
+                    "$ref": "ListJobsResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "patch": {
+                  "description": "Updates a job in a project.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
+                  "httpMethod": "PATCH",
                   "id": "dataproc.projects.regions.jobs.patch",
+                  "parameterOrder": [
+                    "projectId",
+                    "region",
+                    "jobId"
+                  ],
+                  "parameters": {
+                    "jobId": {
+                      "description": "Required. The job ID.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "updateMask": {
+                      "description": "Required. Specifies the path, relative to \u003ccode\u003eJob\u003c/code\u003e, of the field to update. For example, to update the labels of a Job the \u003ccode\u003eupdate_mask\u003c/code\u003e parameter would be specified as \u003ccode\u003elabels\u003c/code\u003e, and the PATCH request body would specify the new value. \u003cstrong\u003eNote:\u003c/strong\u003e Currently, \u003ccode\u003elabels\u003c/code\u003e is the only field that can be updated.",
+                      "format": "google-fieldmask",
+                      "location": "query",
+                      "type": "string"
+                    }
+                  },
                   "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
                   "request": {
                     "$ref": "Job"
                   },
-                  "description": "Updates a job in a project."
-                },
-                "get": {
-                  "httpMethod": "GET",
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "jobId"
-                  ],
                   "response": {
                     "$ref": "Job"
                   },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "region": {
-                      "type": "string",
-                      "required": true,
-                      "location": "path",
-                      "description": "Required. The Cloud Dataproc region in which to handle the request."
-                    },
-                    "jobId": {
-                      "description": "Required. The job ID.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "projectId": {
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
-                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
-                  "id": "dataproc.projects.regions.jobs.get",
-                  "description": "Gets the resource representation for a job in a project."
+                  ]
                 },
                 "submit": {
                   "description": "Submits a job to a cluster.",
+                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs:submit",
+                  "httpMethod": "POST",
+                  "id": "dataproc.projects.regions.jobs.submit",
+                  "parameterOrder": [
+                    "projectId",
+                    "region"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/projects/{projectId}/regions/{region}/jobs:submit",
                   "request": {
                     "$ref": "SubmitJobRequest"
                   },
                   "response": {
                     "$ref": "Job"
                   },
-                  "parameterOrder": [
-                    "projectId",
-                    "region"
-                  ],
-                  "httpMethod": "POST",
-                  "parameters": {
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "projectId": {
-                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs:submit",
-                  "id": "dataproc.projects.regions.jobs.submit",
-                  "path": "v1/projects/{projectId}/regions/{region}/jobs:submit"
-                },
-                "delete": {
-                  "description": "Deletes the job from the project. If the job is active, the delete fails, and the response returns FAILED_PRECONDITION.",
-                  "httpMethod": "DELETE",
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "jobId"
-                  ],
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "jobId": {
-                      "description": "Required. The job ID.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "projectId": {
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
-                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}",
-                  "id": "dataproc.projects.regions.jobs.delete"
-                },
-                "list": {
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterName": {
-                      "location": "query",
-                      "description": "Optional. If set, the returned jobs list includes only jobs that were submitted to the named cluster.",
-                      "type": "string"
-                    },
-                    "projectId": {
-                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "filter": {
-                      "description": "Optional. A filter constraining the jobs to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is status.state or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be either ACTIVE or INACTIVE. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND labels.env = staging AND labels.starred = *",
-                      "type": "string",
-                      "location": "query"
-                    },
-                    "jobStateMatcher": {
-                      "type": "string",
-                      "location": "query",
-                      "enum": [
-                        "ALL",
-                        "ACTIVE",
-                        "NON_ACTIVE"
-                      ],
-                      "description": "Optional. Specifies enumerated categories of jobs to list (default = match ALL jobs)."
-                    },
-                    "pageToken": {
-                      "description": "Optional. The page token, returned by a previous call, to request the next page of results.",
-                      "type": "string",
-                      "location": "query"
-                    },
-                    "pageSize": {
-                      "format": "int32",
-                      "description": "Optional. The number of results to return in each response.",
-                      "type": "integer",
-                      "location": "query"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs",
-                  "path": "v1/projects/{projectId}/regions/{region}/jobs",
-                  "id": "dataproc.projects.regions.jobs.list",
-                  "description": "Lists regions/{region}/jobs in a project.",
-                  "httpMethod": "GET",
-                  "response": {
-                    "$ref": "ListJobsResponse"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "region"
-                  ]
-                },
-                "cancel": {
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}:cancel",
-                  "path": "v1/projects/{projectId}/regions/{region}/jobs/{jobId}:cancel",
-                  "id": "dataproc.projects.regions.jobs.cancel",
-                  "description": "Starts a job cancellation request. To access the job resource after cancellation, call regions/{region}/jobs.list or regions/{region}/jobs.get.",
-                  "request": {
-                    "$ref": "CancelJobRequest"
-                  },
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "jobId"
-                  ],
-                  "response": {
-                    "$ref": "Job"
-                  },
-                  "parameters": {
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "jobId": {
-                      "location": "path",
-                      "description": "Required. The job ID.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "projectId": {
-                      "type": "string",
-                      "required": true,
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the job belongs to."
-                    }
-                  },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
                   ]
                 }
               }
             },
-            "clusters": {
+            "operations": {
               "methods": {
-                "create": {
-                  "response": {
-                    "$ref": "Operation"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "region"
-                  ],
+                "cancel": {
+                  "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns google.rpc.Code.UNIMPLEMENTED. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to Code.CANCELLED.",
+                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}:cancel",
                   "httpMethod": "POST",
-                  "parameters": {
-                    "projectId": {
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "region": {
-                      "location": "path",
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters",
-                  "id": "dataproc.projects.regions.clusters.create",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters",
-                  "description": "Creates a cluster in a project.",
-                  "request": {
-                    "$ref": "Cluster"
-                  }
-                },
-                "patch": {
-                  "httpMethod": "PATCH",
+                  "id": "dataproc.projects.regions.operations.cancel",
                   "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "clusterName"
+                    "name"
                   ],
-                  "response": {
-                    "$ref": "Operation"
-                  },
                   "parameters": {
-                    "projectId": {
-                      "description": "Required. The ID of the Google Cloud Platform project the cluster belongs to.",
-                      "type": "string",
+                    "name": {
+                      "description": "The name of the operation resource to be cancelled.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$",
                       "required": true,
-                      "location": "path"
-                    },
-                    "updateMask": {
-                      "location": "query",
-                      "format": "google-fieldmask",
-                      "description": "Required. Specifies the path, relative to Cluster, of the field to update. For example, to change the number of workers in a cluster to 5, the update_mask parameter would be specified as config.worker_config.num_instances, and the PATCH request body would specify the new value, as follows:\n{\n  \"config\":{\n    \"workerConfig\":{\n      \"numInstances\":\"5\"\n    }\n  }\n}\nSimilarly, to change the number of preemptible workers in a cluster to 5, the update_mask parameter would be config.secondary_worker_config.num_instances, and the PATCH request body would be set as follows:\n{\n  \"config\":{\n    \"secondaryWorkerConfig\":{\n      \"numInstances\":\"5\"\n    }\n  }\n}\n\u003cstrong\u003eNote:\u003c/strong\u003e Currently, only the following fields can be updated:\u003ctable\u003e  \u003ctbody\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003eMask\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003e\u003cstrong\u003ePurpose\u003c/strong\u003e\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003elabels\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eUpdate labels\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003econfig.worker_config.num_instances\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eResize primary worker group\u003c/td\u003e  \u003c/tr\u003e  \u003ctr\u003e  \u003ctd\u003e\u003cstrong\u003e\u003cem\u003econfig.secondary_worker_config.num_instances\u003c/em\u003e\u003c/strong\u003e\u003c/td\u003e  \u003ctd\u003eResize secondary worker group\u003c/td\u003e  \u003c/tr\u003e  \u003c/tbody\u003e  \u003c/table\u003e",
                       "type": "string"
-                    },
-                    "region": {
-                      "location": "path",
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "clusterName": {
-                      "location": "path",
-                      "description": "Required. The cluster name.",
-                      "type": "string",
-                      "required": true
                     }
                   },
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
-                  "id": "dataproc.projects.regions.clusters.patch",
-                  "description": "Updates a cluster in a project.",
-                  "request": {
-                    "$ref": "Cluster"
-                  }
-                },
-                "get": {
-                  "httpMethod": "GET",
+                  "path": "v1/{+name}:cancel",
                   "response": {
-                    "$ref": "Cluster"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "clusterName"
-                  ],
-                  "scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "clusterName": {
-                      "description": "Required. The cluster name.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "projectId": {
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
-                  "id": "dataproc.projects.regions.clusters.get",
-                  "description": "Gets the resource representation for a cluster in a project."
-                },
-                "diagnose": {
-                  "request": {
-                    "$ref": "DiagnoseClusterRequest"
-                  },
-                  "description": "Gets cluster diagnostic information. After the operation completes, the Operation.response field contains DiagnoseClusterOutputLocation.",
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "clusterName"
-                  ],
-                  "response": {
-                    "$ref": "Operation"
+                    "$ref": "Empty"
                   },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "clusterName": {
-                      "type": "string",
-                      "required": true,
-                      "location": "path",
-                      "description": "Required. The cluster name."
-                    },
-                    "projectId": {
-                      "location": "path",
-                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "region": {
-                      "type": "string",
-                      "required": true,
-                      "location": "path",
-                      "description": "Required. The Cloud Dataproc region in which to handle the request."
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}:diagnose",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}:diagnose",
-                  "id": "dataproc.projects.regions.clusters.diagnose"
+                  ]
                 },
                 "delete": {
-                  "id": "dataproc.projects.regions.clusters.delete",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}",
-                  "description": "Deletes a cluster in a project.",
+                  "description": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns google.rpc.Code.UNIMPLEMENTED.",
+                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}",
+                  "httpMethod": "DELETE",
+                  "id": "dataproc.projects.regions.operations.delete",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "The name of the operation resource to be deleted.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "get": {
+                  "description": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
+                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations/{operationsId}",
+                  "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.operations.get",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "The name of the operation resource.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/regions/[^/]+/operations/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}",
                   "response": {
                     "$ref": "Operation"
                   },
-                  "parameterOrder": [
-                    "projectId",
-                    "region",
-                    "clusterName"
-                  ],
-                  "httpMethod": "DELETE",
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "parameters": {
-                    "region": {
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    },
-                    "clusterName": {
-                      "location": "path",
-                      "description": "Required. The cluster name.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "projectId": {
-                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters/{clusterName}"
+                  ]
                 },
                 "list": {
-                  "response": {
-                    "$ref": "ListClustersResponse"
-                  },
-                  "parameterOrder": [
-                    "projectId",
-                    "region"
-                  ],
+                  "description": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns UNIMPLEMENTED.NOTE: the name binding allows API services to override the binding to use different resource name schemes, such as users/*/operations. To override the binding, API services can add a binding such as \"/v1/{name=users/*}/operations\" to their service configuration. For backwards compatibility, the default name includes the operations collection id, however overriding users must ensure the name binding is the parent resource, without the operations collection id.",
+                  "flatPath": "v1/projects/{projectsId}/regions/{regionsId}/operations",
                   "httpMethod": "GET",
+                  "id": "dataproc.projects.regions.operations.list",
+                  "parameterOrder": [
+                    "name"
+                  ],
                   "parameters": {
                     "filter": {
+                      "description": "The standard list filter.",
                       "location": "query",
-                      "description": "Optional. A filter constraining the clusters to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is one of status.state, clusterName, or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be one of the following: ACTIVE, INACTIVE, CREATING, RUNNING, ERROR, DELETING, or UPDATING. ACTIVE contains the CREATING, UPDATING, and RUNNING states. INACTIVE contains the DELETING and ERROR states. clusterName is the name of the cluster provided at creation time. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND clusterName = mycluster AND labels.env = staging AND labels.starred = *",
                       "type": "string"
                     },
-                    "region": {
+                    "name": {
+                      "description": "The name of the operation's parent resource.",
                       "location": "path",
-                      "description": "Required. The Cloud Dataproc region in which to handle the request.",
-                      "type": "string",
-                      "required": true
-                    },
-                    "pageToken": {
-                      "location": "query",
-                      "description": "Optional. The standard List page token.",
+                      "pattern": "^projects/[^/]+/regions/[^/]+/operations$",
+                      "required": true,
                       "type": "string"
                     },
                     "pageSize": {
-                      "location": "query",
+                      "description": "The standard list page size.",
                       "format": "int32",
-                      "description": "Optional. The standard List page size.",
+                      "location": "query",
                       "type": "integer"
                     },
-                    "projectId": {
-                      "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
+                    "pageToken": {
+                      "description": "The standard list page token.",
+                      "location": "query",
+                      "type": "string"
                     }
+                  },
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "ListOperationsResponse"
                   },
                   "scopes": [
                     "https://www.googleapis.com/auth/cloud-platform"
-                  ],
-                  "flatPath": "v1/projects/{projectId}/regions/{region}/clusters",
-                  "id": "dataproc.projects.regions.clusters.list",
-                  "path": "v1/projects/{projectId}/regions/{region}/clusters",
-                  "description": "Lists all regions/{region}/clusters in a project."
+                  ]
                 }
               }
             }
@@ -642,236 +772,87 @@
       }
     }
   },
-  "parameters": {
-    "oauth_token": {
-      "description": "OAuth 2.0 token for the current user.",
-      "type": "string",
-      "location": "query"
-    },
-    "bearer_token": {
-      "type": "string",
-      "location": "query",
-      "description": "OAuth bearer token."
-    },
-    "upload_protocol": {
-      "location": "query",
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "type": "string"
-    },
-    "prettyPrint": {
-      "location": "query",
-      "description": "Returns response with indentations and line breaks.",
-      "default": "true",
-      "type": "boolean"
-    },
-    "uploadType": {
-      "location": "query",
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "type": "string"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "type": "string",
-      "location": "query"
-    },
-    "callback": {
-      "description": "JSONP",
-      "type": "string",
-      "location": "query"
-    },
-    "$.xgafv": {
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "description": "V1 error format.",
-      "type": "string"
-    },
-    "alt": {
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "type": "string",
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "description": "Data format for response.",
-      "default": "json"
-    },
-    "access_token": {
-      "location": "query",
-      "description": "OAuth access token.",
-      "type": "string"
-    },
-    "key": {
-      "location": "query",
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "type": "string"
-    },
-    "quotaUser": {
-      "location": "query",
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "type": "string"
-    },
-    "pp": {
-      "location": "query",
-      "description": "Pretty-print response.",
-      "default": "true",
-      "type": "boolean"
-    }
-  },
+  "revision": "20180702",
+  "rootUrl": "https://dataproc.googleapis.com/",
   "schemas": {
-    "DiskConfig": {
+    "AcceleratorConfig": {
+      "description": "Specifies the type and number of accelerator cards attached to the instances of an instance. See GPUs on Compute Engine.",
+      "id": "AcceleratorConfig",
       "properties": {
-        "numLocalSsds": {
+        "acceleratorCount": {
+          "description": "The number of the accelerator cards of this type exposed to this instance.",
           "format": "int32",
-          "description": "Optional. Number of attached SSDs, from 0 to 4 (default is 0). If SSDs are not attached, the boot disk is used to store runtime logs and HDFS (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html) data. If one or more SSDs are attached, this runtime bulk data is spread across them, and the boot disk contains only basic config and installed binaries.",
           "type": "integer"
         },
-        "bootDiskSizeGb": {
-          "format": "int32",
-          "description": "Optional. Size in GB of the boot disk (default is 500GB).",
-          "type": "integer"
+        "acceleratorTypeUri": {
+          "description": "Full URL, partial URI, or short name of the accelerator type resource to expose to this instance. See Compute Engine AcceleratorTypes.Examples:\nhttps://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80\nprojects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80\nnvidia-tesla-k80Auto Zone Exception: If you are using the Cloud Dataproc Auto Zone Placement feature, you must use the short name of the accelerator type resource, for example, nvidia-tesla-k80.",
+          "type": "string"
         }
       },
-      "id": "DiskConfig",
-      "description": "Specifies the config of disk options for a group of VM instances.",
       "type": "object"
     },
-    "ClusterOperationMetadata": {
-      "type": "object",
+    "CancelJobRequest": {
+      "description": "A request to cancel a job.",
+      "id": "CancelJobRequest",
+      "properties": {},
+      "type": "object"
+    },
+    "Cluster": {
+      "description": "Describes the identifying information, config, and status of a cluster of Compute Engine instances.",
+      "id": "Cluster",
       "properties": {
-        "operationType": {
-          "type": "string",
-          "description": "Output-only. The operation type."
-        },
-        "description": {
-          "description": "Output-only. Short description of operation.",
+        "clusterName": {
+          "description": "Required. The cluster name. Cluster names within a project must be unique. Names of deleted clusters can be reused.",
           "type": "string"
         },
-        "warnings": {
-          "description": "Output-only. Errors encountered during operation execution.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "clusterUuid": {
+          "description": "Output only. A cluster UUID (Unique Universal Identifier). Cloud Dataproc generates this value when it creates the cluster.",
+          "type": "string"
+        },
+        "config": {
+          "$ref": "ClusterConfig",
+          "description": "Required. The cluster config. Note that Cloud Dataproc may set default values, and values may change when clusters are updated."
         },
         "labels": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Output-only. Labels associated with the operation",
+          "description": "Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a cluster.",
           "type": "object"
+        },
+        "metrics": {
+          "$ref": "ClusterMetrics",
+          "description": "Contains cluster daemon metrics such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
+        },
+        "projectId": {
+          "description": "Required. The Google Cloud Platform project ID that the cluster belongs to.",
+          "type": "string"
         },
         "status": {
-          "description": "Output-only. Current operation status.",
-          "$ref": "ClusterOperationStatus"
+          "$ref": "ClusterStatus",
+          "description": "Output only. Cluster status."
         },
         "statusHistory": {
-          "description": "Output-only. The previous operation status.",
+          "description": "Output only. The previous cluster status.",
           "items": {
-            "$ref": "ClusterOperationStatus"
+            "$ref": "ClusterStatus"
           },
           "type": "array"
-        },
-        "clusterName": {
-          "description": "Output-only. Name of the cluster for the operation.",
-          "type": "string"
-        },
-        "clusterUuid": {
-          "description": "Output-only. Cluster UUID for the operation.",
-          "type": "string"
         }
       },
-      "id": "ClusterOperationMetadata",
-      "description": "Metadata describing the operation."
-    },
-    "HiveJob": {
-      "properties": {
-        "jarFileUris": {
-          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATH of the Hive server and Hadoop MapReduce (MR) tasks. Can contain Hive SerDes and UDFs.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "scriptVariables": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Optional. Mapping of query variable names to values (equivalent to the Hive command: SET name=\"value\";).",
-          "type": "object"
-        },
-        "properties": {
-          "description": "Optional. A mapping of property names and values, used to configure Hive. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml, and classes in user code.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "continueOnFailure": {
-          "description": "Optional. Whether to continue executing queries if a query fails. The default value is false. Setting to true can be useful when executing independent parallel queries.",
-          "type": "boolean"
-        },
-        "queryFileUri": {
-          "type": "string",
-          "description": "The HCFS URI of the script that contains Hive queries."
-        },
-        "queryList": {
-          "description": "A list of queries.",
-          "$ref": "QueryList"
-        }
-      },
-      "id": "HiveJob",
-      "description": "A Cloud Dataproc job for running Apache Hive (https://hive.apache.org/) queries on YARN.",
       "type": "object"
-    },
-    "Empty": {
-      "type": "object",
-      "properties": {},
-      "id": "Empty",
-      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance:\nservice Foo {\n  rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n}\nThe JSON representation for Empty is empty JSON object {}."
-    },
-    "DiagnoseClusterResults": {
-      "description": "The location of diagnostic output.",
-      "type": "object",
-      "properties": {
-        "outputUri": {
-          "description": "Output-only. The Google Cloud Storage URI of the diagnostic output. The output report is a plain text file with a summary of collected diagnostics.",
-          "type": "string"
-        }
-      },
-      "id": "DiagnoseClusterResults"
     },
     "ClusterConfig": {
       "description": "The cluster config.",
-      "type": "object",
+      "id": "ClusterConfig",
       "properties": {
+        "configBucket": {
+          "description": "Optional. A Cloud Storage staging bucket used for sharing generated SSH keys and config. If you do not specify a staging bucket, Cloud Dataproc will determine an appropriate Cloud Storage location (US, ASIA, or EU) for your cluster's staging bucket according to the Google Compute Engine zone where your cluster is deployed, and then it will create and manage this project-level, per-location bucket for you.",
+          "type": "string"
+        },
         "gceClusterConfig": {
           "$ref": "GceClusterConfig",
-          "description": "Required. The shared Google Compute Engine config settings for all instances in a cluster."
-        },
-        "softwareConfig": {
-          "description": "Optional. The config settings for software inside the cluster.",
-          "$ref": "SoftwareConfig"
-        },
-        "masterConfig": {
-          "$ref": "InstanceGroupConfig",
-          "description": "Optional. The Google Compute Engine config settings for the master instance in a cluster."
-        },
-        "secondaryWorkerConfig": {
-          "$ref": "InstanceGroupConfig",
-          "description": "Optional. The Google Compute Engine config settings for additional worker instances in a cluster."
+          "description": "Required. The shared Compute Engine config settings for all instances in a cluster."
         },
         "initializationActions": {
           "description": "Optional. Commands to execute on each node after config is completed. By default, executables are run on master and all worker nodes. You can test a node's role metadata to run an executable on a master or worker node, as shown below using curl (you can also use wget):\nROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)\nif [[ \"${ROLE}\" == 'Master' ]]; then\n  ... master specific actions ...\nelse\n  ... worker specific actions ...\nfi\n",
@@ -880,145 +861,33 @@
           },
           "type": "array"
         },
-        "configBucket": {
-          "description": "Optional. A Google Cloud Storage staging bucket used for sharing generated SSH keys and config. If you do not specify a staging bucket, Cloud Dataproc will determine an appropriate Cloud Storage location (US, ASIA, or EU) for your cluster's staging bucket according to the Google Compute Engine zone where your cluster is deployed, and then it will create and manage this project-level, per-location bucket for you.",
-          "type": "string"
+        "masterConfig": {
+          "$ref": "InstanceGroupConfig",
+          "description": "Optional. The Compute Engine config settings for the master instance in a cluster."
+        },
+        "secondaryWorkerConfig": {
+          "$ref": "InstanceGroupConfig",
+          "description": "Optional. The Compute Engine config settings for additional worker instances in a cluster."
+        },
+        "softwareConfig": {
+          "$ref": "SoftwareConfig",
+          "description": "Optional. The config settings for software inside the cluster."
         },
         "workerConfig": {
           "$ref": "InstanceGroupConfig",
-          "description": "Optional. The Google Compute Engine config settings for worker instances in a cluster."
+          "description": "Optional. The Compute Engine config settings for worker instances in a cluster."
         }
       },
-      "id": "ClusterConfig"
-    },
-    "PySparkJob": {
-      "type": "object",
-      "properties": {
-        "archiveUris": {
-          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of .jar, .tar, .tar.gz, .tgz, and .zip.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "jarFileUris": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATHs of the Python driver and tasks."
-        },
-        "loggingConfig": {
-          "description": "Optional. The runtime log config for job execution.",
-          "$ref": "LoggingConfig"
-        },
-        "properties": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Optional. A mapping of property names to values, used to configure PySpark. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/spark/conf/spark-defaults.conf and classes in user code.",
-          "type": "object"
-        },
-        "args": {
-          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as --conf, that can be set as job properties, since a collision may occur that causes an incorrect job submission.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "fileUris": {
-          "description": "Optional. HCFS URIs of files to be copied to the working directory of Python drivers and distributed tasks. Useful for naively parallel tasks.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "pythonFileUris": {
-          "description": "Optional. HCFS file URIs of Python files to pass to the PySpark framework. Supported file types: .py, .egg, and .zip.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mainPythonFileUri": {
-          "description": "Required. The HCFS URI of the main Python file to use as the driver. Must be a .py file.",
-          "type": "string"
-        }
-      },
-      "id": "PySparkJob",
-      "description": "A Cloud Dataproc job for running Apache PySpark (https://spark.apache.org/docs/0.9.0/python-programming-guide.html) applications on YARN."
-    },
-    "GceClusterConfig": {
-      "description": "Common config settings for resources of Google Compute Engine cluster instances, applicable to all instances in the cluster.",
-      "type": "object",
-      "properties": {
-        "tags": {
-          "description": "The Google Compute Engine tags to add to all instances (see Tagging instances).",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "serviceAccount": {
-          "description": "Optional. The service account of the instances. Defaults to the default Google Compute Engine service account. Custom service accounts need permissions equivalent to the folloing IAM roles:\nroles/logging.logWriter\nroles/storage.objectAdmin(see https://cloud.google.com/compute/docs/access/service-accounts#custom_service_accounts for more information). Example: [account_id]@[project_id].iam.gserviceaccount.com",
-          "type": "string"
-        },
-        "subnetworkUri": {
-          "description": "Optional. The Google Compute Engine subnetwork to be used for machine communications. Cannot be specified with network_uri.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0\nprojects/[project_id]/regions/us-east1/sub0\nsub0",
-          "type": "string"
-        },
-        "networkUri": {
-          "type": "string",
-          "description": "Optional. The Google Compute Engine network to be used for machine communications. Cannot be specified with subnetwork_uri. If neither network_uri nor subnetwork_uri is specified, the \"default\" network of the project is used, if it exists. Cannot be a \"Custom Subnet Network\" (see Using Subnetworks for more information).A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default\nprojects/[project_id]/regions/global/default\ndefault"
-        },
-        "zoneUri": {
-          "description": "Optional. The zone where the Google Compute Engine cluster will be located. On a create request, it is required in the \"global\" region. If omitted in a non-global Cloud Dataproc region, the service will pick a zone in the corresponding Compute Engine region. On a get request, zone will always be present.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]\nprojects/[project_id]/zones/[zone]\nus-central1-f",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "The Google Compute Engine metadata entries to add to all instances (see Project and instance metadata (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "internalIpOnly": {
-          "description": "Optional. If true, all instances in the cluster will only have internal IP addresses. By default, clusters are not restricted to internal IP addresses, and will have ephemeral external IP addresses assigned to each instance. This internal_ip_only restriction can only be enabled for subnetwork enabled networks, and all off-cluster dependencies must be configured to be accessible without external IP addresses.",
-          "type": "boolean"
-        },
-        "serviceAccountScopes": {
-          "description": "Optional. The URIs of service account scopes to be included in Google Compute Engine instances. The following base set of scopes is always included:\nhttps://www.googleapis.com/auth/cloud.useraccounts.readonly\nhttps://www.googleapis.com/auth/devstorage.read_write\nhttps://www.googleapis.com/auth/logging.writeIf no scopes are specified, the following defaults are also provided:\nhttps://www.googleapis.com/auth/bigquery\nhttps://www.googleapis.com/auth/bigtable.admin.table\nhttps://www.googleapis.com/auth/bigtable.data\nhttps://www.googleapis.com/auth/devstorage.full_control",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "id": "GceClusterConfig"
-    },
-    "AcceleratorConfig": {
-      "properties": {
-        "acceleratorCount": {
-          "format": "int32",
-          "description": "The number of the accelerator cards of this type exposed to this instance.",
-          "type": "integer"
-        },
-        "acceleratorTypeUri": {
-          "description": "Full URL, partial URI, or short name of the accelerator type resource to expose to this instance. See Google Compute Engine AcceleratorTypes( /compute/docs/reference/beta/acceleratorTypes)Examples * https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80 * projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80 * nvidia-tesla-k80",
-          "type": "string"
-        }
-      },
-      "id": "AcceleratorConfig",
-      "description": "Specifies the type and number of accelerator cards attached to the instances of an instance group (see GPUs on Compute Engine).",
       "type": "object"
     },
     "ClusterMetrics": {
-      "type": "object",
+      "description": "Contains cluster daemon metrics, such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release.",
+      "id": "ClusterMetrics",
       "properties": {
         "hdfsMetrics": {
           "additionalProperties": {
-            "type": "string",
-            "format": "int64"
+            "format": "int64",
+            "type": "string"
           },
           "description": "The HDFS metrics.",
           "type": "object"
@@ -1032,10 +901,628 @@
           "type": "object"
         }
       },
-      "id": "ClusterMetrics",
-      "description": "Contains cluster daemon metrics, such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
+      "type": "object"
+    },
+    "ClusterOperation": {
+      "description": "The cluster operation triggered by a workflow.",
+      "id": "ClusterOperation",
+      "properties": {
+        "done": {
+          "description": "Output only. Indicates the operation is done.",
+          "type": "boolean"
+        },
+        "error": {
+          "description": "Output only. Error, if operation failed.",
+          "type": "string"
+        },
+        "operationId": {
+          "description": "Output only. The id of the cluster operation.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ClusterOperationMetadata": {
+      "description": "Metadata describing the operation.",
+      "id": "ClusterOperationMetadata",
+      "properties": {
+        "clusterName": {
+          "description": "Output only. Name of the cluster for the operation.",
+          "type": "string"
+        },
+        "clusterUuid": {
+          "description": "Output only. Cluster UUID for the operation.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Output only. Short description of operation.",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Output only. Labels associated with the operation",
+          "type": "object"
+        },
+        "operationType": {
+          "description": "Output only. The operation type.",
+          "type": "string"
+        },
+        "status": {
+          "$ref": "ClusterOperationStatus",
+          "description": "Output only. Current operation status."
+        },
+        "statusHistory": {
+          "description": "Output only. The previous operation status.",
+          "items": {
+            "$ref": "ClusterOperationStatus"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "description": "Output only. Errors encountered during operation execution.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ClusterOperationStatus": {
+      "description": "The status of the operation.",
+      "id": "ClusterOperationStatus",
+      "properties": {
+        "details": {
+          "description": "Output only. A message containing any operation metadata details.",
+          "type": "string"
+        },
+        "innerState": {
+          "description": "Output only. A message containing the detailed operation state.",
+          "type": "string"
+        },
+        "state": {
+          "description": "Output only. A message containing the operation state.",
+          "enum": [
+            "UNKNOWN",
+            "PENDING",
+            "RUNNING",
+            "DONE"
+          ],
+          "enumDescriptions": [
+            "Unused.",
+            "The operation has been created.",
+            "The operation is running.",
+            "The operation is done; either cancelled or completed."
+          ],
+          "type": "string"
+        },
+        "stateStartTime": {
+          "description": "Output only. The time this state was entered.",
+          "format": "google-datetime",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ClusterStatus": {
+      "description": "The status of a cluster and its instances.",
+      "id": "ClusterStatus",
+      "properties": {
+        "detail": {
+          "description": "Output only. Optional details of cluster's state.",
+          "type": "string"
+        },
+        "state": {
+          "description": "Output only. The cluster's state.",
+          "enum": [
+            "UNKNOWN",
+            "CREATING",
+            "RUNNING",
+            "ERROR",
+            "DELETING",
+            "UPDATING"
+          ],
+          "enumDescriptions": [
+            "The cluster state is unknown.",
+            "The cluster is being created and set up. It is not ready for use.",
+            "The cluster is currently running and healthy. It is ready for use.",
+            "The cluster encountered an error. It is not ready for use.",
+            "The cluster is being deleted. It cannot be used.",
+            "The cluster is being updated. It continues to accept and process jobs."
+          ],
+          "type": "string"
+        },
+        "stateStartTime": {
+          "description": "Output only. Time when this state was entered.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "substate": {
+          "description": "Output only. Additional state information that includes status reported by the agent.",
+          "enum": [
+            "UNSPECIFIED",
+            "UNHEALTHY",
+            "STALE_STATUS"
+          ],
+          "enumDescriptions": [
+            "The cluster substate is unknown.",
+            "The cluster is known to be in an unhealthy state (for example, critical daemons are not running or HDFS capacity is exhausted).Applies to RUNNING state.",
+            "The agent-reported status is out of date (may occur if Cloud Dataproc loses communication with Agent).Applies to RUNNING state."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DiagnoseClusterRequest": {
+      "description": "A request to collect cluster diagnostic information.",
+      "id": "DiagnoseClusterRequest",
+      "properties": {},
+      "type": "object"
+    },
+    "DiagnoseClusterResults": {
+      "description": "The location of diagnostic output.",
+      "id": "DiagnoseClusterResults",
+      "properties": {
+        "outputUri": {
+          "description": "Output only. The Cloud Storage URI of the diagnostic output. The output report is a plain text file with a summary of collected diagnostics.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DiskConfig": {
+      "description": "Specifies the config of disk options for a group of VM instances.",
+      "id": "DiskConfig",
+      "properties": {
+        "bootDiskSizeGb": {
+          "description": "Optional. Size in GB of the boot disk (default is 500GB).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "bootDiskType": {
+          "description": "Optional. Type of the boot disk (default is \"pd-standard\"). Valid values: \"pd-ssd\" (Persistent Disk Solid State Drive) or \"pd-standard\" (Persistent Disk Hard Disk Drive).",
+          "type": "string"
+        },
+        "numLocalSsds": {
+          "description": "Optional. Number of attached SSDs, from 0 to 4 (default is 0). If SSDs are not attached, the boot disk is used to store runtime logs and HDFS (https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html) data. If one or more SSDs are attached, this runtime bulk data is spread across them, and the boot disk contains only basic config and installed binaries.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance:\nservice Foo {\n  rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n}\nThe JSON representation for Empty is empty JSON object {}.",
+      "id": "Empty",
+      "properties": {},
+      "type": "object"
+    },
+    "GceClusterConfig": {
+      "description": "Common config settings for resources of Compute Engine cluster instances, applicable to all instances in the cluster.",
+      "id": "GceClusterConfig",
+      "properties": {
+        "internalIpOnly": {
+          "description": "Optional. If true, all instances in the cluster will only have internal IP addresses. By default, clusters are not restricted to internal IP addresses, and will have ephemeral external IP addresses assigned to each instance. This internal_ip_only restriction can only be enabled for subnetwork enabled networks, and all off-cluster dependencies must be configured to be accessible without external IP addresses.",
+          "type": "boolean"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The Compute Engine metadata entries to add to all instances (see Project and instance metadata (https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).",
+          "type": "object"
+        },
+        "networkUri": {
+          "description": "Optional. The Compute Engine network to be used for machine communications. Cannot be specified with subnetwork_uri. If neither network_uri nor subnetwork_uri is specified, the \"default\" network of the project is used, if it exists. Cannot be a \"Custom Subnet Network\" (see Using Subnetworks for more information).A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default\nprojects/[project_id]/regions/global/default\ndefault",
+          "type": "string"
+        },
+        "serviceAccount": {
+          "description": "Optional. The service account of the instances. Defaults to the default Compute Engine service account. Custom service accounts need permissions equivalent to the following IAM roles:\nroles/logging.logWriter\nroles/storage.objectAdmin(see https://cloud.google.com/compute/docs/access/service-accounts#custom_service_accounts for more information). Example: [account_id]@[project_id].iam.gserviceaccount.com",
+          "type": "string"
+        },
+        "serviceAccountScopes": {
+          "description": "Optional. The URIs of service account scopes to be included in Compute Engine instances. The following base set of scopes is always included:\nhttps://www.googleapis.com/auth/cloud.useraccounts.readonly\nhttps://www.googleapis.com/auth/devstorage.read_write\nhttps://www.googleapis.com/auth/logging.writeIf no scopes are specified, the following defaults are also provided:\nhttps://www.googleapis.com/auth/bigquery\nhttps://www.googleapis.com/auth/bigtable.admin.table\nhttps://www.googleapis.com/auth/bigtable.data\nhttps://www.googleapis.com/auth/devstorage.full_control",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "subnetworkUri": {
+          "description": "Optional. The Compute Engine subnetwork to be used for machine communications. Cannot be specified with network_uri.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0\nprojects/[project_id]/regions/us-east1/sub0\nsub0",
+          "type": "string"
+        },
+        "tags": {
+          "description": "The Compute Engine tags to add to all instances (see Tagging instances).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "zoneUri": {
+          "description": "Optional. The zone where the Compute Engine cluster will be located. On a create request, it is required in the \"global\" region. If omitted in a non-global Cloud Dataproc region, the service will pick a zone in the corresponding Compute Engine region. On a get request, zone will always be present.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]\nprojects/[project_id]/zones/[zone]\nus-central1-f",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "HadoopJob": {
+      "description": "A Cloud Dataproc job for running Apache Hadoop MapReduce (https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html) jobs on Apache Hadoop YARN (https://hadoop.apache.org/docs/r2.7.1/hadoop-yarn/hadoop-yarn-site/YARN.html).",
+      "id": "HadoopJob",
+      "properties": {
+        "archiveUris": {
+          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of Hadoop drivers and tasks. Supported file types: .jar, .tar, .tar.gz, .tgz, or .zip.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "args": {
+          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as -libjars or -Dfoo=bar, that can be set as job properties, since a collision may occur that causes an incorrect job submission.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fileUris": {
+          "description": "Optional. HCFS (Hadoop Compatible Filesystem) URIs of files to be copied to the working directory of Hadoop drivers and distributed tasks. Useful for naively parallel tasks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "jarFileUris": {
+          "description": "Optional. Jar file URIs to add to the CLASSPATHs of the Hadoop driver and tasks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "loggingConfig": {
+          "$ref": "LoggingConfig",
+          "description": "Optional. The runtime log config for job execution."
+        },
+        "mainClass": {
+          "description": "The name of the driver's main class. The jar file containing the class must be in the default CLASSPATH or specified in jar_file_uris.",
+          "type": "string"
+        },
+        "mainJarFileUri": {
+          "description": "The HCFS URI of the jar file containing the main class. Examples:  'gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar'  'hdfs:/tmp/test-samples/custom-wordcount.jar'  'file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'",
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. A mapping of property names to values, used to configure Hadoop. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/hadoop/conf/*-site and classes in user code.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "HiveJob": {
+      "description": "A Cloud Dataproc job for running Apache Hive (https://hive.apache.org/) queries on YARN.",
+      "id": "HiveJob",
+      "properties": {
+        "continueOnFailure": {
+          "description": "Optional. Whether to continue executing queries if a query fails. The default value is false. Setting to true can be useful when executing independent parallel queries.",
+          "type": "boolean"
+        },
+        "jarFileUris": {
+          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATH of the Hive server and Hadoop MapReduce (MR) tasks. Can contain Hive SerDes and UDFs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. A mapping of property names and values, used to configure Hive. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/hadoop/conf/*-site.xml, /etc/hive/conf/hive-site.xml, and classes in user code.",
+          "type": "object"
+        },
+        "queryFileUri": {
+          "description": "The HCFS URI of the script that contains Hive queries.",
+          "type": "string"
+        },
+        "queryList": {
+          "$ref": "QueryList",
+          "description": "A list of queries."
+        },
+        "scriptVariables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. Mapping of query variable names to values (equivalent to the Hive command: SET name=\"value\";).",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "InstanceGroupConfig": {
+      "description": "Optional. The config settings for Compute Engine resources in an instance group, such as a master or worker group.",
+      "id": "InstanceGroupConfig",
+      "properties": {
+        "accelerators": {
+          "description": "Optional. The Compute Engine accelerator configuration for these instances.Beta Feature: This feature is still under development. It may be changed before final release.",
+          "items": {
+            "$ref": "AcceleratorConfig"
+          },
+          "type": "array"
+        },
+        "diskConfig": {
+          "$ref": "DiskConfig",
+          "description": "Optional. Disk option config settings."
+        },
+        "imageUri": {
+          "description": "Optional. The Compute Engine image resource used for cluster instances. It can be specified or may be inferred from SoftwareConfig.image_version.",
+          "type": "string"
+        },
+        "instanceNames": {
+          "description": "Output only. The list of instance names. Cloud Dataproc derives the names from cluster_name, num_instances, and the instance group.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "isPreemptible": {
+          "description": "Optional. Specifies that this instance group contains preemptible instances.",
+          "type": "boolean"
+        },
+        "machineTypeUri": {
+          "description": "Optional. The Compute Engine machine type used for cluster instances.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2\nprojects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2\nn1-standard-2Auto Zone Exception: If you are using the Cloud Dataproc Auto Zone Placement feature, you must use the short name of the machine type resource, for example, n1-standard-2.",
+          "type": "string"
+        },
+        "managedGroupConfig": {
+          "$ref": "ManagedGroupConfig",
+          "description": "Output only. The config for Compute Engine Instance Group Manager that manages this group. This is only used for preemptible instance groups."
+        },
+        "numInstances": {
+          "description": "Optional. The number of VM instances in the instance group. For master instance groups, must be set to 1.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "Job": {
+      "description": "A Cloud Dataproc job resource.",
+      "id": "Job",
+      "properties": {
+        "driverControlFilesUri": {
+          "description": "Output only. If present, the location of miscellaneous control files which may be used as part of job setup and handling. If not present, control files may be placed in the same location as driver_output_uri.",
+          "type": "string"
+        },
+        "driverOutputResourceUri": {
+          "description": "Output only. A URI pointing to the location of the stdout of the job's driver program.",
+          "type": "string"
+        },
+        "hadoopJob": {
+          "$ref": "HadoopJob",
+          "description": "Job is a Hadoop job."
+        },
+        "hiveJob": {
+          "$ref": "HiveJob",
+          "description": "Job is a Hive job."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. The labels to associate with this job. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a job.",
+          "type": "object"
+        },
+        "pigJob": {
+          "$ref": "PigJob",
+          "description": "Job is a Pig job."
+        },
+        "placement": {
+          "$ref": "JobPlacement",
+          "description": "Required. Job information, including how, when, and where to run the job."
+        },
+        "pysparkJob": {
+          "$ref": "PySparkJob",
+          "description": "Job is a Pyspark job."
+        },
+        "reference": {
+          "$ref": "JobReference",
+          "description": "Optional. The fully qualified reference to the job, which can be used to obtain the equivalent REST path of the job resource. If this property is not specified when a job is created, the server generates a \u003ccode\u003ejob_id\u003c/code\u003e."
+        },
+        "scheduling": {
+          "$ref": "JobScheduling",
+          "description": "Optional. Job scheduling configuration."
+        },
+        "sparkJob": {
+          "$ref": "SparkJob",
+          "description": "Job is a Spark job."
+        },
+        "sparkSqlJob": {
+          "$ref": "SparkSqlJob",
+          "description": "Job is a SparkSql job."
+        },
+        "status": {
+          "$ref": "JobStatus",
+          "description": "Output only. The job status. Additional application-specific status information may be contained in the \u003ccode\u003etype_job\u003c/code\u003e and \u003ccode\u003eyarn_applications\u003c/code\u003e fields."
+        },
+        "statusHistory": {
+          "description": "Output only. The previous job status.",
+          "items": {
+            "$ref": "JobStatus"
+          },
+          "type": "array"
+        },
+        "yarnApplications": {
+          "description": "Output only. The collection of YARN applications spun up by this job.Beta Feature: This report is available for testing purposes only. It may be changed before final release.",
+          "items": {
+            "$ref": "YarnApplication"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "JobPlacement": {
+      "description": "Cloud Dataproc job config.",
+      "id": "JobPlacement",
+      "properties": {
+        "clusterName": {
+          "description": "Required. The name of the cluster where the job will be submitted.",
+          "type": "string"
+        },
+        "clusterUuid": {
+          "description": "Output only. A cluster UUID generated by the Cloud Dataproc service when the job is submitted.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "JobReference": {
+      "description": "Encapsulates the full scoping used to reference a job.",
+      "id": "JobReference",
+      "properties": {
+        "jobId": {
+          "description": "Optional. The job ID, which must be unique within the project. The job ID is generated by the server upon job submission or provided by the user as a means to perform retries without creating duplicate jobs. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or hyphens (-). The maximum length is 100 characters.",
+          "type": "string"
+        },
+        "projectId": {
+          "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "JobScheduling": {
+      "description": "Job scheduling options.",
+      "id": "JobScheduling",
+      "properties": {
+        "maxFailuresPerHour": {
+          "description": "Optional. Maximum number of times per hour a driver may be restarted as a result of driver terminating with non-zero code before job is reported failed.A job may be reported as thrashing if driver exits with non-zero code 4 times within 10 minute window.Maximum value is 10.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "JobStatus": {
+      "description": "Cloud Dataproc job status.",
+      "id": "JobStatus",
+      "properties": {
+        "details": {
+          "description": "Output only. Optional job state details, such as an error description if the state is \u003ccode\u003eERROR\u003c/code\u003e.",
+          "type": "string"
+        },
+        "state": {
+          "description": "Output only. A state message specifying the overall job state.",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "PENDING",
+            "SETUP_DONE",
+            "RUNNING",
+            "CANCEL_PENDING",
+            "CANCEL_STARTED",
+            "CANCELLED",
+            "DONE",
+            "ERROR",
+            "ATTEMPT_FAILURE"
+          ],
+          "enumDescriptions": [
+            "The job state is unknown.",
+            "The job is pending; it has been submitted, but is not yet running.",
+            "Job has been received by the service and completed initial setup; it will soon be submitted to the cluster.",
+            "The job is running on the cluster.",
+            "A CancelJob request has been received, but is pending.",
+            "Transient in-flight resources have been canceled, and the request to cancel the running job has been issued to the cluster.",
+            "The job cancellation was successful.",
+            "The job has completed successfully.",
+            "The job has completed, but encountered an error.",
+            "Job attempt has failed. The detail field contains failure details for this attempt.Applies to restartable jobs only."
+          ],
+          "type": "string"
+        },
+        "stateStartTime": {
+          "description": "Output only. The time when this state was entered.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "substate": {
+          "description": "Output only. Additional state information, which includes status reported by the agent.",
+          "enum": [
+            "UNSPECIFIED",
+            "SUBMITTED",
+            "QUEUED",
+            "STALE_STATUS"
+          ],
+          "enumDescriptions": [
+            "The job substate is unknown.",
+            "The Job is submitted to the agent.Applies to RUNNING state.",
+            "The Job has been received and is awaiting execution (it may be waiting for a condition to be met). See the \"details\" field for the reason for the delay.Applies to RUNNING state.",
+            "The agent-reported status is out of date, which may be caused by a loss of communication between the agent and Cloud Dataproc. If the agent does not send a timely update, the job will fail.Applies to RUNNING state."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ListClustersResponse": {
+      "description": "The list of all clusters in a project.",
+      "id": "ListClustersResponse",
+      "properties": {
+        "clusters": {
+          "description": "Output only. The clusters in the project.",
+          "items": {
+            "$ref": "Cluster"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "description": "Output only. This token is included in the response if there are more results to fetch. To fetch additional results, provide this value as the page_token in a subsequent ListClustersRequest.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ListJobsResponse": {
+      "description": "A list of jobs in a project.",
+      "id": "ListJobsResponse",
+      "properties": {
+        "jobs": {
+          "description": "Output only. Jobs list.",
+          "items": {
+            "$ref": "Job"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "description": "Optional. This token is included in the response if there are more results to fetch. To fetch additional results, provide this value as the page_token in a subsequent \u003ccode\u003eListJobsRequest\u003c/code\u003e.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ListOperationsResponse": {
+      "description": "The response message for Operations.ListOperations.",
+      "id": "ListOperationsResponse",
+      "properties": {
+        "nextPageToken": {
+          "description": "The standard List next-page token.",
+          "type": "string"
+        },
+        "operations": {
+          "description": "A list of operations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Operation"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     },
     "LoggingConfig": {
+      "description": "The runtime logging config of the job.",
+      "id": "LoggingConfig",
       "properties": {
         "driverLogLevels": {
           "additionalProperties": {
@@ -1056,25 +1543,46 @@
           "type": "object"
         }
       },
-      "id": "LoggingConfig",
-      "description": "The runtime logging config of the job.",
+      "type": "object"
+    },
+    "ManagedGroupConfig": {
+      "description": "Specifies the resources used to actively manage an instance group.",
+      "id": "ManagedGroupConfig",
+      "properties": {
+        "instanceGroupManagerName": {
+          "description": "Output only. The name of the Instance Group Manager for this group.",
+          "type": "string"
+        },
+        "instanceTemplateName": {
+          "description": "Output only. The name of the Instance Template used for the Managed Instance Group.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "NodeInitializationAction": {
+      "description": "Specifies an executable to run on a fully configured node and a timeout period for executable completion.",
+      "id": "NodeInitializationAction",
+      "properties": {
+        "executableFile": {
+          "description": "Required. Cloud Storage URI of executable file.",
+          "type": "string"
+        },
+        "executionTimeout": {
+          "description": "Optional. Amount of time executable has to complete. Default is 10 minutes. Cluster creation fails with an explanatory error message (the name of the executable that caused the error and the exceeded timeout period) if the executable is not completed at end of the timeout period.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "Operation": {
       "description": "This resource represents a long-running operation that is the result of a network API call.",
-      "type": "object",
+      "id": "Operation",
       "properties": {
-        "response": {
-          "type": "object",
-          "additionalProperties": {
-            "description": "Properties of the object. Contains field @type with type URL.",
-            "type": "any"
-          },
-          "description": "The normal response of the operation in case of success. If the original method returns no data on success, such as Delete, the response is google.protobuf.Empty. If the original method is standard Get/Create/Update, the response should be the resource. For other methods, the response should have the type XxxResponse, where Xxx is the original method name. For example, if the original method name is TakeSnapshot(), the inferred response type is TakeSnapshotResponse."
-        },
-        "name": {
-          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the name should have the format of operations/some/unique/name.",
-          "type": "string"
+        "done": {
+          "description": "If the value is false, it means the operation is still in progress. If true, the operation is completed, and either error or response is available.",
+          "type": "boolean"
         },
         "error": {
           "$ref": "Status",
@@ -1088,328 +1596,35 @@
           "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
           "type": "object"
         },
-        "done": {
-          "description": "If the value is false, it means the operation is still in progress. If true, the operation is completed, and either error or response is available.",
-          "type": "boolean"
-        }
-      },
-      "id": "Operation"
-    },
-    "JobReference": {
-      "description": "Encapsulates the full scoping used to reference a job.",
-      "type": "object",
-      "properties": {
-        "jobId": {
-          "description": "Optional. The job ID, which must be unique within the project. The job ID is generated by the server upon job submission or provided by the user as a means to perform retries without creating duplicate jobs. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or hyphens (-). The maximum length is 100 characters.",
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the name should have the format of operations/some/unique/name.",
           "type": "string"
         },
-        "projectId": {
-          "description": "Required. The ID of the Google Cloud Platform project that the job belongs to.",
-          "type": "string"
-        }
-      },
-      "id": "JobReference"
-    },
-    "SubmitJobRequest": {
-      "description": "A request to submit a job.",
-      "type": "object",
-      "properties": {
-        "job": {
-          "description": "Required. The job resource.",
-          "$ref": "Job"
-        }
-      },
-      "id": "SubmitJobRequest"
-    },
-    "Status": {
-      "description": "The Status type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by gRPC (https://github.com/grpc). The error model is designed to be:\nSimple to use and understand for most users\nFlexible enough to meet unexpected needsOverviewThe Status message contains three pieces of data: error code, error message, and error details. The error code should be an enum value of google.rpc.Code, but it may accept additional error codes if needed. The error message should be a developer-facing English message that helps developers understand and resolve the error. If a localized user-facing error message is needed, put the localized message in the error details or localize it in the client. The optional error details may contain arbitrary information about the error. There is a predefined set of error detail types in the package google.rpc that can be used for common error conditions.Language mappingThe Status message is the logical representation of the error model, but it is not necessarily the actual wire format. When the Status message is exposed in different client libraries and different wire protocols, it can be mapped differently. For example, it will likely be mapped to some exceptions in Java, but more likely mapped to some error codes in C.Other usesThe error model and the Status message can be used in a variety of environments, either with or without APIs, to provide a consistent developer experience across different environments.Example uses of this error model include:\nPartial errors. If a service needs to return partial errors to the client, it may embed the Status in the normal response to indicate the partial errors.\nWorkflow errors. A typical workflow has multiple steps. Each step may have a Status message for error reporting.\nBatch operations. If a client uses batch request and batch response, the Status message should be used directly inside batch response, one for each error sub-response.\nAsynchronous operations. If an API call embeds asynchronous operation results in its response, the status of those operations should be represented directly using the Status message.\nLogging. If some API errors are stored in logs, the message Status could be used directly after any stripping needed for security/privacy reasons.",
-      "type": "object",
-      "properties": {
-        "details": {
-          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "description": "Properties of the object. Contains field @type with type URL.",
-              "type": "any"
-            }
-          },
-          "type": "array"
-        },
-        "code": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The status code, which should be an enum value of google.rpc.Code."
-        },
-        "message": {
-          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
-          "type": "string"
-        }
-      },
-      "id": "Status"
-    },
-    "InstanceGroupConfig": {
-      "description": "Optional. The config settings for Google Compute Engine resources in an instance group, such as a master or worker group.",
-      "type": "object",
-      "properties": {
-        "diskConfig": {
-          "$ref": "DiskConfig",
-          "description": "Optional. Disk option config settings."
-        },
-        "managedGroupConfig": {
-          "$ref": "ManagedGroupConfig",
-          "description": "Output-only. The config for Google Compute Engine Instance Group Manager that manages this group. This is only used for preemptible instance groups."
-        },
-        "isPreemptible": {
-          "description": "Optional. Specifies that this instance group contains preemptible instances.",
-          "type": "boolean"
-        },
-        "imageUri": {
-          "type": "string",
-          "description": "Output-only. The Google Compute Engine image resource used for cluster instances. Inferred from SoftwareConfig.image_version."
-        },
-        "machineTypeUri": {
-          "description": "Optional. The Google Compute Engine machine type used for cluster instances.A full URL, partial URI, or short name are valid. Examples:\nhttps://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2\nprojects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2\nn1-standard-2",
-          "type": "string"
-        },
-        "instanceNames": {
-          "description": "Optional. The list of instance names. Cloud Dataproc derives the names from cluster_name, num_instances, and the instance group if not set by user (recommended practice is to let Cloud Dataproc derive the name).",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "accelerators": {
-          "description": "Optional. The Google Compute Engine accelerator configuration for these instances.Beta Feature: This feature is still under development. It may be changed before final release.",
-          "items": {
-            "$ref": "AcceleratorConfig"
-          },
-          "type": "array"
-        },
-        "numInstances": {
-          "format": "int32",
-          "description": "Optional. The number of VM instances in the instance group. For master instance groups, must be set to 1.",
-          "type": "integer"
-        }
-      },
-      "id": "InstanceGroupConfig"
-    },
-    "JobScheduling": {
-      "description": "Job scheduling options.Beta Feature: These options are available for testing purposes only. They may be changed before final release.",
-      "type": "object",
-      "properties": {
-        "maxFailuresPerHour": {
-          "format": "int32",
-          "description": "Optional. Maximum number of times per hour a driver may be restarted as a result of driver terminating with non-zero code before job is reported failed.A job may be reported as thrashing if driver exits with non-zero code 4 times within 10 minute window.Maximum value is 10.",
-          "type": "integer"
-        }
-      },
-      "id": "JobScheduling"
-    },
-    "NodeInitializationAction": {
-      "description": "Specifies an executable to run on a fully configured node and a timeout period for executable completion.",
-      "type": "object",
-      "properties": {
-        "executionTimeout": {
-          "format": "google-duration",
-          "description": "Optional. Amount of time executable has to complete. Default is 10 minutes. Cluster creation fails with an explanatory error message (the name of the executable that caused the error and the exceeded timeout period) if the executable is not completed at end of the timeout period.",
-          "type": "string"
-        },
-        "executableFile": {
-          "description": "Required. Google Cloud Storage URI of executable file.",
-          "type": "string"
-        }
-      },
-      "id": "NodeInitializationAction"
-    },
-    "ListJobsResponse": {
-      "description": "A list of jobs in a project.",
-      "type": "object",
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "Optional. This token is included in the response if there are more results to fetch. To fetch additional results, provide this value as the page_token in a subsequent \u003ccode\u003eListJobsRequest\u003c/code\u003e."
-        },
-        "jobs": {
-          "description": "Output-only. Jobs list.",
-          "items": {
-            "$ref": "Job"
-          },
-          "type": "array"
-        }
-      },
-      "id": "ListJobsResponse"
-    },
-    "CancelJobRequest": {
-      "description": "A request to cancel a job.",
-      "type": "object",
-      "properties": {},
-      "id": "CancelJobRequest"
-    },
-    "SparkSqlJob": {
-      "description": "A Cloud Dataproc job for running Apache Spark SQL (http://spark.apache.org/sql/) queries.",
-      "type": "object",
-      "properties": {
-        "queryList": {
-          "$ref": "QueryList",
-          "description": "A list of queries."
-        },
-        "queryFileUri": {
-          "type": "string",
-          "description": "The HCFS URI of the script that contains SQL queries."
-        },
-        "scriptVariables": {
+        "response": {
           "additionalProperties": {
-            "type": "string"
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
           },
-          "description": "Optional. Mapping of query variable names to values (equivalent to the Spark SQL command: SET name=\"value\";).",
-          "type": "object"
-        },
-        "jarFileUris": {
-          "description": "Optional. HCFS URIs of jar files to be added to the Spark CLASSPATH.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "loggingConfig": {
-          "description": "Optional. The runtime log config for job execution.",
-          "$ref": "LoggingConfig"
-        },
-        "properties": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Optional. A mapping of property names to values, used to configure Spark SQL's SparkConf. Properties that conflict with values set by the Cloud Dataproc API may be overwritten.",
+          "description": "The normal response of the operation in case of success. If the original method returns no data on success, such as Delete, the response is google.protobuf.Empty. If the original method is standard Get/Create/Update, the response should be the resource. For other methods, the response should have the type XxxResponse, where Xxx is the original method name. For example, if the original method name is TakeSnapshot(), the inferred response type is TakeSnapshotResponse.",
           "type": "object"
         }
       },
-      "id": "SparkSqlJob"
-    },
-    "Cluster": {
-      "description": "Describes the identifying information, config, and status of a cluster of Google Compute Engine instances.",
-      "type": "object",
-      "properties": {
-        "labels": {
-          "description": "Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a cluster.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "metrics": {
-          "$ref": "ClusterMetrics",
-          "description": "Contains cluster daemon metrics such as HDFS and YARN stats.Beta Feature: This report is available for testing purposes only. It may be changed before final release."
-        },
-        "status": {
-          "description": "Output-only. Cluster status.",
-          "$ref": "ClusterStatus"
-        },
-        "statusHistory": {
-          "description": "Output-only. The previous cluster status.",
-          "items": {
-            "$ref": "ClusterStatus"
-          },
-          "type": "array"
-        },
-        "config": {
-          "$ref": "ClusterConfig",
-          "description": "Required. The cluster config. Note that Cloud Dataproc may set default values, and values may change when clusters are updated."
-        },
-        "clusterUuid": {
-          "description": "Output-only. A cluster UUID (Unique Universal Identifier). Cloud Dataproc generates this value when it creates the cluster.",
-          "type": "string"
-        },
-        "clusterName": {
-          "type": "string",
-          "description": "Required. The cluster name. Cluster names within a project must be unique. Names of deleted clusters can be reused."
-        },
-        "projectId": {
-          "description": "Required. The Google Cloud Platform project ID that the cluster belongs to.",
-          "type": "string"
-        }
-      },
-      "id": "Cluster"
-    },
-    "ListOperationsResponse": {
-      "description": "The response message for Operations.ListOperations.",
-      "type": "object",
-      "properties": {
-        "nextPageToken": {
-          "description": "The standard List next-page token.",
-          "type": "string"
-        },
-        "operations": {
-          "description": "A list of operations that matches the specified filter in the request.",
-          "items": {
-            "$ref": "Operation"
-          },
-          "type": "array"
-        }
-      },
-      "id": "ListOperationsResponse"
-    },
-    "JobPlacement": {
-      "description": "Cloud Dataproc job config.",
-      "type": "object",
-      "properties": {
-        "clusterUuid": {
-          "description": "Output-only. A cluster UUID generated by the Cloud Dataproc service when the job is submitted.",
-          "type": "string"
-        },
-        "clusterName": {
-          "description": "Required. The name of the cluster where the job will be submitted.",
-          "type": "string"
-        }
-      },
-      "id": "JobPlacement"
-    },
-    "SoftwareConfig": {
-      "id": "SoftwareConfig",
-      "description": "Specifies the selection and config of software inside the cluster.",
-      "type": "object",
-      "properties": {
-        "imageVersion": {
-          "description": "Optional. The version of software inside the cluster. It must match the regular expression [0-9]+\\.[0-9]+. If unspecified, it defaults to the latest version (see Cloud Dataproc Versioning).",
-          "type": "string"
-        },
-        "properties": {
-          "description": "Optional. The properties to set on daemon config files.Property keys are specified in prefix:property format, such as core:fs.defaultFS. The following are supported prefixes and their mappings:\ncapacity-scheduler: capacity-scheduler.xml\ncore: core-site.xml\ndistcp: distcp-default.xml\nhdfs: hdfs-site.xml\nhive: hive-site.xml\nmapred: mapred-site.xml\npig: pig.properties\nspark: spark-defaults.conf\nyarn: yarn-site.xml",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "object"
     },
     "PigJob": {
-      "type": "object",
+      "description": "A Cloud Dataproc job for running Apache Pig (https://pig.apache.org/) queries on YARN.",
+      "id": "PigJob",
       "properties": {
         "continueOnFailure": {
           "description": "Optional. Whether to continue executing queries if a query fails. The default value is false. Setting to true can be useful when executing independent parallel queries.",
           "type": "boolean"
         },
-        "queryFileUri": {
-          "description": "The HCFS URI of the script that contains the Pig queries.",
-          "type": "string"
-        },
-        "queryList": {
-          "$ref": "QueryList",
-          "description": "A list of queries."
-        },
         "jarFileUris": {
+          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATH of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain Pig UDFs.",
           "items": {
             "type": "string"
           },
-          "type": "array",
-          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATH of the Pig Client and Hadoop MapReduce (MR) tasks. Can contain Pig UDFs."
-        },
-        "scriptVariables": {
-          "description": "Optional. Mapping of query variable names to values (equivalent to the Pig command: name=[value]).",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "type": "array"
         },
         "loggingConfig": {
           "$ref": "LoggingConfig",
@@ -1421,85 +1636,138 @@
           },
           "description": "Optional. A mapping of property names to values, used to configure Pig. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/hadoop/conf/*-site.xml, /etc/pig/conf/pig.properties, and classes in user code.",
           "type": "object"
+        },
+        "queryFileUri": {
+          "description": "The HCFS URI of the script that contains the Pig queries.",
+          "type": "string"
+        },
+        "queryList": {
+          "$ref": "QueryList",
+          "description": "A list of queries."
+        },
+        "scriptVariables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. Mapping of query variable names to values (equivalent to the Pig command: name=[value]).",
+          "type": "object"
         }
       },
-      "id": "PigJob",
-      "description": "A Cloud Dataproc job for running Apache Pig (https://pig.apache.org/) queries on YARN."
+      "type": "object"
     },
-    "ClusterStatus": {
-      "description": "The status of a cluster and its instances.",
-      "type": "object",
+    "PySparkJob": {
+      "description": "A Cloud Dataproc job for running Apache PySpark (https://spark.apache.org/docs/0.9.0/python-programming-guide.html) applications on YARN.",
+      "id": "PySparkJob",
       "properties": {
-        "substate": {
-          "description": "Output-only. Additional state information that includes status reported by the agent.",
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "The cluster is known to be in an unhealthy state (for example, critical daemons are not running or HDFS capacity is exhausted).Applies to RUNNING state.",
-            "The agent-reported status is out of date (may occur if Cloud Dataproc loses communication with Agent).Applies to RUNNING state."
-          ],
-          "enum": [
-            "UNSPECIFIED",
-            "UNHEALTHY",
-            "STALE_STATUS"
-          ]
-        },
-        "stateStartTime": {
-          "format": "google-datetime",
-          "description": "Output-only. Time when this state was entered.",
-          "type": "string"
-        },
-        "detail": {
-          "description": "Output-only. Optional details of cluster's state.",
-          "type": "string"
-        },
-        "state": {
-          "enumDescriptions": [
-            "The cluster state is unknown.",
-            "The cluster is being created and set up. It is not ready for use.",
-            "The cluster is currently running and healthy. It is ready for use.",
-            "The cluster encountered an error. It is not ready for use.",
-            "The cluster is being deleted. It cannot be used.",
-            "The cluster is being updated. It continues to accept and process jobs."
-          ],
-          "enum": [
-            "UNKNOWN",
-            "CREATING",
-            "RUNNING",
-            "ERROR",
-            "DELETING",
-            "UPDATING"
-          ],
-          "description": "Output-only. The cluster's state.",
-          "type": "string"
-        }
-      },
-      "id": "ClusterStatus"
-    },
-    "ListClustersResponse": {
-      "properties": {
-        "nextPageToken": {
-          "description": "Output-only. This token is included in the response if there are more results to fetch. To fetch additional results, provide this value as the page_token in a subsequent ListClustersRequest.",
-          "type": "string"
-        },
-        "clusters": {
-          "description": "Output-only. The clusters in the project.",
+        "archiveUris": {
+          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of .jar, .tar, .tar.gz, .tgz, and .zip.",
           "items": {
-            "$ref": "Cluster"
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "args": {
+          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as --conf, that can be set as job properties, since a collision may occur that causes an incorrect job submission.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fileUris": {
+          "description": "Optional. HCFS URIs of files to be copied to the working directory of Python drivers and distributed tasks. Useful for naively parallel tasks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "jarFileUris": {
+          "description": "Optional. HCFS URIs of jar files to add to the CLASSPATHs of the Python driver and tasks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "loggingConfig": {
+          "$ref": "LoggingConfig",
+          "description": "Optional. The runtime log config for job execution."
+        },
+        "mainPythonFileUri": {
+          "description": "Required. The HCFS URI of the main Python file to use as the driver. Must be a .py file.",
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. A mapping of property names to values, used to configure PySpark. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/spark/conf/spark-defaults.conf and classes in user code.",
+          "type": "object"
+        },
+        "pythonFileUris": {
+          "description": "Optional. HCFS file URIs of Python files to pass to the PySpark framework. Supported file types: .py, .egg, and .zip.",
+          "items": {
+            "type": "string"
           },
           "type": "array"
         }
       },
-      "id": "ListClustersResponse",
-      "description": "The list of all clusters in a project.",
+      "type": "object"
+    },
+    "QueryList": {
+      "description": "A list of queries to run on a cluster.",
+      "id": "QueryList",
+      "properties": {
+        "queries": {
+          "description": "Required. The queries to execute. You do not need to terminate a query with a semicolon. Multiple queries can be specified in one string by separating each with a semicolon. Here is an example of an Cloud Dataproc API snippet that uses a QueryList to specify a HiveJob:\n\"hiveJob\": {\n  \"queryList\": {\n    \"queries\": [\n      \"query1\",\n      \"query2\",\n      \"query3;query4\",\n    ]\n  }\n}\n",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "SoftwareConfig": {
+      "description": "Specifies the selection and config of software inside the cluster.",
+      "id": "SoftwareConfig",
+      "properties": {
+        "imageVersion": {
+          "description": "Optional. The version of software inside the cluster. It must be one of the supported Cloud Dataproc Versions, such as \"1.2\" (including a subminor version, such as \"1.2.29\"), or the \"preview\" version. If unspecified, it defaults to the latest version.",
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional. The properties to set on daemon config files.Property keys are specified in prefix:property format, such as core:fs.defaultFS. The following are supported prefixes and their mappings:\ncapacity-scheduler: capacity-scheduler.xml\ncore: core-site.xml\ndistcp: distcp-default.xml\nhdfs: hdfs-site.xml\nhive: hive-site.xml\nmapred: mapred-site.xml\npig: pig.properties\nspark: spark-defaults.conf\nyarn: yarn-site.xmlFor more information, see Cluster properties.",
+          "type": "object"
+        }
+      },
       "type": "object"
     },
     "SparkJob": {
-      "type": "object",
+      "description": "A Cloud Dataproc job for running Apache Spark (http://spark.apache.org/) applications on YARN.",
+      "id": "SparkJob",
       "properties": {
-        "mainJarFileUri": {
-          "type": "string",
-          "description": "The HCFS URI of the jar file that contains the main class."
+        "archiveUris": {
+          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of Spark drivers and tasks. Supported file types: .jar, .tar, .tar.gz, .tgz, and .zip.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "args": {
+          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as --conf, that can be set as job properties, since a collision may occur that causes an incorrect job submission.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fileUris": {
+          "description": "Optional. HCFS URIs of files to be copied to the working directory of Spark drivers and distributed tasks. Useful for naively parallel tasks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "jarFileUris": {
           "description": "Optional. HCFS URIs of jar files to add to the CLASSPATHs of the Spark driver and tasks.",
@@ -1509,8 +1777,16 @@
           "type": "array"
         },
         "loggingConfig": {
-          "description": "Optional. The runtime log config for job execution.",
-          "$ref": "LoggingConfig"
+          "$ref": "LoggingConfig",
+          "description": "Optional. The runtime log config for job execution."
+        },
+        "mainClass": {
+          "description": "The name of the driver's main class. The jar file that contains the class must be in the default CLASSPATH or specified in jar_file_uris.",
+          "type": "string"
+        },
+        "mainJarFileUri": {
+          "description": "The HCFS URI of the jar file that contains the main class.",
+          "type": "string"
         },
         "properties": {
           "additionalProperties": {
@@ -1518,244 +1794,16 @@
           },
           "description": "Optional. A mapping of property names to values, used to configure Spark. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/spark/conf/spark-defaults.conf and classes in user code.",
           "type": "object"
-        },
-        "args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as --conf, that can be set as job properties, since a collision may occur that causes an incorrect job submission."
-        },
-        "fileUris": {
-          "description": "Optional. HCFS URIs of files to be copied to the working directory of Spark drivers and distributed tasks. Useful for naively parallel tasks.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mainClass": {
-          "description": "The name of the driver's main class. The jar file that contains the class must be in the default CLASSPATH or specified in jar_file_uris.",
-          "type": "string"
-        },
-        "archiveUris": {
-          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of Spark drivers and tasks. Supported file types: .jar, .tar, .tar.gz, .tgz, and .zip.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
         }
       },
-      "id": "SparkJob",
-      "description": "A Cloud Dataproc job for running Apache Spark (http://spark.apache.org/) applications on YARN."
+      "type": "object"
     },
-    "Job": {
-      "description": "A Cloud Dataproc job resource.",
-      "type": "object",
+    "SparkSqlJob": {
+      "description": "A Cloud Dataproc job for running Apache Spark SQL (http://spark.apache.org/sql/) queries.",
+      "id": "SparkSqlJob",
       "properties": {
-        "scheduling": {
-          "description": "Optional. Job scheduling configuration.",
-          "$ref": "JobScheduling"
-        },
-        "pigJob": {
-          "$ref": "PigJob",
-          "description": "Job is a Pig job."
-        },
-        "hiveJob": {
-          "$ref": "HiveJob",
-          "description": "Job is a Hive job."
-        },
-        "labels": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Optional. The labels to associate with this job. Label keys must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). Label values may be empty, but, if present, must contain 1 to 63 characters, and must conform to RFC 1035 (https://www.ietf.org/rfc/rfc1035.txt). No more than 32 labels can be associated with a job.",
-          "type": "object"
-        },
-        "driverOutputResourceUri": {
-          "description": "Output-only. A URI pointing to the location of the stdout of the job's driver program.",
-          "type": "string"
-        },
-        "sparkJob": {
-          "$ref": "SparkJob",
-          "description": "Job is a Spark job."
-        },
-        "sparkSqlJob": {
-          "$ref": "SparkSqlJob",
-          "description": "Job is a SparkSql job."
-        },
-        "statusHistory": {
-          "description": "Output-only. The previous job status.",
-          "items": {
-            "$ref": "JobStatus"
-          },
-          "type": "array"
-        },
-        "yarnApplications": {
-          "description": "Output-only. The collection of YARN applications spun up by this job.Beta Feature: This report is available for testing purposes only. It may be changed before final release.",
-          "items": {
-            "$ref": "YarnApplication"
-          },
-          "type": "array"
-        },
-        "pysparkJob": {
-          "$ref": "PySparkJob",
-          "description": "Job is a Pyspark job."
-        },
-        "reference": {
-          "$ref": "JobReference",
-          "description": "Optional. The fully qualified reference to the job, which can be used to obtain the equivalent REST path of the job resource. If this property is not specified when a job is created, the server generates a \u003ccode\u003ejob_id\u003c/code\u003e."
-        },
-        "hadoopJob": {
-          "$ref": "HadoopJob",
-          "description": "Job is a Hadoop job."
-        },
-        "placement": {
-          "description": "Required. Job information, including how, when, and where to run the job.",
-          "$ref": "JobPlacement"
-        },
-        "status": {
-          "$ref": "JobStatus",
-          "description": "Output-only. The job status. Additional application-specific status information may be contained in the \u003ccode\u003etype_job\u003c/code\u003e and \u003ccode\u003eyarn_applications\u003c/code\u003e fields."
-        },
-        "driverControlFilesUri": {
-          "description": "Output-only. If present, the location of miscellaneous control files which may be used as part of job setup and handling. If not present, control files may be placed in the same location as driver_output_uri.",
-          "type": "string"
-        }
-      },
-      "id": "Job"
-    },
-    "JobStatus": {
-      "type": "object",
-      "properties": {
-        "details": {
-          "description": "Output-only. Optional job state details, such as an error description if the state is \u003ccode\u003eERROR\u003c/code\u003e.",
-          "type": "string"
-        },
-        "state": {
-          "description": "Output-only. A state message specifying the overall job state.",
-          "type": "string",
-          "enumDescriptions": [
-            "The job state is unknown.",
-            "The job is pending; it has been submitted, but is not yet running.",
-            "Job has been received by the service and completed initial setup; it will soon be submitted to the cluster.",
-            "The job is running on the cluster.",
-            "A CancelJob request has been received, but is pending.",
-            "Transient in-flight resources have been canceled, and the request to cancel the running job has been issued to the cluster.",
-            "The job cancellation was successful.",
-            "The job has completed successfully.",
-            "The job has completed, but encountered an error.",
-            "Job attempt has failed. The detail field contains failure details for this attempt.Applies to restartable jobs only."
-          ],
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "PENDING",
-            "SETUP_DONE",
-            "RUNNING",
-            "CANCEL_PENDING",
-            "CANCEL_STARTED",
-            "CANCELLED",
-            "DONE",
-            "ERROR",
-            "ATTEMPT_FAILURE"
-          ]
-        },
-        "substate": {
-          "description": "Output-only. Additional state information, which includes status reported by the agent.",
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "The Job is submitted to the agent.Applies to RUNNING state.",
-            "The Job has been received and is awaiting execution (it may be waiting for a condition to be met). See the \"details\" field for the reason for the delay.Applies to RUNNING state.",
-            "The agent-reported status is out of date, which may be caused by a loss of communication between the agent and Cloud Dataproc. If the agent does not send a timely update, the job will fail.Applies to RUNNING state."
-          ],
-          "enum": [
-            "UNSPECIFIED",
-            "SUBMITTED",
-            "QUEUED",
-            "STALE_STATUS"
-          ]
-        },
-        "stateStartTime": {
-          "format": "google-datetime",
-          "description": "Output-only. The time when this state was entered.",
-          "type": "string"
-        }
-      },
-      "id": "JobStatus",
-      "description": "Cloud Dataproc job status."
-    },
-    "ManagedGroupConfig": {
-      "description": "Specifies the resources used to actively manage an instance group.",
-      "type": "object",
-      "properties": {
-        "instanceTemplateName": {
-          "description": "Output-only. The name of the Instance Template used for the Managed Instance Group.",
-          "type": "string"
-        },
-        "instanceGroupManagerName": {
-          "description": "Output-only. The name of the Instance Group Manager for this group.",
-          "type": "string"
-        }
-      },
-      "id": "ManagedGroupConfig"
-    },
-    "ClusterOperationStatus": {
-      "description": "The status of the operation.",
-      "type": "object",
-      "properties": {
-        "stateStartTime": {
-          "format": "google-datetime",
-          "description": "Output-only. The time this state was entered.",
-          "type": "string"
-        },
-        "details": {
-          "description": "Output-only.A message containing any operation metadata details.",
-          "type": "string"
-        },
-        "state": {
-          "enumDescriptions": [
-            "Unused.",
-            "The operation has been created.",
-            "The operation is running.",
-            "The operation is done; either cancelled or completed."
-          ],
-          "enum": [
-            "UNKNOWN",
-            "PENDING",
-            "RUNNING",
-            "DONE"
-          ],
-          "description": "Output-only. A message containing the operation state.",
-          "type": "string"
-        },
-        "innerState": {
-          "description": "Output-only. A message containing the detailed operation state.",
-          "type": "string"
-        }
-      },
-      "id": "ClusterOperationStatus"
-    },
-    "HadoopJob": {
-      "description": "A Cloud Dataproc job for running Apache Hadoop MapReduce (https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html) jobs on Apache Hadoop YARN (https://hadoop.apache.org/docs/r2.7.1/hadoop-yarn/hadoop-yarn-site/YARN.html).",
-      "type": "object",
-      "properties": {
-        "mainClass": {
-          "description": "The name of the driver's main class. The jar file containing the class must be in the default CLASSPATH or specified in jar_file_uris.",
-          "type": "string"
-        },
-        "archiveUris": {
-          "description": "Optional. HCFS URIs of archives to be extracted in the working directory of Hadoop drivers and tasks. Supported file types: .jar, .tar, .tar.gz, .tgz, or .zip.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mainJarFileUri": {
-          "description": "The HCFS URI of the jar file containing the main class. Examples:  'gs://foo-bucket/analytics-binaries/extract-useful-metrics-mr.jar'  'hdfs:/tmp/test-samples/custom-wordcount.jar'  'file:///home/usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar'",
-          "type": "string"
-        },
         "jarFileUris": {
-          "description": "Optional. Jar file URIs to add to the CLASSPATHs of the Hadoop driver and tasks.",
+          "description": "Optional. HCFS URIs of jar files to be added to the Spark CLASSPATH.",
           "items": {
             "type": "string"
           },
@@ -1769,52 +1817,210 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Optional. A mapping of property names to values, used to configure Hadoop. Properties that conflict with values set by the Cloud Dataproc API may be overwritten. Can include properties set in /etc/hadoop/conf/*-site and classes in user code.",
+          "description": "Optional. A mapping of property names to values, used to configure Spark SQL's SparkConf. Properties that conflict with values set by the Cloud Dataproc API may be overwritten.",
           "type": "object"
         },
-        "args": {
-          "description": "Optional. The arguments to pass to the driver. Do not include arguments, such as -libjars or -Dfoo=bar, that can be set as job properties, since a collision may occur that causes an incorrect job submission.",
-          "items": {
+        "queryFileUri": {
+          "description": "The HCFS URI of the script that contains SQL queries.",
+          "type": "string"
+        },
+        "queryList": {
+          "$ref": "QueryList",
+          "description": "A list of queries."
+        },
+        "scriptVariables": {
+          "additionalProperties": {
             "type": "string"
+          },
+          "description": "Optional. Mapping of query variable names to values (equivalent to the Spark SQL command: SET name=\"value\";).",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Status": {
+      "description": "The Status type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by gRPC (https://github.com/grpc). The error model is designed to be:\nSimple to use and understand for most users\nFlexible enough to meet unexpected needsOverviewThe Status message contains three pieces of data: error code, error message, and error details. The error code should be an enum value of google.rpc.Code, but it may accept additional error codes if needed. The error message should be a developer-facing English message that helps developers understand and resolve the error. If a localized user-facing error message is needed, put the localized message in the error details or localize it in the client. The optional error details may contain arbitrary information about the error. There is a predefined set of error detail types in the package google.rpc that can be used for common error conditions.Language mappingThe Status message is the logical representation of the error model, but it is not necessarily the actual wire format. When the Status message is exposed in different client libraries and different wire protocols, it can be mapped differently. For example, it will likely be mapped to some exceptions in Java, but more likely mapped to some error codes in C.Other usesThe error model and the Status message can be used in a variety of environments, either with or without APIs, to provide a consistent developer experience across different environments.Example uses of this error model include:\nPartial errors. If a service needs to return partial errors to the client, it may embed the Status in the normal response to indicate the partial errors.\nWorkflow errors. A typical workflow has multiple steps. Each step may have a Status message for error reporting.\nBatch operations. If a client uses batch request and batch response, the Status message should be used directly inside batch response, one for each error sub-response.\nAsynchronous operations. If an API call embeds asynchronous operation results in its response, the status of those operations should be represented directly using the Status message.\nLogging. If some API errors are stored in logs, the message Status could be used directly after any stripping needed for security/privacy reasons.",
+      "id": "Status",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
           },
           "type": "array"
         },
-        "fileUris": {
-          "description": "Optional. HCFS (Hadoop Compatible Filesystem) URIs of files to be copied to the working directory of Hadoop drivers and distributed tasks. Useful for naively parallel tasks.",
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SubmitJobRequest": {
+      "description": "A request to submit a job.",
+      "id": "SubmitJobRequest",
+      "properties": {
+        "job": {
+          "$ref": "Job",
+          "description": "Required. The job resource."
+        },
+        "requestId": {
+          "description": "Optional. A unique id used to identify the request. If the server receives two SubmitJobRequest requests with the same id, then the second request will be ignored and the first Job created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "WorkflowGraph": {
+      "description": "The workflow graph.",
+      "id": "WorkflowGraph",
+      "properties": {
+        "nodes": {
+          "description": "Output only. The workflow nodes.",
           "items": {
-            "type": "string"
+            "$ref": "WorkflowNode"
           },
           "type": "array"
         }
       },
-      "id": "HadoopJob"
+      "type": "object"
     },
-    "QueryList": {
-      "id": "QueryList",
-      "description": "A list of queries to run on a cluster.",
-      "type": "object",
+    "WorkflowMetadata": {
+      "description": "A Cloud Dataproc workflow template resource.",
+      "id": "WorkflowMetadata",
       "properties": {
-        "queries": {
-          "description": "Required. The queries to execute. You do not need to terminate a query with a semicolon. Multiple queries can be specified in one string by separating each with a semicolon. Here is an example of an Cloud Dataproc API snippet that uses a QueryList to specify a HiveJob:\n\"hiveJob\": {\n  \"queryList\": {\n    \"queries\": [\n      \"query1\",\n      \"query2\",\n      \"query3;query4\",\n    ]\n  }\n}\n",
+        "clusterName": {
+          "description": "Output only. The name of the managed cluster.",
+          "type": "string"
+        },
+        "createCluster": {
+          "$ref": "ClusterOperation",
+          "description": "Output only. The create cluster operation metadata."
+        },
+        "deleteCluster": {
+          "$ref": "ClusterOperation",
+          "description": "Output only. The delete cluster operation metadata."
+        },
+        "graph": {
+          "$ref": "WorkflowGraph",
+          "description": "Output only. The workflow graph."
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map from parameter names to values that were used for those parameters.",
+          "type": "object"
+        },
+        "state": {
+          "description": "Output only. The workflow state.",
+          "enum": [
+            "UNKNOWN",
+            "PENDING",
+            "RUNNING",
+            "DONE"
+          ],
+          "enumDescriptions": [
+            "Unused.",
+            "The operation has been created.",
+            "The operation is running.",
+            "The operation is done; either cancelled or completed."
+          ],
+          "type": "string"
+        },
+        "template": {
+          "description": "Output only. The \"resource name\" of the template.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Output only. The version of template at the time of workflow instantiation.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "WorkflowNode": {
+      "description": "The workflow node.",
+      "id": "WorkflowNode",
+      "properties": {
+        "error": {
+          "description": "Output only. The error detail.",
+          "type": "string"
+        },
+        "jobId": {
+          "description": "Output only. The job id; populated after the node enters RUNNING state.",
+          "type": "string"
+        },
+        "prerequisiteStepIds": {
+          "description": "Output only. Node's prerequisite nodes.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "state": {
+          "description": "Output only. The node state.",
+          "enum": [
+            "NODE_STATE_UNSPECIFIED",
+            "BLOCKED",
+            "RUNNABLE",
+            "RUNNING",
+            "COMPLETED",
+            "FAILED"
+          ],
+          "enumDescriptions": [
+            "State is unspecified.",
+            "The node is awaiting prerequisite node to finish.",
+            "The node is runnable but not running.",
+            "The node is running.",
+            "The node completed successfully.",
+            "The node failed. A node can be marked FAILED because its ancestor or peer failed."
+          ],
+          "type": "string"
+        },
+        "stepId": {
+          "description": "Output only. The name of the node.",
+          "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "YarnApplication": {
       "description": "A YARN application created by a job. Application information is a subset of \u003ccode\u003eorg.apache.hadoop.yarn.proto.YarnProtos.ApplicationReportProto\u003c/code\u003e.Beta Feature: This report is available for testing purposes only. It may be changed before final release.",
-      "type": "object",
+      "id": "YarnApplication",
       "properties": {
+        "name": {
+          "description": "Required. The application name.",
+          "type": "string"
+        },
         "progress": {
-          "format": "float",
           "description": "Required. The numerical progress of the application, from 1 to 100.",
+          "format": "float",
           "type": "number"
         },
         "state": {
           "description": "Required. The application state.",
-          "type": "string",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "NEW",
+            "NEW_SAVING",
+            "SUBMITTED",
+            "ACCEPTED",
+            "RUNNING",
+            "FINISHED",
+            "FAILED",
+            "KILLED"
+          ],
           "enumDescriptions": [
             "Status is unspecified.",
             "Status is NEW.",
@@ -1826,20 +2032,6 @@
             "Status is FAILED.",
             "Status is KILLED."
           ],
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "NEW",
-            "NEW_SAVING",
-            "SUBMITTED",
-            "ACCEPTED",
-            "RUNNING",
-            "FINISHED",
-            "FAILED",
-            "KILLED"
-          ]
-        },
-        "name": {
-          "description": "Required. The application name.",
           "type": "string"
         },
         "trackingUrl": {
@@ -1847,43 +2039,10 @@
           "type": "string"
         }
       },
-      "id": "YarnApplication"
-    },
-    "DiagnoseClusterRequest": {
-      "properties": {},
-      "id": "DiagnoseClusterRequest",
-      "description": "A request to collect cluster diagnostic information.",
       "type": "object"
     }
   },
-  "protocol": "rest",
-  "icons": {
-    "x32": "http://www.google.com/images/icons/product/search-32.gif",
-    "x16": "http://www.google.com/images/icons/product/search-16.gif"
-  },
-  "version": "v1",
-  "baseUrl": "https://dataproc.googleapis.com/",
-  "auth": {
-    "oauth2": {
-      "scopes": {
-        "https://www.googleapis.com/auth/cloud-platform": {
-          "description": "View and manage your data across Google Cloud Platform services"
-        }
-      }
-    }
-  },
-  "description": "Manages Hadoop-based clusters and jobs on Google Cloud Platform.",
   "servicePath": "",
-  "kind": "discovery#restDescription",
-  "rootUrl": "https://dataproc.googleapis.com/",
-  "basePath": "",
-  "ownerDomain": "google.com",
-  "name": "dataproc",
-  "batchPath": "batch",
-  "id": "dataproc:v1",
-  "documentationLink": "https://cloud.google.com/dataproc/",
-  "revision": "20170801",
-  "title": "Google Cloud Dataproc API",
-  "ownerName": "Google",
-  "discoveryVersion": "v1"
+  "title": "Cloud Dataproc API",
+  "version": "v1"
 }

--- a/vendor/google.golang.org/api/dataproc/v1/dataproc-gen.go
+++ b/vendor/google.golang.org/api/dataproc/v1/dataproc-gen.go
@@ -1,4 +1,6 @@
-// Package dataproc provides access to the Google Cloud Dataproc API.
+// Package dataproc provides access to the Cloud Dataproc API.
+//
+// This package is DEPRECATED. Use package cloud.google.com/go/dataproc/apiv1 instead.
 //
 // See https://cloud.google.com/dataproc/
 //
@@ -133,19 +135,24 @@ type ProjectsRegionsOperationsService struct {
 }
 
 // AcceleratorConfig: Specifies the type and number of accelerator cards
-// attached to the instances of an instance group (see GPUs on Compute
-// Engine).
+// attached to the instances of an instance. See GPUs on Compute Engine.
 type AcceleratorConfig struct {
 	// AcceleratorCount: The number of the accelerator cards of this type
 	// exposed to this instance.
 	AcceleratorCount int64 `json:"acceleratorCount,omitempty"`
 
 	// AcceleratorTypeUri: Full URL, partial URI, or short name of the
-	// accelerator type resource to expose to this instance. See Google
-	// Compute Engine AcceleratorTypes(
-	// /compute/docs/reference/beta/acceleratorTypes)Examples *
-	// https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80 * projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80 *
-	// nvidia-tesla-k80
+	// accelerator type resource to expose to this instance. See Compute
+	// Engine
+	// AcceleratorTypes.Examples:
+	// https://www.googleapis.com/compute/beta/pro
+	// jects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
+	//
+	// projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k
+	// 80
+	// nvidia-tesla-k80Auto Zone Exception: If you are using the Cloud
+	// Dataproc Auto Zone Placement feature, you must use the short name of
+	// the accelerator type resource, for example, nvidia-tesla-k80.
 	AcceleratorTypeUri string `json:"acceleratorTypeUri,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "AcceleratorCount") to
@@ -167,8 +174,8 @@ type AcceleratorConfig struct {
 }
 
 func (s *AcceleratorConfig) MarshalJSON() ([]byte, error) {
-	type noMethod AcceleratorConfig
-	raw := noMethod(*s)
+	type NoMethod AcceleratorConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -177,13 +184,13 @@ type CancelJobRequest struct {
 }
 
 // Cluster: Describes the identifying information, config, and status of
-// a cluster of Google Compute Engine instances.
+// a cluster of Compute Engine instances.
 type Cluster struct {
 	// ClusterName: Required. The cluster name. Cluster names within a
 	// project must be unique. Names of deleted clusters can be reused.
 	ClusterName string `json:"clusterName,omitempty"`
 
-	// ClusterUuid: Output-only. A cluster UUID (Unique Universal
+	// ClusterUuid: Output only. A cluster UUID (Unique Universal
 	// Identifier). Cloud Dataproc generates this value when it creates the
 	// cluster.
 	ClusterUuid string `json:"clusterUuid,omitempty"`
@@ -209,10 +216,10 @@ type Cluster struct {
 	// cluster belongs to.
 	ProjectId string `json:"projectId,omitempty"`
 
-	// Status: Output-only. Cluster status.
+	// Status: Output only. Cluster status.
 	Status *ClusterStatus `json:"status,omitempty"`
 
-	// StatusHistory: Output-only. The previous cluster status.
+	// StatusHistory: Output only. The previous cluster status.
 	StatusHistory []*ClusterStatus `json:"statusHistory,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
@@ -237,15 +244,15 @@ type Cluster struct {
 }
 
 func (s *Cluster) MarshalJSON() ([]byte, error) {
-	type noMethod Cluster
-	raw := noMethod(*s)
+	type NoMethod Cluster
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ClusterConfig: The cluster config.
 type ClusterConfig struct {
-	// ConfigBucket: Optional. A Google Cloud Storage staging bucket used
-	// for sharing generated SSH keys and config. If you do not specify a
+	// ConfigBucket: Optional. A Cloud Storage staging bucket used for
+	// sharing generated SSH keys and config. If you do not specify a
 	// staging bucket, Cloud Dataproc will determine an appropriate Cloud
 	// Storage location (US, ASIA, or EU) for your cluster's staging bucket
 	// according to the Google Compute Engine zone where your cluster is
@@ -253,8 +260,8 @@ type ClusterConfig struct {
 	// per-location bucket for you.
 	ConfigBucket string `json:"configBucket,omitempty"`
 
-	// GceClusterConfig: Required. The shared Google Compute Engine config
-	// settings for all instances in a cluster.
+	// GceClusterConfig: Required. The shared Compute Engine config settings
+	// for all instances in a cluster.
 	GceClusterConfig *GceClusterConfig `json:"gceClusterConfig,omitempty"`
 
 	// InitializationActions: Optional. Commands to execute on each node
@@ -273,20 +280,20 @@ type ClusterConfig struct {
 	//
 	InitializationActions []*NodeInitializationAction `json:"initializationActions,omitempty"`
 
-	// MasterConfig: Optional. The Google Compute Engine config settings for
-	// the master instance in a cluster.
+	// MasterConfig: Optional. The Compute Engine config settings for the
+	// master instance in a cluster.
 	MasterConfig *InstanceGroupConfig `json:"masterConfig,omitempty"`
 
-	// SecondaryWorkerConfig: Optional. The Google Compute Engine config
-	// settings for additional worker instances in a cluster.
+	// SecondaryWorkerConfig: Optional. The Compute Engine config settings
+	// for additional worker instances in a cluster.
 	SecondaryWorkerConfig *InstanceGroupConfig `json:"secondaryWorkerConfig,omitempty"`
 
 	// SoftwareConfig: Optional. The config settings for software inside the
 	// cluster.
 	SoftwareConfig *SoftwareConfig `json:"softwareConfig,omitempty"`
 
-	// WorkerConfig: Optional. The Google Compute Engine config settings for
-	// worker instances in a cluster.
+	// WorkerConfig: Optional. The Compute Engine config settings for worker
+	// instances in a cluster.
 	WorkerConfig *InstanceGroupConfig `json:"workerConfig,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "ConfigBucket") to
@@ -307,8 +314,8 @@ type ClusterConfig struct {
 }
 
 func (s *ClusterConfig) MarshalJSON() ([]byte, error) {
-	type noMethod ClusterConfig
-	raw := noMethod(*s)
+	type NoMethod ClusterConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -340,35 +347,69 @@ type ClusterMetrics struct {
 }
 
 func (s *ClusterMetrics) MarshalJSON() ([]byte, error) {
-	type noMethod ClusterMetrics
-	raw := noMethod(*s)
+	type NoMethod ClusterMetrics
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ClusterOperation: The cluster operation triggered by a workflow.
+type ClusterOperation struct {
+	// Done: Output only. Indicates the operation is done.
+	Done bool `json:"done,omitempty"`
+
+	// Error: Output only. Error, if operation failed.
+	Error string `json:"error,omitempty"`
+
+	// OperationId: Output only. The id of the cluster operation.
+	OperationId string `json:"operationId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Done") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Done") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ClusterOperation) MarshalJSON() ([]byte, error) {
+	type NoMethod ClusterOperation
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ClusterOperationMetadata: Metadata describing the operation.
 type ClusterOperationMetadata struct {
-	// ClusterName: Output-only. Name of the cluster for the operation.
+	// ClusterName: Output only. Name of the cluster for the operation.
 	ClusterName string `json:"clusterName,omitempty"`
 
-	// ClusterUuid: Output-only. Cluster UUID for the operation.
+	// ClusterUuid: Output only. Cluster UUID for the operation.
 	ClusterUuid string `json:"clusterUuid,omitempty"`
 
-	// Description: Output-only. Short description of operation.
+	// Description: Output only. Short description of operation.
 	Description string `json:"description,omitempty"`
 
-	// Labels: Output-only. Labels associated with the operation
+	// Labels: Output only. Labels associated with the operation
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// OperationType: Output-only. The operation type.
+	// OperationType: Output only. The operation type.
 	OperationType string `json:"operationType,omitempty"`
 
-	// Status: Output-only. Current operation status.
+	// Status: Output only. Current operation status.
 	Status *ClusterOperationStatus `json:"status,omitempty"`
 
-	// StatusHistory: Output-only. The previous operation status.
+	// StatusHistory: Output only. The previous operation status.
 	StatusHistory []*ClusterOperationStatus `json:"statusHistory,omitempty"`
 
-	// Warnings: Output-only. Errors encountered during operation execution.
+	// Warnings: Output only. Errors encountered during operation execution.
 	Warnings []string `json:"warnings,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "ClusterName") to
@@ -389,22 +430,22 @@ type ClusterOperationMetadata struct {
 }
 
 func (s *ClusterOperationMetadata) MarshalJSON() ([]byte, error) {
-	type noMethod ClusterOperationMetadata
-	raw := noMethod(*s)
+	type NoMethod ClusterOperationMetadata
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ClusterOperationStatus: The status of the operation.
 type ClusterOperationStatus struct {
-	// Details: Output-only.A message containing any operation metadata
+	// Details: Output only. A message containing any operation metadata
 	// details.
 	Details string `json:"details,omitempty"`
 
-	// InnerState: Output-only. A message containing the detailed operation
+	// InnerState: Output only. A message containing the detailed operation
 	// state.
 	InnerState string `json:"innerState,omitempty"`
 
-	// State: Output-only. A message containing the operation state.
+	// State: Output only. A message containing the operation state.
 	//
 	// Possible values:
 	//   "UNKNOWN" - Unused.
@@ -413,7 +454,7 @@ type ClusterOperationStatus struct {
 	//   "DONE" - The operation is done; either cancelled or completed.
 	State string `json:"state,omitempty"`
 
-	// StateStartTime: Output-only. The time this state was entered.
+	// StateStartTime: Output only. The time this state was entered.
 	StateStartTime string `json:"stateStartTime,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "Details") to
@@ -434,17 +475,17 @@ type ClusterOperationStatus struct {
 }
 
 func (s *ClusterOperationStatus) MarshalJSON() ([]byte, error) {
-	type noMethod ClusterOperationStatus
-	raw := noMethod(*s)
+	type NoMethod ClusterOperationStatus
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ClusterStatus: The status of a cluster and its instances.
 type ClusterStatus struct {
-	// Detail: Output-only. Optional details of cluster's state.
+	// Detail: Output only. Optional details of cluster's state.
 	Detail string `json:"detail,omitempty"`
 
-	// State: Output-only. The cluster's state.
+	// State: Output only. The cluster's state.
 	//
 	// Possible values:
 	//   "UNKNOWN" - The cluster state is unknown.
@@ -459,14 +500,14 @@ type ClusterStatus struct {
 	// and process jobs.
 	State string `json:"state,omitempty"`
 
-	// StateStartTime: Output-only. Time when this state was entered.
+	// StateStartTime: Output only. Time when this state was entered.
 	StateStartTime string `json:"stateStartTime,omitempty"`
 
-	// Substate: Output-only. Additional state information that includes
+	// Substate: Output only. Additional state information that includes
 	// status reported by the agent.
 	//
 	// Possible values:
-	//   "UNSPECIFIED"
+	//   "UNSPECIFIED" - The cluster substate is unknown.
 	//   "UNHEALTHY" - The cluster is known to be in an unhealthy state (for
 	// example, critical daemons are not running or HDFS capacity is
 	// exhausted).Applies to RUNNING state.
@@ -493,8 +534,8 @@ type ClusterStatus struct {
 }
 
 func (s *ClusterStatus) MarshalJSON() ([]byte, error) {
-	type noMethod ClusterStatus
-	raw := noMethod(*s)
+	type NoMethod ClusterStatus
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -505,9 +546,9 @@ type DiagnoseClusterRequest struct {
 
 // DiagnoseClusterResults: The location of diagnostic output.
 type DiagnoseClusterResults struct {
-	// OutputUri: Output-only. The Google Cloud Storage URI of the
-	// diagnostic output. The output report is a plain text file with a
-	// summary of collected diagnostics.
+	// OutputUri: Output only. The Cloud Storage URI of the diagnostic
+	// output. The output report is a plain text file with a summary of
+	// collected diagnostics.
 	OutputUri string `json:"outputUri,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "OutputUri") to
@@ -528,8 +569,8 @@ type DiagnoseClusterResults struct {
 }
 
 func (s *DiagnoseClusterResults) MarshalJSON() ([]byte, error) {
-	type noMethod DiagnoseClusterResults
-	raw := noMethod(*s)
+	type NoMethod DiagnoseClusterResults
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -539,6 +580,11 @@ type DiskConfig struct {
 	// BootDiskSizeGb: Optional. Size in GB of the boot disk (default is
 	// 500GB).
 	BootDiskSizeGb int64 `json:"bootDiskSizeGb,omitempty"`
+
+	// BootDiskType: Optional. Type of the boot disk (default is
+	// "pd-standard"). Valid values: "pd-ssd" (Persistent Disk Solid State
+	// Drive) or "pd-standard" (Persistent Disk Hard Disk Drive).
+	BootDiskType string `json:"bootDiskType,omitempty"`
 
 	// NumLocalSsds: Optional. Number of attached SSDs, from 0 to 4 (default
 	// is 0). If SSDs are not attached, the boot disk is used to store
@@ -568,8 +614,8 @@ type DiskConfig struct {
 }
 
 func (s *DiskConfig) MarshalJSON() ([]byte, error) {
-	type noMethod DiskConfig
-	raw := noMethod(*s)
+	type NoMethod DiskConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -588,9 +634,8 @@ type Empty struct {
 	googleapi.ServerResponse `json:"-"`
 }
 
-// GceClusterConfig: Common config settings for resources of Google
-// Compute Engine cluster instances, applicable to all instances in the
-// cluster.
+// GceClusterConfig: Common config settings for resources of Compute
+// Engine cluster instances, applicable to all instances in the cluster.
 type GceClusterConfig struct {
 	// InternalIpOnly: Optional. If true, all instances in the cluster will
 	// only have internal IP addresses. By default, clusters are not
@@ -601,15 +646,15 @@ type GceClusterConfig struct {
 	// without external IP addresses.
 	InternalIpOnly bool `json:"internalIpOnly,omitempty"`
 
-	// Metadata: The Google Compute Engine metadata entries to add to all
-	// instances (see Project and instance metadata
+	// Metadata: The Compute Engine metadata entries to add to all instances
+	// (see Project and instance metadata
 	// (https://cloud.google.com/compute/docs/storing-retrieving-metadata#pro
 	// ject_and_instance_metadata)).
 	Metadata map[string]string `json:"metadata,omitempty"`
 
-	// NetworkUri: Optional. The Google Compute Engine network to be used
-	// for machine communications. Cannot be specified with subnetwork_uri.
-	// If neither network_uri nor subnetwork_uri is specified, the "default"
+	// NetworkUri: Optional. The Compute Engine network to be used for
+	// machine communications. Cannot be specified with subnetwork_uri. If
+	// neither network_uri nor subnetwork_uri is specified, the "default"
 	// network of the project is used, if it exists. Cannot be a "Custom
 	// Subnet Network" (see Using Subnetworks for more information).A full
 	// URL, partial URI, or short name are valid.
@@ -622,8 +667,8 @@ type GceClusterConfig struct {
 	NetworkUri string `json:"networkUri,omitempty"`
 
 	// ServiceAccount: Optional. The service account of the instances.
-	// Defaults to the default Google Compute Engine service account. Custom
-	// service accounts need permissions equivalent to the folloing IAM
+	// Defaults to the default Compute Engine service account. Custom
+	// service accounts need permissions equivalent to the following IAM
 	// roles:
 	// roles/logging.logWriter
 	// roles/storage.objectAdmin(see
@@ -632,8 +677,8 @@ type GceClusterConfig struct {
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 
 	// ServiceAccountScopes: Optional. The URIs of service account scopes to
-	// be included in Google Compute Engine instances. The following base
-	// set of scopes is always
+	// be included in Compute Engine instances. The following base set of
+	// scopes is always
 	// included:
 	// https://www.googleapis.com/auth/cloud.useraccounts.readonly
 	//
@@ -650,9 +695,9 @@ type GceClusterConfig struct {
 	// https://www.googleapis.com/auth/devstorage.full_control
 	ServiceAccountScopes []string `json:"serviceAccountScopes,omitempty"`
 
-	// SubnetworkUri: Optional. The Google Compute Engine subnetwork to be
-	// used for machine communications. Cannot be specified with
-	// network_uri.A full URL, partial URI, or short name are valid.
+	// SubnetworkUri: Optional. The Compute Engine subnetwork to be used for
+	// machine communications. Cannot be specified with network_uri.A full
+	// URL, partial URI, or short name are valid.
 	// Examples:
 	// https://www.googleapis.com/compute/v1/projects/[project_id]/
 	// regions/us-east1/sub0
@@ -660,14 +705,14 @@ type GceClusterConfig struct {
 	// sub0
 	SubnetworkUri string `json:"subnetworkUri,omitempty"`
 
-	// Tags: The Google Compute Engine tags to add to all instances (see
-	// Tagging instances).
+	// Tags: The Compute Engine tags to add to all instances (see Tagging
+	// instances).
 	Tags []string `json:"tags,omitempty"`
 
-	// ZoneUri: Optional. The zone where the Google Compute Engine cluster
-	// will be located. On a create request, it is required in the "global"
-	// region. If omitted in a non-global Cloud Dataproc region, the service
-	// will pick a zone in the corresponding Compute Engine region. On a get
+	// ZoneUri: Optional. The zone where the Compute Engine cluster will be
+	// located. On a create request, it is required in the "global" region.
+	// If omitted in a non-global Cloud Dataproc region, the service will
+	// pick a zone in the corresponding Compute Engine region. On a get
 	// request, zone will always be present.A full URL, partial URI, or
 	// short name are valid.
 	// Examples:
@@ -696,8 +741,8 @@ type GceClusterConfig struct {
 }
 
 func (s *GceClusterConfig) MarshalJSON() ([]byte, error) {
-	type noMethod GceClusterConfig
-	raw := noMethod(*s)
+	type NoMethod GceClusterConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -767,8 +812,8 @@ type HadoopJob struct {
 }
 
 func (s *HadoopJob) MarshalJSON() ([]byte, error) {
-	type noMethod HadoopJob
-	raw := noMethod(*s)
+	type NoMethod HadoopJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -821,49 +866,49 @@ type HiveJob struct {
 }
 
 func (s *HiveJob) MarshalJSON() ([]byte, error) {
-	type noMethod HiveJob
-	raw := noMethod(*s)
+	type NoMethod HiveJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
-// InstanceGroupConfig: Optional. The config settings for Google Compute
-// Engine resources in an instance group, such as a master or worker
-// group.
+// InstanceGroupConfig: Optional. The config settings for Compute Engine
+// resources in an instance group, such as a master or worker group.
 type InstanceGroupConfig struct {
-	// Accelerators: Optional. The Google Compute Engine accelerator
-	// configuration for these instances.Beta Feature: This feature is still
-	// under development. It may be changed before final release.
+	// Accelerators: Optional. The Compute Engine accelerator configuration
+	// for these instances.Beta Feature: This feature is still under
+	// development. It may be changed before final release.
 	Accelerators []*AcceleratorConfig `json:"accelerators,omitempty"`
 
 	// DiskConfig: Optional. Disk option config settings.
 	DiskConfig *DiskConfig `json:"diskConfig,omitempty"`
 
-	// ImageUri: Output-only. The Google Compute Engine image resource used
-	// for cluster instances. Inferred from SoftwareConfig.image_version.
+	// ImageUri: Optional. The Compute Engine image resource used for
+	// cluster instances. It can be specified or may be inferred from
+	// SoftwareConfig.image_version.
 	ImageUri string `json:"imageUri,omitempty"`
 
-	// InstanceNames: Optional. The list of instance names. Cloud Dataproc
-	// derives the names from cluster_name, num_instances, and the instance
-	// group if not set by user (recommended practice is to let Cloud
-	// Dataproc derive the name).
+	// InstanceNames: Output only. The list of instance names. Cloud
+	// Dataproc derives the names from cluster_name, num_instances, and the
+	// instance group.
 	InstanceNames []string `json:"instanceNames,omitempty"`
 
 	// IsPreemptible: Optional. Specifies that this instance group contains
 	// preemptible instances.
 	IsPreemptible bool `json:"isPreemptible,omitempty"`
 
-	// MachineTypeUri: Optional. The Google Compute Engine machine type used
-	// for cluster instances.A full URL, partial URI, or short name are
-	// valid.
+	// MachineTypeUri: Optional. The Compute Engine machine type used for
+	// cluster instances.A full URL, partial URI, or short name are valid.
 	// Examples:
 	// https://www.googleapis.com/compute/v1/projects/[project_id]/
 	// zones/us-east1-a/machineTypes/n1-standard-2
 	// projects/[project_id]/zone
 	// s/us-east1-a/machineTypes/n1-standard-2
-	// n1-standard-2
+	// n1-standard-2Auto Zone Exception: If you are using the Cloud Dataproc
+	// Auto Zone Placement feature, you must use the short name of the
+	// machine type resource, for example, n1-standard-2.
 	MachineTypeUri string `json:"machineTypeUri,omitempty"`
 
-	// ManagedGroupConfig: Output-only. The config for Google Compute Engine
+	// ManagedGroupConfig: Output only. The config for Compute Engine
 	// Instance Group Manager that manages this group. This is only used for
 	// preemptible instance groups.
 	ManagedGroupConfig *ManagedGroupConfig `json:"managedGroupConfig,omitempty"`
@@ -890,20 +935,20 @@ type InstanceGroupConfig struct {
 }
 
 func (s *InstanceGroupConfig) MarshalJSON() ([]byte, error) {
-	type noMethod InstanceGroupConfig
-	raw := noMethod(*s)
+	type NoMethod InstanceGroupConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // Job: A Cloud Dataproc job resource.
 type Job struct {
-	// DriverControlFilesUri: Output-only. If present, the location of
+	// DriverControlFilesUri: Output only. If present, the location of
 	// miscellaneous control files which may be used as part of job setup
 	// and handling. If not present, control files may be placed in the same
 	// location as driver_output_uri.
 	DriverControlFilesUri string `json:"driverControlFilesUri,omitempty"`
 
-	// DriverOutputResourceUri: Output-only. A URI pointing to the location
+	// DriverOutputResourceUri: Output only. A URI pointing to the location
 	// of the stdout of the job's driver program.
 	DriverOutputResourceUri string `json:"driverOutputResourceUri,omitempty"`
 
@@ -946,15 +991,15 @@ type Job struct {
 	// SparkSqlJob: Job is a SparkSql job.
 	SparkSqlJob *SparkSqlJob `json:"sparkSqlJob,omitempty"`
 
-	// Status: Output-only. The job status. Additional application-specific
+	// Status: Output only. The job status. Additional application-specific
 	// status information may be contained in the <code>type_job</code> and
 	// <code>yarn_applications</code> fields.
 	Status *JobStatus `json:"status,omitempty"`
 
-	// StatusHistory: Output-only. The previous job status.
+	// StatusHistory: Output only. The previous job status.
 	StatusHistory []*JobStatus `json:"statusHistory,omitempty"`
 
-	// YarnApplications: Output-only. The collection of YARN applications
+	// YarnApplications: Output only. The collection of YARN applications
 	// spun up by this job.Beta Feature: This report is available for
 	// testing purposes only. It may be changed before final release.
 	YarnApplications []*YarnApplication `json:"yarnApplications,omitempty"`
@@ -983,8 +1028,8 @@ type Job struct {
 }
 
 func (s *Job) MarshalJSON() ([]byte, error) {
-	type noMethod Job
-	raw := noMethod(*s)
+	type NoMethod Job
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -994,7 +1039,7 @@ type JobPlacement struct {
 	// submitted.
 	ClusterName string `json:"clusterName,omitempty"`
 
-	// ClusterUuid: Output-only. A cluster UUID generated by the Cloud
+	// ClusterUuid: Output only. A cluster UUID generated by the Cloud
 	// Dataproc service when the job is submitted.
 	ClusterUuid string `json:"clusterUuid,omitempty"`
 
@@ -1016,8 +1061,8 @@ type JobPlacement struct {
 }
 
 func (s *JobPlacement) MarshalJSON() ([]byte, error) {
-	type noMethod JobPlacement
-	raw := noMethod(*s)
+	type NoMethod JobPlacement
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1053,14 +1098,12 @@ type JobReference struct {
 }
 
 func (s *JobReference) MarshalJSON() ([]byte, error) {
-	type noMethod JobReference
-	raw := noMethod(*s)
+	type NoMethod JobReference
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
-// JobScheduling: Job scheduling options.Beta Feature: These options are
-// available for testing purposes only. They may be changed before final
-// release.
+// JobScheduling: Job scheduling options.
 type JobScheduling struct {
 	// MaxFailuresPerHour: Optional. Maximum number of times per hour a
 	// driver may be restarted as a result of driver terminating with
@@ -1088,18 +1131,18 @@ type JobScheduling struct {
 }
 
 func (s *JobScheduling) MarshalJSON() ([]byte, error) {
-	type noMethod JobScheduling
-	raw := noMethod(*s)
+	type NoMethod JobScheduling
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // JobStatus: Cloud Dataproc job status.
 type JobStatus struct {
-	// Details: Output-only. Optional job state details, such as an error
+	// Details: Output only. Optional job state details, such as an error
 	// description if the state is <code>ERROR</code>.
 	Details string `json:"details,omitempty"`
 
-	// State: Output-only. A state message specifying the overall job state.
+	// State: Output only. A state message specifying the overall job state.
 	//
 	// Possible values:
 	//   "STATE_UNSPECIFIED" - The job state is unknown.
@@ -1121,14 +1164,14 @@ type JobStatus struct {
 	// only.
 	State string `json:"state,omitempty"`
 
-	// StateStartTime: Output-only. The time when this state was entered.
+	// StateStartTime: Output only. The time when this state was entered.
 	StateStartTime string `json:"stateStartTime,omitempty"`
 
-	// Substate: Output-only. Additional state information, which includes
+	// Substate: Output only. Additional state information, which includes
 	// status reported by the agent.
 	//
 	// Possible values:
-	//   "UNSPECIFIED"
+	//   "UNSPECIFIED" - The job substate is unknown.
 	//   "SUBMITTED" - The Job is submitted to the agent.Applies to RUNNING
 	// state.
 	//   "QUEUED" - The Job has been received and is awaiting execution (it
@@ -1158,17 +1201,17 @@ type JobStatus struct {
 }
 
 func (s *JobStatus) MarshalJSON() ([]byte, error) {
-	type noMethod JobStatus
-	raw := noMethod(*s)
+	type NoMethod JobStatus
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ListClustersResponse: The list of all clusters in a project.
 type ListClustersResponse struct {
-	// Clusters: Output-only. The clusters in the project.
+	// Clusters: Output only. The clusters in the project.
 	Clusters []*Cluster `json:"clusters,omitempty"`
 
-	// NextPageToken: Output-only. This token is included in the response if
+	// NextPageToken: Output only. This token is included in the response if
 	// there are more results to fetch. To fetch additional results, provide
 	// this value as the page_token in a subsequent ListClustersRequest.
 	NextPageToken string `json:"nextPageToken,omitempty"`
@@ -1195,14 +1238,14 @@ type ListClustersResponse struct {
 }
 
 func (s *ListClustersResponse) MarshalJSON() ([]byte, error) {
-	type noMethod ListClustersResponse
-	raw := noMethod(*s)
+	type NoMethod ListClustersResponse
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ListJobsResponse: A list of jobs in a project.
 type ListJobsResponse struct {
-	// Jobs: Output-only. Jobs list.
+	// Jobs: Output only. Jobs list.
 	Jobs []*Job `json:"jobs,omitempty"`
 
 	// NextPageToken: Optional. This token is included in the response if
@@ -1233,8 +1276,8 @@ type ListJobsResponse struct {
 }
 
 func (s *ListJobsResponse) MarshalJSON() ([]byte, error) {
-	type noMethod ListJobsResponse
-	raw := noMethod(*s)
+	type NoMethod ListJobsResponse
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1270,8 +1313,8 @@ type ListOperationsResponse struct {
 }
 
 func (s *ListOperationsResponse) MarshalJSON() ([]byte, error) {
-	type noMethod ListOperationsResponse
-	raw := noMethod(*s)
+	type NoMethod ListOperationsResponse
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1301,19 +1344,19 @@ type LoggingConfig struct {
 }
 
 func (s *LoggingConfig) MarshalJSON() ([]byte, error) {
-	type noMethod LoggingConfig
-	raw := noMethod(*s)
+	type NoMethod LoggingConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // ManagedGroupConfig: Specifies the resources used to actively manage
 // an instance group.
 type ManagedGroupConfig struct {
-	// InstanceGroupManagerName: Output-only. The name of the Instance Group
+	// InstanceGroupManagerName: Output only. The name of the Instance Group
 	// Manager for this group.
 	InstanceGroupManagerName string `json:"instanceGroupManagerName,omitempty"`
 
-	// InstanceTemplateName: Output-only. The name of the Instance Template
+	// InstanceTemplateName: Output only. The name of the Instance Template
 	// used for the Managed Instance Group.
 	InstanceTemplateName string `json:"instanceTemplateName,omitempty"`
 
@@ -1337,16 +1380,15 @@ type ManagedGroupConfig struct {
 }
 
 func (s *ManagedGroupConfig) MarshalJSON() ([]byte, error) {
-	type noMethod ManagedGroupConfig
-	raw := noMethod(*s)
+	type NoMethod ManagedGroupConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 // NodeInitializationAction: Specifies an executable to run on a fully
 // configured node and a timeout period for executable completion.
 type NodeInitializationAction struct {
-	// ExecutableFile: Required. Google Cloud Storage URI of executable
-	// file.
+	// ExecutableFile: Required. Cloud Storage URI of executable file.
 	ExecutableFile string `json:"executableFile,omitempty"`
 
 	// ExecutionTimeout: Optional. Amount of time executable has to
@@ -1375,8 +1417,8 @@ type NodeInitializationAction struct {
 }
 
 func (s *NodeInitializationAction) MarshalJSON() ([]byte, error) {
-	type noMethod NodeInitializationAction
-	raw := noMethod(*s)
+	type NoMethod NodeInitializationAction
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1436,8 +1478,8 @@ type Operation struct {
 }
 
 func (s *Operation) MarshalJSON() ([]byte, error) {
-	type noMethod Operation
-	raw := noMethod(*s)
+	type NoMethod Operation
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1494,8 +1536,8 @@ type PigJob struct {
 }
 
 func (s *PigJob) MarshalJSON() ([]byte, error) {
-	type noMethod PigJob
-	raw := noMethod(*s)
+	type NoMethod PigJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1556,8 +1598,8 @@ type PySparkJob struct {
 }
 
 func (s *PySparkJob) MarshalJSON() ([]byte, error) {
-	type noMethod PySparkJob
-	raw := noMethod(*s)
+	type NoMethod PySparkJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1598,8 +1640,8 @@ type QueryList struct {
 }
 
 func (s *QueryList) MarshalJSON() ([]byte, error) {
-	type noMethod QueryList
-	raw := noMethod(*s)
+	type NoMethod QueryList
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1607,8 +1649,9 @@ func (s *QueryList) MarshalJSON() ([]byte, error) {
 // the cluster.
 type SoftwareConfig struct {
 	// ImageVersion: Optional. The version of software inside the cluster.
-	// It must match the regular expression [0-9]+\.[0-9]+. If unspecified,
-	// it defaults to the latest version (see Cloud Dataproc Versioning).
+	// It must be one of the supported Cloud Dataproc Versions, such as
+	// "1.2" (including a subminor version, such as "1.2.29"), or the
+	// "preview" version. If unspecified, it defaults to the latest version.
 	ImageVersion string `json:"imageVersion,omitempty"`
 
 	// Properties: Optional. The properties to set on daemon config
@@ -1623,7 +1666,7 @@ type SoftwareConfig struct {
 	// mapred: mapred-site.xml
 	// pig: pig.properties
 	// spark: spark-defaults.conf
-	// yarn: yarn-site.xml
+	// yarn: yarn-site.xmlFor more information, see Cluster properties.
 	Properties map[string]string `json:"properties,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "ImageVersion") to
@@ -1644,8 +1687,8 @@ type SoftwareConfig struct {
 }
 
 func (s *SoftwareConfig) MarshalJSON() ([]byte, error) {
-	type noMethod SoftwareConfig
-	raw := noMethod(*s)
+	type NoMethod SoftwareConfig
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1707,8 +1750,8 @@ type SparkJob struct {
 }
 
 func (s *SparkJob) MarshalJSON() ([]byte, error) {
-	type noMethod SparkJob
-	raw := noMethod(*s)
+	type NoMethod SparkJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1755,8 +1798,8 @@ type SparkSqlJob struct {
 }
 
 func (s *SparkSqlJob) MarshalJSON() ([]byte, error) {
-	type noMethod SparkSqlJob
-	raw := noMethod(*s)
+	type NoMethod SparkSqlJob
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1831,8 +1874,8 @@ type Status struct {
 }
 
 func (s *Status) MarshalJSON() ([]byte, error) {
-	type noMethod Status
-	raw := noMethod(*s)
+	type NoMethod Status
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1840,6 +1883,16 @@ func (s *Status) MarshalJSON() ([]byte, error) {
 type SubmitJobRequest struct {
 	// Job: Required. The job resource.
 	Job *Job `json:"job,omitempty"`
+
+	// RequestId: Optional. A unique id used to identify the request. If the
+	// server receives two SubmitJobRequest requests with the same id, then
+	// the second request will be ignored and the first Job created and
+	// stored in the backend is returned.It is recommended to always set
+	// this value to a UUID
+	// (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id
+	// must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+	// and hyphens (-). The maximum length is 40 characters.
+	RequestId string `json:"requestId,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "Job") to
 	// unconditionally include in API requests. By default, fields with
@@ -1859,8 +1912,143 @@ type SubmitJobRequest struct {
 }
 
 func (s *SubmitJobRequest) MarshalJSON() ([]byte, error) {
-	type noMethod SubmitJobRequest
-	raw := noMethod(*s)
+	type NoMethod SubmitJobRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkflowGraph: The workflow graph.
+type WorkflowGraph struct {
+	// Nodes: Output only. The workflow nodes.
+	Nodes []*WorkflowNode `json:"nodes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Nodes") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Nodes") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkflowGraph) MarshalJSON() ([]byte, error) {
+	type NoMethod WorkflowGraph
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkflowMetadata: A Cloud Dataproc workflow template resource.
+type WorkflowMetadata struct {
+	// ClusterName: Output only. The name of the managed cluster.
+	ClusterName string `json:"clusterName,omitempty"`
+
+	// CreateCluster: Output only. The create cluster operation metadata.
+	CreateCluster *ClusterOperation `json:"createCluster,omitempty"`
+
+	// DeleteCluster: Output only. The delete cluster operation metadata.
+	DeleteCluster *ClusterOperation `json:"deleteCluster,omitempty"`
+
+	// Graph: Output only. The workflow graph.
+	Graph *WorkflowGraph `json:"graph,omitempty"`
+
+	// Parameters: Map from parameter names to values that were used for
+	// those parameters.
+	Parameters map[string]string `json:"parameters,omitempty"`
+
+	// State: Output only. The workflow state.
+	//
+	// Possible values:
+	//   "UNKNOWN" - Unused.
+	//   "PENDING" - The operation has been created.
+	//   "RUNNING" - The operation is running.
+	//   "DONE" - The operation is done; either cancelled or completed.
+	State string `json:"state,omitempty"`
+
+	// Template: Output only. The "resource name" of the template.
+	Template string `json:"template,omitempty"`
+
+	// Version: Output only. The version of template at the time of workflow
+	// instantiation.
+	Version int64 `json:"version,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ClusterName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ClusterName") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkflowMetadata) MarshalJSON() ([]byte, error) {
+	type NoMethod WorkflowMetadata
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkflowNode: The workflow node.
+type WorkflowNode struct {
+	// Error: Output only. The error detail.
+	Error string `json:"error,omitempty"`
+
+	// JobId: Output only. The job id; populated after the node enters
+	// RUNNING state.
+	JobId string `json:"jobId,omitempty"`
+
+	// PrerequisiteStepIds: Output only. Node's prerequisite nodes.
+	PrerequisiteStepIds []string `json:"prerequisiteStepIds,omitempty"`
+
+	// State: Output only. The node state.
+	//
+	// Possible values:
+	//   "NODE_STATE_UNSPECIFIED" - State is unspecified.
+	//   "BLOCKED" - The node is awaiting prerequisite node to finish.
+	//   "RUNNABLE" - The node is runnable but not running.
+	//   "RUNNING" - The node is running.
+	//   "COMPLETED" - The node completed successfully.
+	//   "FAILED" - The node failed. A node can be marked FAILED because its
+	// ancestor or peer failed.
+	State string `json:"state,omitempty"`
+
+	// StepId: Output only. The name of the node.
+	StepId string `json:"stepId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Error") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Error") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkflowNode) MarshalJSON() ([]byte, error) {
+	type NoMethod WorkflowNode
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
@@ -1915,18 +2103,18 @@ type YarnApplication struct {
 }
 
 func (s *YarnApplication) MarshalJSON() ([]byte, error) {
-	type noMethod YarnApplication
-	raw := noMethod(*s)
+	type NoMethod YarnApplication
+	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
 func (s *YarnApplication) UnmarshalJSON(data []byte) error {
-	type noMethod YarnApplication
+	type NoMethod YarnApplication
 	var s1 struct {
 		Progress gensupport.JSONFloat64 `json:"progress"`
-		*noMethod
+		*NoMethod
 	}
-	s1.noMethod = (*noMethod)(s)
+	s1.NoMethod = (*NoMethod)(s)
 	if err := json.Unmarshal(data, &s1); err != nil {
 		return err
 	}
@@ -1952,6 +2140,20 @@ func (r *ProjectsRegionsClustersService) Create(projectId string, region string,
 	c.projectId = projectId
 	c.region = region
 	c.cluster = cluster
+	return c
+}
+
+// RequestId sets the optional parameter "requestId": A unique id used
+// to identify the request. If the server receives two
+// CreateClusterRequest requests with the same id, then the second
+// request will be ignored and the first google.longrunning.Operation
+// created and stored in the backend is returned.It is recommended to
+// always set this value to a UUID
+// (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id
+// must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+// and hyphens (-). The maximum length is 40 characters.
+func (c *ProjectsRegionsClustersCreateCall) RequestId(requestId string) *ProjectsRegionsClustersCreateCall {
+	c.urlParams_.Set("requestId", requestId)
 	return c
 }
 
@@ -2037,7 +2239,7 @@ func (c *ProjectsRegionsClustersCreateCall) Do(opts ...googleapi.CallOption) (*O
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2061,6 +2263,11 @@ func (c *ProjectsRegionsClustersCreateCall) Do(opts ...googleapi.CallOption) (*O
 	//       "description": "Required. The Cloud Dataproc region in which to handle the request.",
 	//       "location": "path",
 	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "requestId": {
+	//       "description": "Optional. A unique id used to identify the request. If the server receives two CreateClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+	//       "location": "query",
 	//       "type": "string"
 	//     }
 	//   },
@@ -2096,6 +2303,28 @@ func (r *ProjectsRegionsClustersService) Delete(projectId string, region string,
 	c.projectId = projectId
 	c.region = region
 	c.clusterName = clusterName
+	return c
+}
+
+// ClusterUuid sets the optional parameter "clusterUuid": Specifying the
+// cluster_uuid means the RPC should fail (with error NOT_FOUND) if
+// cluster with specified UUID does not exist.
+func (c *ProjectsRegionsClustersDeleteCall) ClusterUuid(clusterUuid string) *ProjectsRegionsClustersDeleteCall {
+	c.urlParams_.Set("clusterUuid", clusterUuid)
+	return c
+}
+
+// RequestId sets the optional parameter "requestId": A unique id used
+// to identify the request. If the server receives two
+// DeleteClusterRequest requests with the same id, then the second
+// request will be ignored and the first google.longrunning.Operation
+// created and stored in the backend is returned.It is recommended to
+// always set this value to a UUID
+// (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id
+// must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+// and hyphens (-). The maximum length is 40 characters.
+func (c *ProjectsRegionsClustersDeleteCall) RequestId(requestId string) *ProjectsRegionsClustersDeleteCall {
+	c.urlParams_.Set("requestId", requestId)
 	return c
 }
 
@@ -2177,7 +2406,7 @@ func (c *ProjectsRegionsClustersDeleteCall) Do(opts ...googleapi.CallOption) (*O
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2198,6 +2427,11 @@ func (c *ProjectsRegionsClustersDeleteCall) Do(opts ...googleapi.CallOption) (*O
 	//       "required": true,
 	//       "type": "string"
 	//     },
+	//     "clusterUuid": {
+	//       "description": "Optional. Specifying the cluster_uuid means the RPC should fail (with error NOT_FOUND) if cluster with specified UUID does not exist.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
 	//     "projectId": {
 	//       "description": "Required. The ID of the Google Cloud Platform project that the cluster belongs to.",
 	//       "location": "path",
@@ -2208,6 +2442,11 @@ func (c *ProjectsRegionsClustersDeleteCall) Do(opts ...googleapi.CallOption) (*O
 	//       "description": "Required. The Cloud Dataproc region in which to handle the request.",
 	//       "location": "path",
 	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "requestId": {
+	//       "description": "Optional. A unique id used to identify the request. If the server receives two DeleteClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+	//       "location": "query",
 	//       "type": "string"
 	//     }
 	//   },
@@ -2330,7 +2569,7 @@ func (c *ProjectsRegionsClustersDiagnoseCall) Do(opts ...googleapi.CallOption) (
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2491,7 +2730,7 @@ func (c *ProjectsRegionsClustersGetCall) Do(opts ...googleapi.CallOption) (*Clus
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2678,7 +2917,7 @@ func (c *ProjectsRegionsClustersListCall) Do(opts ...googleapi.CallOption) (*Lis
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2773,6 +3012,33 @@ func (r *ProjectsRegionsClustersService) Patch(projectId string, region string, 
 	c.region = region
 	c.clusterName = clusterName
 	c.cluster = cluster
+	return c
+}
+
+// GracefulDecommissionTimeout sets the optional parameter
+// "gracefulDecommissionTimeout": Timeout for graceful YARN
+// decomissioning. Graceful decommissioning allows removing nodes from
+// the cluster without interrupting jobs in progress. Timeout specifies
+// how long to wait for jobs in progress to finish before forcefully
+// removing nodes (and potentially interrupting jobs). Default timeout
+// is 0 (for forceful decommission), and the maximum allowed timeout is
+// 1 day.Only supported on Dataproc image versions 1.2 and higher.
+func (c *ProjectsRegionsClustersPatchCall) GracefulDecommissionTimeout(gracefulDecommissionTimeout string) *ProjectsRegionsClustersPatchCall {
+	c.urlParams_.Set("gracefulDecommissionTimeout", gracefulDecommissionTimeout)
+	return c
+}
+
+// RequestId sets the optional parameter "requestId": A unique id used
+// to identify the request. If the server receives two
+// UpdateClusterRequest requests with the same id, then the second
+// request will be ignored and the first google.longrunning.Operation
+// created and stored in the backend is returned.It is recommended to
+// always set this value to a UUID
+// (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id
+// must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+// and hyphens (-). The maximum length is 40 characters.
+func (c *ProjectsRegionsClustersPatchCall) RequestId(requestId string) *ProjectsRegionsClustersPatchCall {
+	c.urlParams_.Set("requestId", requestId)
 	return c
 }
 
@@ -2898,7 +3164,7 @@ func (c *ProjectsRegionsClustersPatchCall) Do(opts ...googleapi.CallOption) (*Op
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -2919,6 +3185,12 @@ func (c *ProjectsRegionsClustersPatchCall) Do(opts ...googleapi.CallOption) (*Op
 	//       "required": true,
 	//       "type": "string"
 	//     },
+	//     "gracefulDecommissionTimeout": {
+	//       "description": "Optional. Timeout for graceful YARN decomissioning. Graceful decommissioning allows removing nodes from the cluster without interrupting jobs in progress. Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs). Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day.Only supported on Dataproc image versions 1.2 and higher.",
+	//       "format": "google-duration",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
 	//     "projectId": {
 	//       "description": "Required. The ID of the Google Cloud Platform project the cluster belongs to.",
 	//       "location": "path",
@@ -2929,6 +3201,11 @@ func (c *ProjectsRegionsClustersPatchCall) Do(opts ...googleapi.CallOption) (*Op
 	//       "description": "Required. The Cloud Dataproc region in which to handle the request.",
 	//       "location": "path",
 	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "requestId": {
+	//       "description": "Optional. A unique id used to identify the request. If the server receives two UpdateClusterRequest requests with the same id, then the second request will be ignored and the first google.longrunning.Operation created and stored in the backend is returned.It is recommended to always set this value to a UUID (https://en.wikipedia.org/wiki/Universally_unique_identifier).The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.",
+	//       "location": "query",
 	//       "type": "string"
 	//     },
 	//     "updateMask": {
@@ -3060,7 +3337,7 @@ func (c *ProjectsRegionsJobsCancelCall) Do(opts ...googleapi.CallOption) (*Job, 
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -3208,7 +3485,7 @@ func (c *ProjectsRegionsJobsDeleteCall) Do(opts ...googleapi.CallOption) (*Empty
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -3366,7 +3643,7 @@ func (c *ProjectsRegionsJobsGetCall) Do(opts ...googleapi.CallOption) (*Job, err
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -3443,7 +3720,7 @@ func (c *ProjectsRegionsJobsListCall) ClusterName(clusterName string) *ProjectsR
 // the jobs to list. Filters are case-sensitive and have the following
 // syntax:field = value AND field = value ...where field is status.state
 // or labels.[KEY], and [KEY] is a label key. value can be * to match
-// all values. status.state can be either ACTIVE or INACTIVE. Only the
+// all values. status.state can be either ACTIVE or NON_ACTIVE. Only the
 // logical AND operator is supported; space-separated items are treated
 // as having an implicit AND operator.Example filter:status.state =
 // ACTIVE AND labels.env = staging AND labels.starred = *
@@ -3453,8 +3730,8 @@ func (c *ProjectsRegionsJobsListCall) Filter(filter string) *ProjectsRegionsJobs
 }
 
 // JobStateMatcher sets the optional parameter "jobStateMatcher":
-// Specifies enumerated categories of jobs to list (default = match ALL
-// jobs).
+// Specifies enumerated categories of jobs to list. (default = match ALL
+// jobs).If filter is provided, jobStateMatcher will be ignored.
 //
 // Possible values:
 //   "ALL"
@@ -3569,7 +3846,7 @@ func (c *ProjectsRegionsJobsListCall) Do(opts ...googleapi.CallOption) (*ListJob
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -3589,12 +3866,12 @@ func (c *ProjectsRegionsJobsListCall) Do(opts ...googleapi.CallOption) (*ListJob
 	//       "type": "string"
 	//     },
 	//     "filter": {
-	//       "description": "Optional. A filter constraining the jobs to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is status.state or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be either ACTIVE or INACTIVE. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND labels.env = staging AND labels.starred = *",
+	//       "description": "Optional. A filter constraining the jobs to list. Filters are case-sensitive and have the following syntax:field = value AND field = value ...where field is status.state or labels.[KEY], and [KEY] is a label key. value can be * to match all values. status.state can be either ACTIVE or NON_ACTIVE. Only the logical AND operator is supported; space-separated items are treated as having an implicit AND operator.Example filter:status.state = ACTIVE AND labels.env = staging AND labels.starred = *",
 	//       "location": "query",
 	//       "type": "string"
 	//     },
 	//     "jobStateMatcher": {
-	//       "description": "Optional. Specifies enumerated categories of jobs to list (default = match ALL jobs).",
+	//       "description": "Optional. Specifies enumerated categories of jobs to list. (default = match ALL jobs).If filter is provided, jobStateMatcher will be ignored.",
 	//       "enum": [
 	//         "ALL",
 	//         "ACTIVE",
@@ -3777,7 +4054,7 @@ func (c *ProjectsRegionsJobsPatchCall) Do(opts ...googleapi.CallOption) (*Job, e
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -3934,7 +4211,7 @@ func (c *ProjectsRegionsJobsSubmitCall) Do(opts ...googleapi.CallOption) (*Job, 
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -4077,7 +4354,7 @@ func (c *ProjectsRegionsOperationsCancelCall) Do(opts ...googleapi.CallOption) (
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -4205,7 +4482,7 @@ func (c *ProjectsRegionsOperationsDeleteCall) Do(opts ...googleapi.CallOption) (
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -4346,7 +4623,7 @@ func (c *ProjectsRegionsOperationsGetCall) Do(opts ...googleapi.CallOption) (*Op
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -4515,7 +4792,7 @@ func (c *ProjectsRegionsOperationsListCall) Do(opts ...googleapi.CallOption) (*L
 		},
 	}
 	target := &ret
-	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+	if err := gensupport.DecodeResponse(target, res); err != nil {
 		return nil, err
 	}
 	return ret, nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1328,9 +1328,10 @@
 			"revisionTime": "2017-12-13T00:03:45Z"
 		},
 		{
-			"checksumSHA1": "4spHGEYR8VWzwlBGD+xSwi8ZRkw=",
+			"checksumSHA1": "xXFRPq6wWR4G/zDHWOrVl7q3hpc=",
 			"path": "google.golang.org/api/dataproc/v1",
-			"revision": "93a219feb72690ca01348faec80d5a076a32f688"
+			"revision": "6e1e03fd226b4390709001a431fb7283256a7d03",
+			"revisionTime": "2018-08-08T00:04:36Z"
 		},
 		{
 			"checksumSHA1": "wv8+a9dOWrdJEIt1mva9qLlTSfo=",

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -38,6 +38,7 @@ resource "google_dataproc_cluster" "mycluster" {
             num_instances     = 1
             machine_type      = "n1-standard-1"
             disk_config {
+                boot_disk_type = "pd-ssd"
                 boot_disk_size_gb = 10
             }
         }
@@ -100,7 +101,7 @@ resource "google_dataproc_cluster" "mycluster" {
 
 - - -
 
-The **cluster_config** block supports:
+The `cluster_config` block supports:
 
 ```hcl
     cluster_config {
@@ -149,7 +150,7 @@ The **cluster_config** block supports:
 
 - - -
 
-The **cluster_config.gce_cluster_config** block supports:
+The `cluster_config.gce_cluster_config` block supports:
 
 ```hcl
     cluster_config {
@@ -203,7 +204,7 @@ The **cluster_config.gce_cluster_config** block supports:
    will be launched in.
 - - -
 
-The **cluster_config.master_config** block supports:
+The `cluster_config.master_config` block supports:
 
 ```hcl
     cluster_config {
@@ -211,6 +212,7 @@ The **cluster_config.master_config** block supports:
             num_instances     = 1
             machine_type      = "n1-standard-1"
             disk_config {
+                boot_disk_type    = "pd-ssd"
                 boot_disk_size_gb = 10
                 num_local_ssds    = 1
             }
@@ -225,18 +227,23 @@ The **cluster_config.master_config** block supports:
    to create for the master. If not specified, GCP will default to a predetermined
    computed value (currently `n1-standard-4`).
 
-* `disk_config.boot_disk_size_gb` - (Optional, Computed) Size of the primary disk attached to each node, specified
+* `disk_config` (Optional) Disk Config
+
+	* `disk_config.boot_disk_type` - (Optional) The disk type of the primary disk attached to each node.
+	One of `"pd-ssd"` or `"pd-standard"`. Defaults to `"pd-standard"`.
+
+	* `disk_config.boot_disk_size_gb` - (Optional, Computed) Size of the primary disk attached to each node, specified
 	in GB. The primary disk contains the boot volume and system libraries, and the
 	smallest allowed disk size is 10GB. GCP will default to a predetermined
 	computed value if not set (currently 500GB). Note: If SSDs are not
 	attached, it also contains the HDFS data blocks and Hadoop working directories.
 
-* `disk_config.num_local_ssds` - (Optional) The amount of local SSD disks that will be
+	* `disk_config.num_local_ssds` - (Optional) The amount of local SSD disks that will be
 	attached to each master cluster node. Defaults to 0.
 
 - - -
 
-The **cluster_config.worker_config** block supports:
+The `cluster_config.worker_config` block supports:
 
 ```hcl
     cluster_config {
@@ -244,6 +251,7 @@ The **cluster_config.worker_config** block supports:
             num_instances     = 3
             machine_type      = "n1-standard-1"
             disk_config {
+                boot_disk_type    = "pd-standard"
                 boot_disk_size_gb = 10
                 num_local_ssds    = 1
             }
@@ -265,6 +273,9 @@ The **cluster_config.worker_config** block supports:
 
 * `disk_config` (Optional) Disk Config
 
+    * `disk_config.boot_disk_type` - (Optional) The disk type of the primary disk attached to each node.
+	One of `"pd-ssd"` or `"pd-standard"`. Defaults to `"pd-standard"`.
+
     * `boot_disk_size_gb` - (Optional, Computed) Size of the primary disk attached to each worker node, specified
     in GB. The smallest allowed disk size is 10GB. GCP will default to a predetermined
     computed value if not set (currently 500GB). Note: If SSDs are not
@@ -275,7 +286,7 @@ The **cluster_config.worker_config** block supports:
 
 - - -
 
-The **cluster_config.preemptible_worker_config** block supports:
+The `cluster_config.preemptible_worker_config` block supports:
 
 ```hcl
     cluster_config {
@@ -303,7 +314,7 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
 
 - - -
 
-The **cluster_config.software_config** block supports:
+The `cluster_config.software_config` block supports:
 
 ```hcl
     cluster_config {
@@ -330,7 +341,7 @@ The **cluster_config.software_config** block supports:
 
 - - -
 
-The **initialization_action** block (Optional) can be specified multiple times and supports:
+The `initialization_action` block (Optional) can be specified multiple times and supports:
 
 ```hcl
     cluster_config {
@@ -370,7 +381,6 @@ exported:
 * `cluster_config.software_config.properties` - A list of the properties used to set the daemon config files.
    This will include any values supplied by the user via `cluster_config.software_config.override_properties`
 
-<a id="timeouts"></a>
 ## Timeouts
 
 `google_dataproc_cluster` provides the following


### PR DESCRIPTION
Fixes #1730.

- Vendor a new copy of `google.golang.org/api/dataproc/v1`.
- Add support for `boot_disk_type` to `google_dataproc_cluster`'s master and worker `disk_config` subfields.
- Clean up `google_dataproc_cluster` test names so `-run=TestAccDataprocCluster_basic` only matches `TestAccDataprocCluster_basic`.
- Minor formatting fixes in the `google_dataproc_cluster` documentation.