### PR TITLE
Add import support for org, folder, billing logging sinks

### DIFF
--- a/google/logging_utils.go
+++ b/google/logging_utils.go
@@ -7,7 +7,7 @@ import (
 
 // loggingSinkResourceTypes contains all the possible Stackdriver Logging resource types. Used to parse ids safely.
 var loggingSinkResourceTypes = []string{
-	"billingAccount",
+	"billingAccounts",
 	"folders",
 	"organizations",
 	"projects",

--- a/google/resource_logging_billing_account_sink.go
+++ b/google/resource_logging_billing_account_sink.go
@@ -12,6 +12,9 @@ func resourceLoggingBillingAccountSink() *schema.Resource {
 		Delete: resourceLoggingBillingAccountSinkDelete,
 		Update: resourceLoggingBillingAccountSinkUpdate,
 		Schema: resourceLoggingSinkSchema(),
+		Importer: &schema.ResourceImporter{
+			State: resourceLoggingSinkImportState("billing_account"),
+		},
 	}
 	schm.Schema["billing_account"] = &schema.Schema{
 		Type:     schema.TypeString,

--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -30,6 +30,10 @@ func TestAccLoggingBillingAccountSink_basic(t *testing.T) {
 					testAccCheckLoggingBillingAccountSinkExists("google_logging_billing_account_sink.basic", &sink),
 					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.basic"),
 				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -62,6 +66,10 @@ func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 					testAccCheckLoggingBillingAccountSinkExists("google_logging_billing_account_sink.update", &sinkAfter),
 					testAccCheckLoggingBillingAccountSink(&sinkAfter, "google_logging_billing_account_sink.update"),
 				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.update",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -96,6 +104,10 @@ func TestAccLoggingBillingAccountSink_heredoc(t *testing.T) {
 					testAccCheckLoggingBillingAccountSinkExists("google_logging_billing_account_sink.heredoc", &sink),
 					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_folder_sink.go
+++ b/google/resource_logging_folder_sink.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -13,12 +14,17 @@ func resourceLoggingFolderSink() *schema.Resource {
 		Delete: resourceLoggingFolderSinkDelete,
 		Update: resourceLoggingFolderSinkUpdate,
 		Schema: resourceLoggingSinkSchema(),
+		Importer: &schema.ResourceImporter{
+			State: resourceLoggingSinkImportState("folder"),
+		},
 	}
 	schm.Schema["folder"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		ForceNew:         true,
-		DiffSuppressFunc: optionalPrefixSuppress("folders/"),
+		Type:     schema.TypeString,
+		Required: true,
+		ForceNew: true,
+		StateFunc: func(v interface{}) string {
+			return strings.Replace(v.(string), "folders/", "", 1)
+		},
 	}
 	schm.Schema["include_children"] = &schema.Schema{
 		Type:     schema.TypeBool,

--- a/google/resource_logging_folder_sink_test.go
+++ b/google/resource_logging_folder_sink_test.go
@@ -32,6 +32,10 @@ func TestAccLoggingFolderSink_basic(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.basic", &sink),
 					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.basic"),
 				),
+			}, {
+				ResourceName:      "google_logging_folder_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -58,6 +62,10 @@ func TestAccLoggingFolderSink_folderAcceptsFullFolderPath(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.basic", &sink),
 					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.basic"),
 				),
+			}, {
+				ResourceName:      "google_logging_folder_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -92,6 +100,10 @@ func TestAccLoggingFolderSink_update(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.basic", &sinkAfter),
 					testAccCheckLoggingFolderSink(&sinkAfter, "google_logging_folder_sink.basic"),
 				),
+			}, {
+				ResourceName:      "google_logging_folder_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -127,6 +139,10 @@ func TestAccLoggingFolderSink_heredoc(t *testing.T) {
 					testAccCheckLoggingFolderSinkExists("google_logging_folder_sink.heredoc", &sink),
 					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_folder_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_organization_sink.go
+++ b/google/resource_logging_organization_sink.go
@@ -2,6 +2,8 @@ package google
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -12,11 +14,16 @@ func resourceLoggingOrganizationSink() *schema.Resource {
 		Delete: resourceLoggingOrganizationSinkDelete,
 		Update: resourceLoggingOrganizationSinkUpdate,
 		Schema: resourceLoggingSinkSchema(),
+		Importer: &schema.ResourceImporter{
+			State: resourceLoggingSinkImportState("org_id"),
+		},
 	}
 	schm.Schema["org_id"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		DiffSuppressFunc: optionalPrefixSuppress("organizations/"),
+		Type:     schema.TypeString,
+		Required: true,
+		StateFunc: func(v interface{}) string {
+			return strings.Replace(v.(string), "organizations/", "", 1)
+		},
 	}
 	schm.Schema["include_children"] = &schema.Schema{
 		Type:     schema.TypeBool,

--- a/google/resource_logging_organization_sink_test.go
+++ b/google/resource_logging_organization_sink_test.go
@@ -31,6 +31,10 @@ func TestAccLoggingOrganizationSink_basic(t *testing.T) {
 					testAccCheckLoggingOrganizationSinkExists("google_logging_organization_sink.basic", &sink),
 					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.basic"),
 				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -63,6 +67,10 @@ func TestAccLoggingOrganizationSink_update(t *testing.T) {
 					testAccCheckLoggingOrganizationSinkExists("google_logging_organization_sink.update", &sinkAfter),
 					testAccCheckLoggingOrganizationSink(&sinkAfter, "google_logging_organization_sink.update"),
 				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.update",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -97,6 +105,10 @@ func TestAccLoggingOrganizationSink_heredoc(t *testing.T) {
 					testAccCheckLoggingOrganizationSinkExists("google_logging_organization_sink.heredoc", &sink),
 					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.heredoc"),
 				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.heredoc",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/google/resource_logging_project_sink.go
+++ b/google/resource_logging_project_sink.go
@@ -16,7 +16,7 @@ func resourceLoggingProjectSink() *schema.Resource {
 		Update: resourceLoggingProjectSinkUpdate,
 		Schema: resourceLoggingSinkSchema(),
 		Importer: &schema.ResourceImporter{
-			State: resourceLoggingProjectSinkImportState,
+			State: resourceLoggingSinkImportState("project"),
 		},
 	}
 	schm.Schema["project"] = &schema.Schema{
@@ -102,19 +102,4 @@ func resourceLoggingProjectSinkDelete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
-}
-
-func resourceLoggingProjectSinkImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	config := meta.(*Config)
-
-	loggingSinkId, err := parseLoggingSinkId(d.Id())
-	if err != nil {
-		return nil, err
-	}
-
-	if config.Project != loggingSinkId.resourceId {
-		d.Set("project", loggingSinkId.resourceId)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -69,3 +69,16 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) *logging.LogSink
 	}
 	return &sink
 }
+
+func resourceLoggingSinkImportState(sinkType string) schema.StateFunc {
+	return func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+		loggingSinkId, err := parseLoggingSinkId(d.Id())
+		if err != nil {
+			return nil, err
+		}
+
+		d.Set(sinkType, loggingSinkId.resourceId)
+
+		return []*schema.ResourceData{d}, nil
+	}
+}

--- a/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/website/docs/r/logging_billing_account_sink.html.markdown
@@ -67,3 +67,11 @@ exported:
 
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
+
+## Import
+
+Billing account logging sinks can be imported using this format:
+
+```
+$ terraform import google_logging_billing_account_sink.my_sink billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}
+```

--- a/website/docs/r/logging_folder_sink.html.markdown
+++ b/website/docs/r/logging_folder_sink.html.markdown
@@ -79,3 +79,11 @@ exported:
 
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
+
+## Import
+
+Folder-level logging sinks can be imported using this format:
+
+```
+$ terraform import google_logging_folder_sink.my_sink folders/{{folder_id}}/sinks/{{sink_id}}
+```

--- a/website/docs/r/logging_organization_sink.html.markdown
+++ b/website/docs/r/logging_organization_sink.html.markdown
@@ -73,3 +73,11 @@ exported:
 
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
+
+## Import
+
+Organization-level logging sinks can be imported using this format:
+
+```
+$ terraform import google_logging_organization_sink.my_sink organizations/{{organization_id}}/sinks/{{sink_id}}
+```


### PR DESCRIPTION
Fixes #1494.

* Add import support for `google_logging_organization_sink`, `google_logging_folder_sink`, `google_logging_billing_account_sink`.

Using `StateFunc` over `DiffSuppressFunc` should only affect tests; for some reason `TestAccLoggingFolderSink_folderAcceptsFullFolderPath` expected a `folder` value of `folders/{{id}}` vs expecting `{{id}}` when only `DiffSuppressFunc` was used, when in real use `DiffSuppressFunc` should be sufficient.