### PR TITLE
alphabatize/update sidebar

### DIFF
--- a/website/google.erb
+++ b/website/google.erb
@@ -13,6 +13,9 @@
     <li<%= sidebar_current("docs-google-datasource") %>>
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav nav-visible">
+      <li<%= sidebar_current("docs-google-datasource-active-folder") %>>
+      <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-billing-account") %>>
         <a href="/docs/providers/google/d/google_billing_account.html">google_billing_account</a>
       </li>
@@ -25,11 +28,11 @@
       <li<%= sidebar_current("docs-google-datasource-compute-address") %>>
         <a href="/docs/providers/google/d/datasource_compute_address.html">google_compute_address</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
+      <a href="/docs/providers/google/d/datasource_google_compute_backend_service.html">google_compute_backend_service</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-default-service-account") %>>
         <a href="/docs/providers/google/d/google_compute_default_service_account.html">google_compute_default_service_account</a>
-      </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-image") %>>
-        <a href="/docs/providers/google/d/datasource_compute_image.html">google_compute_image</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-forwarding-rule") %>>
         <a href="/docs/providers/google/d/datasource_compute_forwarding_rule.html">google_compute_forwarding_rule</a>
@@ -37,11 +40,20 @@
       <li<%= sidebar_current("docs-google-datasource-compute-global-address") %>>
         <a href="/docs/providers/google/d/datasource_compute_global_address.html">google_compute_global_address</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-image") %>>
+        <a href="/docs/providers/google/d/datasource_compute_image.html">google_compute_image</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
+      <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
+      <a href="/docs/providers/google/d/datasource_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
+      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-project") %>>
-        <a href="/docs/providers/google/d/google_project.html">google_project</a>
+      <li<%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
+      <a href="/docs/providers/google/d/datasource_compute_region_instance_group.html">google_compute_region_instance_group</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-regions") %>>
       <a href="/docs/providers/google/d/google_compute_regions.html">google_compute_regions</a>
@@ -58,35 +70,23 @@
       <li<%= sidebar_current("docs-google-datasource-compute-zones") %>>
       <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
-      <a href="/docs/providers/google/d/datasource_compute_region_instance_group.html">google_compute_region_instance_group</a>
-      </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
-      <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
-      </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
-      <a href="/docs/providers/google/d/datasource_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
-      </li>
       <li<%= sidebar_current("docs-google-datasource-container-cluster") %>>
       <a href="/docs/providers/google/d/google_container_cluster.html">google_container_cluster</a>
-      </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
-      <a href="/docs/providers/google/d/datasource_google_compute_backend_service.html">google_compute_backend_service</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-container-versions") %>>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-container-repo") %>>
-      <a href="/docs/providers/google/d/google_container_registry_repository.html">google_container_registry_repository</a>
-      </li>
       <li<%= sidebar_current("docs-google-datasource-container-image") %>>
       <a href="/docs/providers/google/d/google_container_registry_image.html">google_container_registry_image</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-container-repo") %>>
+      <a href="/docs/providers/google/d/google_container_registry_repository.html">google_container_registry_repository</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-dns-managed-zone") %>>
       <a href="/docs/providers/google/d/dns_managed_zone.html">google_dns_managed_zone</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-active-folder") %>>
-      <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
+      <li<%= sidebar_current("docs-google-datasource-folder") %>>
+      <a href="/docs/providers/google/d/google_folder.html">google_folder</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
@@ -100,8 +100,8 @@
       <li<%= sidebar_current("docs-google-datasource-organization") %>>
       <a href="/docs/providers/google/d/google_organization.html">google_organization</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-folder") %>>
-      <a href="/docs/providers/google/d/google_folder.html">google_folder</a>
+      <li<%= sidebar_current("docs-google-datasource-project") %>>
+        <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-service-account") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
@@ -315,12 +315,12 @@
       <a href="/docs/providers/google/r/compute_instance_template.html">google_compute_instance_template</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-network-peering") %>>
-      <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
-      </li>
-
       <li<%= sidebar_current("docs-google-compute-network-x") %>>
       <a href="/docs/providers/google/r/compute_network.html">google_compute_network</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-compute-network-peering") %>>
+      <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
       </li>
 
       <li<%= sidebar_current("docs-google-compute-project-metadata") %>>
@@ -337,6 +337,10 @@
 
       <li<%= sidebar_current("docs-google-compute-region-backend-service") %>>
       <a href="/docs/providers/google/r/compute_region_backend_service.html">google_compute_region_backend_service</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-compute-region-disk") %>>
+      <a href="/docs/providers/google/r/compute_region_disk">google_compute_region_disk</a>
       </li>
 
       <li<%= sidebar_current("docs-google-compute-region-instance-group-manager") %>>
@@ -495,18 +499,6 @@
     <li<%= sidebar_current("docs-google-pubsub") %>>
     <a href="#">Google PubSub Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-pubsub-topic-x") %>>
-      <a href="/docs/providers/google/r/pubsub_topic.html">google_pubsub_topic</a>
-      </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
-        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_binding</a>
-      </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
-        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_member</a>
-      </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
-        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_policy</a>
-      </li>
       <li<%= sidebar_current("docs-google-pubsub-subscription-x") %>>
       <a href="/docs/providers/google/r/pubsub_subscription.html">google_pubsub_subscription</a>
       </li>
@@ -518,6 +510,18 @@
       </li>
       <li<%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_policy</a>
+      </li>
+      <li<%= sidebar_current("docs-google-pubsub-topic-x") %>>
+      <a href="/docs/providers/google/r/pubsub_topic.html">google_pubsub_topic</a>
+      </li>
+      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_binding</a>
+      </li>
+      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_member</a>
+      </li>
+      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+        <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_policy</a>
       </li>
     </ul>
     </li>
@@ -604,36 +608,36 @@
     <li<%= sidebar_current("docs-google-logging") %>>
     <a href="#">Google Stackdriver Logging Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-logging-billing-account-sink") %>>
-      <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
-      </li>
-
       <li<%= sidebar_current("docs-google-logging-billing-account-exclusion") %>>
       <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-organization-sink") %>>
-      <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
-      </li>
-
-      <li<%= sidebar_current("docs-google-logging-organization-exclusion") %>>
-      <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
-      </li>
-
-      <li<%= sidebar_current("docs-google-logging-folder-sink") %>>
-      <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
+      <li<%= sidebar_current("docs-google-logging-billing-account-sink") %>>
+      <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
       </li>
 
       <li<%= sidebar_current("docs-google-logging-folder-exclusion") %>>
       <a href="/docs/providers/google/r/logging_folder_exclusion.html">google_logging_folder_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-project-sink") %>>
-      <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
+      <li<%= sidebar_current("docs-google-logging-folder-sink") %>>
+      <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-logging-organization-exclusion") %>>
+      <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-logging-organization-sink") %>>
+      <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
       </li>
 
       <li<%= sidebar_current("docs-google-logging-project-exclusion") %>>
       <a href="/docs/providers/google/r/logging_project_exclusion.html">google_logging_project_exclusion</a>
+      </li>
+
+      <li<%= sidebar_current("docs-google-logging-project-sink") %>>
+      <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
       </li>
     </ul>
     </li>
@@ -678,6 +682,15 @@
     <li<%= sidebar_current("docs-google-kms") %>>
     <a href="#">Google Key Management Service Resources</a>
     <ul class="nav nav-visible">
+      <li<%= sidebar_current("docs-google-kms-crypto-key-x") %>>
+        <a href="/docs/providers/google/r/google_kms_crypto_key.html">google_kms_crypto_key</a>
+      </li>
+      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-binding") %>>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam_binding.html">google_kms_crypto_key_iam_binding</a>
+      </li>
+      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-member") %>>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam_member.html">google_kms_crypto_key_iam_member</a>
+      </li>
       <li<%= sidebar_current("docs-google-kms-key-ring-x") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring.html">google_kms_key_ring</a>
       </li>
@@ -689,15 +702,6 @@
       </li>
       <li<%= sidebar_current("docs-google-kms-key-ring-iam") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
-      </li>
-      <li<%= sidebar_current("docs-google-kms-crypto-key-x") %>>
-        <a href="/docs/providers/google/r/google_kms_crypto_key.html">google_kms_crypto_key</a>
-      </li>
-      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-binding") %>>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam_binding.html">google_kms_crypto_key_iam_binding</a>
-      </li>
-      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-member") %>>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam_member.html">google_kms_crypto_key_iam_member</a>
       </li>
     </ul>
     </li>

--- a/website/google.erb
+++ b/website/google.erb
@@ -340,7 +340,7 @@
       </li>
 
       <li<%= sidebar_current("docs-google-compute-region-disk") %>>
-      <a href="/docs/providers/google/r/compute_region_disk">google_compute_region_disk</a>
+      <a href="/docs/providers/google/r/compute_region_disk.html">google_compute_region_disk</a>
       </li>
 
       <li<%= sidebar_current("docs-google-compute-region-instance-group-manager") %>>


### PR DESCRIPTION
I noticed we were missing the link for `region_disk`, and wanted to make sure we weren't missing any others. The easiest way to check was to alphabetize them, which I think is probably a good idea in general so I kept it. Turns out we were only missing `region_disk`, good job us.