### PR TITLE
Project iam policy import.

### DIFF
--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -18,7 +18,7 @@ func resourceGoogleProjectIamPolicy() *schema.Resource {
 		Update: resourceGoogleProjectIamPolicyUpdate,
 		Delete: resourceGoogleProjectIamPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceGoogleProjectIamPolicyImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -262,6 +262,11 @@ func resourceGoogleProjectIamPolicyDelete(d *schema.ResourceData, meta interface
 	}
 	d.SetId("")
 	return nil
+}
+
+func resourceGoogleProjectIamPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("project", d.Id())
+	return []*schema.ResourceData{d}, nil
 }
 
 // Subtract all bindings in policy b from policy a, and return the result

--- a/google/resource_google_project_iam_policy_test.go
+++ b/google/resource_google_project_iam_policy_test.go
@@ -245,6 +245,14 @@ func TestAccProjectIamPolicy_basic(t *testing.T) {
 					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", pid),
 				),
 			},
+			resource.TestStep{
+				ResourceName: "google_project_iam_policy.acceptance",
+				ImportState:  true,
+				// Skipping the normal "ImportStateVerify" - Unfortunately, it's not
+				// really possible to make the imported policy match exactly, since
+				// the policy depends on the service account being used to create the
+				// project.
+			},
 			// Finally, remove the custom IAM policy from config and apply, then
 			// confirm that the project is in its original state.
 			resource.TestStep{


### PR DESCRIPTION
Fixes #1827 - we weren't setting the project to the ID during import, which meant imports never worked unless the project was set in the provider.