### PR TITLE
If the interface or peer is the last one, it won't be removed.

### DIFF
--- a/google/resource_compute_router_interface.go
+++ b/google/resource_compute_router_interface.go
@@ -240,6 +240,10 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 		Interfaces: newIfaces,
 	}
 
+	if len(newIfaces) == 0 {
+		patchRouter.ForceSendFields = append(patchRouter.ForceSendFields, "Interfaces")
+	}
+
 	log.Printf("[DEBUG] Updating router %s/%s with interfaces: %+v", region, routerName, newIfaces)
 	op, err := routersService.Patch(project, region, router.Name, patchRouter).Do()
 	if err != nil {

--- a/google/resource_compute_router_peer.go
+++ b/google/resource_compute_router_peer.go
@@ -261,6 +261,10 @@ func resourceComputeRouterPeerDelete(d *schema.ResourceData, meta interface{}) e
 		BgpPeers: newPeers,
 	}
 
+	if len(newPeers) == 0 {
+		patchRouter.ForceSendFields = append(patchRouter.ForceSendFields, "BgpPeers")
+	}
+
 	log.Printf("[DEBUG] Updating router %s/%s with peers: %+v", region, routerName, newPeers)
 	op, err := routersService.Patch(project, region, router.Name, patchRouter).Do()
 	if err != nil {


### PR DESCRIPTION
We need to `ForceSendFields` if we're removing the very last `Interface` or `BgpPeer` from a router.

Fixes #1831.