### PR TITLE
Switch from debian-8 to debian-9

### DIFF
--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -194,8 +194,8 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfig() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance" "test" {

--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -194,7 +194,7 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfig() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -237,7 +237,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -290,7 +290,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroup_fromIGM() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -237,8 +237,8 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance" "test" {
@@ -290,8 +290,8 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroup_fromIGM() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-basic" {

--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -193,6 +193,11 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfig() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "test" {
   name         = "tf-test-%s"
   machine_type = "n1-standard-1"
@@ -200,7 +205,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -231,6 +236,11 @@ data "google_compute_instance_group" "test" {
 
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "test" {
   name         = "tf-test-%s"
   machine_type = "n1-standard-1"
@@ -238,7 +248,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -279,12 +289,17 @@ data "google_compute_instance_group" "test" {
 
 func testAccCheckDataSourceGoogleComputeInstanceGroup_fromIGM() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-basic" {
   name = "%s"
   machine_type = "n1-standard-1"
 
   disk {
-    source_image = "debian-cloud/debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete = true
     boot = true
   }

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -222,8 +222,8 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -222,7 +222,7 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -221,6 +221,11 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 
 func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -228,7 +233,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -679,7 +679,7 @@ func testAccComputeBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -737,7 +737,7 @@ func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -895,7 +895,7 @@ func testAccComputeBackendService_withMaxConnections(
 	serviceName, igName, itName, checkName string, maxConnections int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -953,7 +953,7 @@ func testAccComputeBackendService_withMaxConnectionsPerInstance(
 	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -678,6 +678,11 @@ resource "google_compute_http_health_check" "one" {
 func testAccComputeBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
@@ -713,7 +718,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete  = true
     boot         = true
   }
@@ -731,6 +736,11 @@ resource "google_compute_http_health_check" "default" {
 func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
@@ -767,7 +777,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete  = true
     boot         = true
   }
@@ -884,6 +894,11 @@ resource "google_compute_security_policy" "policy" {
 func testAccComputeBackendService_withMaxConnections(
 	serviceName, igName, itName, checkName string, maxConnections int64) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
@@ -919,7 +934,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete  = true
     boot         = true
   }
@@ -937,6 +952,11 @@ resource "google_compute_health_check" "default" {
 func testAccComputeBackendService_withMaxConnectionsPerInstance(
 	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
@@ -972,7 +992,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete  = true
     boot         = true
   }

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -679,8 +679,8 @@ func testAccComputeBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_backend_service" "lipsum" {
@@ -737,8 +737,8 @@ func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_backend_service" "lipsum" {
@@ -895,8 +895,8 @@ func testAccComputeBackendService_withMaxConnections(
 	serviceName, igName, itName, checkName string, maxConnections int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_backend_service" "lipsum" {
@@ -953,8 +953,8 @@ func testAccComputeBackendService_withMaxConnectionsPerInstance(
 	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_backend_service" "lipsum" {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -601,8 +601,8 @@ func testAccCheckComputeDiskInstances(n string, disk *compute.Disk) resource.Tes
 func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -620,8 +620,8 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_timeout() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -639,8 +639,8 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -659,8 +659,8 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, ref_selector string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -691,8 +691,8 @@ resource "google_compute_disk" "seconddisk" {
 func testAccComputeDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -708,8 +708,8 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_encryptionMigrate(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -727,8 +727,8 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foo" {
@@ -763,8 +763,8 @@ resource "google_compute_instance" "bar" {
 func testAccComputeDisk_deleteDetachIGM(diskName, mgrName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foo" {

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -601,7 +601,7 @@ func testAccCheckComputeDiskInstances(n string, disk *compute.Disk) resource.Tes
 func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -620,7 +620,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_timeout() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -639,7 +639,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -659,7 +659,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, ref_selector string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -691,7 +691,7 @@ resource "google_compute_disk" "seconddisk" {
 func testAccComputeDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -708,7 +708,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_encryptionMigrate(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -727,7 +727,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -763,7 +763,7 @@ resource "google_compute_instance" "bar" {
 func testAccComputeDisk_deleteDetachIGM(diskName, mgrName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -600,9 +600,14 @@ func testAccCheckComputeDiskInstances(n string, disk *compute.Disk) resource.Tes
 
 func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -614,9 +619,14 @@ resource "google_compute_disk" "foobar" {
 
 func testAccComputeDisk_timeout() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	type  = "pd-ssd"
 	zone  = "us-central1-a"
 
@@ -628,9 +638,14 @@ resource "google_compute_disk" "foobar" {
 
 func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 100
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -643,9 +658,14 @@ resource "google_compute_disk" "foobar" {
 
 func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, ref_selector string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "d1-%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -670,9 +690,14 @@ resource "google_compute_disk" "seconddisk" {
 
 func testAccComputeDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -682,9 +707,14 @@ resource "google_compute_disk" "foobar" {
 
 func testAccComputeDisk_encryptionMigrate(diskName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -696,9 +726,14 @@ resource "google_compute_disk" "foobar" {
 
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foo" {
 	name = "%s"
-	image = "debian-8-jessie-v20170523"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -711,7 +746,7 @@ resource "google_compute_instance" "bar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20170523"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -727,9 +762,14 @@ resource "google_compute_instance" "bar" {
 
 func testAccComputeDisk_deleteDetachIGM(diskName, mgrName string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foo" {
 	name = "%s"
-	image = "debian-8-jessie-v20170523"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -321,10 +321,15 @@ resource "google_compute_image" "foobar" {
 
 func testAccComputeImage_basedondisk() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "disk-test-%s"
 	zone = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 }
 resource "google_compute_image" "foobar" {
 	name = "image-test-%s"

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -322,8 +322,8 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_basedondisk() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -322,7 +322,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_basedondisk() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_instance_from_template_test.go
+++ b/google/resource_compute_instance_from_template_test.go
@@ -57,9 +57,14 @@ func testAccCheckComputeInstanceFromTemplateDestroy(s *terraform.State) error {
 
 func testAccComputeInstanceFromTemplate_basic(instance, template string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -70,7 +75,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-cloud/debian-8"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true

--- a/google/resource_compute_instance_from_template_test.go
+++ b/google/resource_compute_instance_from_template_test.go
@@ -58,7 +58,7 @@ func testAccCheckComputeInstanceFromTemplateDestroy(s *terraform.State) error {
 func testAccComputeInstanceFromTemplate_basic(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -693,7 +693,7 @@ func testAccCheckInstanceGroupManagerRollingUpdatePolicy(manager *computeBeta.In
 func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -752,7 +752,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -794,7 +794,7 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 func testAccInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -848,7 +848,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 func testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -939,7 +939,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -984,7 +984,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 func testAccInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -1030,7 +1030,7 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1083,7 +1083,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1132,7 +1132,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -1183,7 +1183,7 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1240,7 +1240,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1316,7 +1316,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 func testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -693,8 +693,8 @@ func testAccCheckInstanceGroupManagerRollingUpdatePolicy(manager *computeBeta.In
 func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -752,8 +752,8 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -794,8 +794,8 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 func testAccInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -848,8 +848,8 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 func testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -939,8 +939,8 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -984,8 +984,8 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 func testAccInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update-strategy" {
@@ -1030,8 +1030,8 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
@@ -1083,8 +1083,8 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
@@ -1132,8 +1132,8 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -1183,8 +1183,8 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-basic" {
@@ -1240,8 +1240,8 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-primary" {
@@ -1316,8 +1316,8 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 func testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-basic" {

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -692,6 +692,11 @@ func testAccCheckInstanceGroupManagerRollingUpdatePolicy(manager *computeBeta.In
 
 func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -699,7 +704,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -746,6 +751,11 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 
 func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -753,7 +763,7 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -783,6 +793,11 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 
 func testAccInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -790,7 +805,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -832,6 +847,11 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 // Change IGM's instance template and target size
 func testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -839,7 +859,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -876,7 +896,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -918,13 +938,18 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 
 func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		machine_type = "n1-standard-1"
 		can_ip_forward = false
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -958,13 +983,18 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 
 func testAccInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update-strategy" {
 		machine_type = "n1-standard-1"
 		can_ip_forward = false
 		tags = ["terraform-testing"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -999,13 +1029,18 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1047,13 +1082,18 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1091,13 +1131,18 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 
 func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		machine_type = "n1-standard-1"
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -1137,13 +1182,18 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 
 func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1189,13 +1239,18 @@ resource "google_compute_http_health_check" "zero" {
 
 func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-primary" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1216,7 +1271,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1260,13 +1315,18 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 // with Beta fields.
 func testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_instance_group_test.go
+++ b/google/resource_compute_instance_group_test.go
@@ -308,7 +308,7 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(nInstanceGroup string, nNetwo
 func testAccComputeInstanceGroup_basic(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family  = "debian-9"
 		project = "debian-cloud"
 	}
 
@@ -362,7 +362,7 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 func testAccComputeInstanceGroup_update(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family    = "debian-9"
 		project = "debian-cloud"
 	}
 
@@ -404,7 +404,7 @@ func testAccComputeInstanceGroup_update(instance string) string {
 func testAccComputeInstanceGroup_update2(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family  = "debian-9"
 		project = "debian-cloud"
 	}
 
@@ -446,7 +446,7 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family  = "debian-9"
 		project = "debian-cloud"
 	}
 
@@ -489,7 +489,7 @@ func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family  = "debian-9"
 		project = "debian-cloud"
 	}
 
@@ -546,7 +546,7 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 func testAccComputeInstanceGroup_network(instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		name    = "debian-9"
+		family  = "debian-9"
 		project = "debian-cloud"
 	}
 

--- a/google/resource_compute_instance_group_test.go
+++ b/google/resource_compute_instance_group_test.go
@@ -307,6 +307,11 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(nInstanceGroup string, nNetwo
 
 func testAccComputeInstanceGroup_basic(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_instance" "ig_instance" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -315,7 +320,7 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -356,6 +361,11 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 
 func testAccComputeInstanceGroup_update(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_instance" "ig_instance" {
 		name = "%s-${count.index}"
 		machine_type = "n1-standard-1"
@@ -365,7 +375,7 @@ func testAccComputeInstanceGroup_update(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -393,6 +403,11 @@ func testAccComputeInstanceGroup_update(instance string) string {
 // Change IGM's instance template and target size
 func testAccComputeInstanceGroup_update2(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_instance" "ig_instance" {
 		name = "%s-${count.index}"
 		machine_type = "n1-standard-1"
@@ -402,7 +417,7 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -430,6 +445,11 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 
 func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_instance" "ig_instance" {
 		name = "%s-${count.index}"
 		machine_type = "n1-standard-1"
@@ -439,7 +459,7 @@ func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -468,6 +488,11 @@ func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 
 func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_instance" "ig_instance" {
 		name = "%s-1"
 		machine_type = "n1-standard-1"
@@ -476,7 +501,7 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -493,7 +518,7 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 
@@ -520,6 +545,11 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 
 func testAccComputeInstanceGroup_network(instance string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+		name    = "debian-9"
+		project = "debian-cloud"
+	}
+
 	resource "google_compute_network" "ig_network" {
 		name = "%[1]s"
 		auto_create_subnetworks = true
@@ -533,7 +563,7 @@ func testAccComputeInstanceGroup_network(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "${data.google_compute_image.my_image.self_link}"
 			}
 		}
 

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -125,7 +125,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 		},
@@ -192,7 +192,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 		},
@@ -254,7 +254,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	diskName := fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
 	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
@@ -274,7 +274,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -334,7 +334,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	diskName := fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
 	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
@@ -354,7 +354,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -416,13 +416,13 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -449,7 +449,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-8",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone": zone,
@@ -484,13 +484,13 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -517,7 +517,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-8",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone": zone,
@@ -551,19 +551,19 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
 				},
 			},
 		},
@@ -587,9 +587,9 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-8",
+		"disk.1.image":       "global/images/family/debian-9",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -623,19 +623,19 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
 				},
 			},
 		},
@@ -659,9 +659,9 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180814",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-8",
+		"disk.1.image":       "global/images/family/debian-9",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -695,7 +695,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -759,7 +759,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -31,7 +31,6 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateContainsLabel(&instanceTemplate, "my_label", "foobar"),
 				),
 			},
@@ -193,7 +192,6 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
 			},
@@ -728,6 +726,11 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 
 func testAccComputeInstanceTemplate_basic() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
@@ -735,7 +738,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -765,6 +768,11 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_preemptible() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
@@ -772,7 +780,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -802,13 +810,18 @@ resource "google_compute_address" "foo" {
 	name = "instancet-test-%s"
 }
 
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 	}
 
 	network_interface {
@@ -826,12 +839,17 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_networkTier() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 	}
 
 	network_interface {
@@ -845,13 +863,18 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_networkIP(networkIP string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 	}
 
 	network_interface {
@@ -867,13 +890,18 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_address(address string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
 	machine_type = "n1-standard-1"
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 	}
 
 	network_interface {
@@ -889,9 +917,14 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_disks() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "instancet-test-%s"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -902,7 +935,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true
@@ -926,6 +959,11 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_network" "auto-network" {
 		name = "%s"
 		auto_create_subnetworks = true
@@ -936,7 +974,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 		machine_type = "n1-standard-1"
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			disk_size_gb = 10
 			boot = true
@@ -966,13 +1004,18 @@ resource "google_compute_subnetwork" "subnetwork" {
 	network = "${google_compute_network.network.self_link}"
 }
 
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 	region = "us-central1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1037,13 +1080,18 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 		project = "${google_compute_shared_vpc_host_project.host_project.project}"
 	}
 
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "foobar" {
 		name = "instance-test-%s"
 		machine_type = "n1-standard-1"
 		region = "us-central1"
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			disk_size_gb = 10
 			boot = true
@@ -1063,12 +1111,17 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 
 func testAccComputeInstanceTemplate_startup_script() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1088,12 +1141,17 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_primaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1127,12 +1185,16 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 		ip_cidr_range = "172.16.0.0/20"
 	}
 }
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1160,12 +1222,17 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_guestAccelerator(i string, count uint8) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1189,12 +1256,17 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_minCpuPlatform(i string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -727,8 +727,8 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 func testAccComputeInstanceTemplate_basic() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -769,8 +769,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_preemptible() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -811,8 +811,8 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -840,8 +840,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkTier() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -864,8 +864,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkIP(networkIP string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -891,8 +891,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_address(address string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -918,8 +918,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_disks() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -960,8 +960,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_network" "auto-network" {
@@ -1005,8 +1005,8 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -1081,8 +1081,8 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 	}
 
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "foobar" {
@@ -1112,8 +1112,8 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 func testAccComputeInstanceTemplate_startup_script() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -1142,8 +1142,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_primaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -1186,8 +1186,8 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 	}
 }
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 resource "google_compute_instance_template" "foobar" {
 	name = "instance-test-%s"
@@ -1223,8 +1223,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_guestAccelerator(i string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -1257,8 +1257,8 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_minCpuPlatform(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -727,7 +727,7 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 func testAccComputeInstanceTemplate_basic() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -769,7 +769,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_preemptible() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -811,7 +811,7 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -840,7 +840,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkTier() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -864,7 +864,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkIP(networkIP string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -891,7 +891,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_address(address string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -918,7 +918,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_disks() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -960,7 +960,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -1005,7 +1005,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1081,7 +1081,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 	}
 
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -1112,7 +1112,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 func testAccComputeInstanceTemplate_startup_script() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1142,7 +1142,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_primaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1186,7 +1186,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 	}
 }
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 resource "google_compute_instance_template" "foobar" {
@@ -1223,7 +1223,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_guestAccelerator(i string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1257,7 +1257,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_minCpuPlatform(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -2817,8 +2817,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_minCpuPlatform(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2843,8 +2843,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_primaryAliasIpRange(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1539,6 +1539,11 @@ func testAccCheckComputeInstanceHasConfiguredDeletionProtection(instance *comput
 
 func testAccComputeInstance_basic(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1549,7 +1554,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1578,6 +1583,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic2(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1587,7 +1597,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1604,6 +1614,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic3(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1613,7 +1628,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-cloud/debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1630,6 +1645,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic4(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1639,7 +1659,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-cloud/debian-8"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1657,6 +1677,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic5(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1666,7 +1691,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1683,6 +1708,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic_deletionProtectionFalse(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name                 = "%s"
 	machine_type         = "n1-standard-1"
@@ -1693,7 +1723,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1706,6 +1736,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_basic_deletionProtectionTrue(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name                 = "%s"
 	machine_type         = "n1-standard-1"
@@ -1716,7 +1751,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1731,6 +1766,11 @@ resource "google_compute_instance" "foobar" {
 // Generates diff mismatch
 func testAccComputeInstance_forceNewAndChangeMetadata(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -1739,7 +1779,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1758,6 +1798,11 @@ resource "google_compute_instance" "foobar" {
 // Update metadata, tags, and network_interface
 func testAccComputeInstance_update(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -1767,7 +1812,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1792,6 +1837,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_ip(ip, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_address" "foo" {
 	name = "%s"
 }
@@ -1804,7 +1854,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1824,6 +1874,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_PTRRecord(record, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -1832,7 +1887,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1852,6 +1907,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_generateIp(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -1860,7 +1920,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1880,6 +1940,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_networkTier(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -1887,7 +1952,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -1907,6 +1972,11 @@ func testAccComputeInstance_disks_encryption(bootEncryptionKey string, diskNameT
 		diskNames = append(diskNames, k)
 	}
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -1948,7 +2018,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 		disk_encryption_key_raw = "%s"
 	}
@@ -1990,6 +2060,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_attachedDisk(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2004,7 +2079,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2021,6 +2096,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_attachedDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2035,7 +2115,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2052,6 +2132,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2066,7 +2151,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2084,6 +2169,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_addAttachedDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2105,7 +2195,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2126,6 +2216,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_detachDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2147,7 +2242,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2164,6 +2259,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_updateAttachedDiskEncryptionKey(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	size = 10
@@ -2179,7 +2279,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2197,10 +2297,15 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2221,10 +2326,15 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_bootDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2245,6 +2355,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_bootDisk_type(instance string, diskType string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -2252,7 +2367,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image	= "debian-8-jessie-v20160803"
+			image	= "${data.google_compute_image.my_image.self_link}"
 			type	= "%s"
 		}
 	}
@@ -2266,6 +2381,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_scratchDisk(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "scratch" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -2273,7 +2393,7 @@ resource "google_compute_instance" "scratch" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2295,6 +2415,11 @@ resource "google_compute_instance" "scratch" {
 
 func testAccComputeInstance_service_account(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -2302,7 +2427,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2323,6 +2448,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_scheduling(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -2330,7 +2460,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2347,6 +2477,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_subnet_auto(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "inst-test-network-%s"
 
@@ -2360,7 +2495,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2375,6 +2510,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_subnet_custom(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "inst-test-network-%s"
 
@@ -2395,7 +2535,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2410,6 +2550,10 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_subnet_xpn(org, billingId, projectName, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
 
 resource "google_project" "host_project" {
 	name = "Test Project XPN Host"
@@ -2468,7 +2612,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2484,6 +2628,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_address_auto(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "inst-test-network-%s"
 }
@@ -2500,7 +2649,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2515,6 +2664,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_address_custom(instance, address string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "inst-test-network-%s"
 }
@@ -2531,7 +2685,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2547,10 +2701,15 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_private_image_family(disk, family, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "${data.google_compute_image.my_image.self_link}"
 }
 
 resource "google_compute_image" "foobar" {
@@ -2583,6 +2742,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name         = "%s"
 	machine_type = "n1-standard-1"
@@ -2590,7 +2754,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2618,6 +2782,11 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
   name = "%s"
   machine_type = "n1-standard-1"
@@ -2625,7 +2794,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -2647,6 +2816,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_minCpuPlatform(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
   name = "%s"
   machine_type = "n1-standard-1"
@@ -2654,7 +2828,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -2668,6 +2842,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_primaryAliasIpRange(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
   name = "%s"
   machine_type = "n1-standard-1"
@@ -2675,7 +2854,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -2691,6 +2870,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_secondaryAliasIpRange(network, subnet, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "%s"
 }
@@ -2711,7 +2895,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -2728,6 +2912,11 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_secondaryAliasIpRangeUpdate(network, subnet, instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_network" "inst-test-network" {
 	name = "%s"
 }
@@ -2748,7 +2937,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 
@@ -2765,6 +2954,11 @@ resource "google_compute_instance" "foobar" {
 // Set fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
 func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-1"
@@ -2772,7 +2966,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2797,6 +2991,11 @@ resource "google_compute_instance" "foobar" {
 // Update fields that require stopping the instance: machine_type, min_cpu_platform, and service_account
 func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-2"
@@ -2804,7 +3003,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 
@@ -2828,6 +3027,11 @@ resource "google_compute_instance" "foobar" {
 // Remove fields that require stopping the instance: min_cpu_platform and service_account (machine_type is Required)
 func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foobar" {
 	name           = "%s"
 	machine_type   = "n1-standard-2"
@@ -2835,7 +3039,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1540,7 +1540,7 @@ func testAccCheckComputeInstanceHasConfiguredDeletionProtection(instance *comput
 func testAccComputeInstance_basic(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1584,7 +1584,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1615,7 +1615,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1646,7 +1646,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic4(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1678,7 +1678,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic5(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1709,7 +1709,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionFalse(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1737,7 +1737,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionTrue(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1767,7 +1767,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_forceNewAndChangeMetadata(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1799,7 +1799,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_update(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1838,7 +1838,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_ip(ip, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1875,7 +1875,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_PTRRecord(record, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1908,7 +1908,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_generateIp(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1941,7 +1941,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkTier(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1973,7 +1973,7 @@ func testAccComputeInstance_disks_encryption(bootEncryptionKey string, diskNameT
 	}
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2061,7 +2061,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2097,7 +2097,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2133,7 +2133,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2170,7 +2170,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_addAttachedDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2217,7 +2217,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_detachDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2260,7 +2260,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_updateAttachedDiskEncryptionKey(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2298,7 +2298,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2327,7 +2327,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2356,7 +2356,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_type(instance string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2382,7 +2382,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_scratchDisk(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2416,7 +2416,7 @@ resource "google_compute_instance" "scratch" {
 func testAccComputeInstance_service_account(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2449,7 +2449,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_scheduling(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2478,7 +2478,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_auto(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2511,7 +2511,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_custom(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2551,7 +2551,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_xpn(org, billingId, projectName, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2629,7 +2629,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_address_auto(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2665,7 +2665,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_address_custom(instance, address string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2702,7 +2702,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_private_image_family(disk, family, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2743,7 +2743,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2783,7 +2783,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2817,7 +2817,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_minCpuPlatform(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2843,7 +2843,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_primaryAliasIpRange(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2871,7 +2871,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRange(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2913,7 +2913,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeUpdate(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2955,7 +2955,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -2992,7 +2992,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -3028,7 +3028,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1540,8 +1540,8 @@ func testAccCheckComputeInstanceHasConfiguredDeletionProtection(instance *comput
 func testAccComputeInstance_basic(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1584,8 +1584,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1615,8 +1615,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1646,8 +1646,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic4(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1678,8 +1678,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic5(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1709,8 +1709,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionFalse(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1737,8 +1737,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionTrue(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1767,8 +1767,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_forceNewAndChangeMetadata(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1799,8 +1799,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_update(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1838,8 +1838,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_ip(ip, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_address" "foo" {
@@ -1875,8 +1875,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_PTRRecord(record, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1908,8 +1908,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_generateIp(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1941,8 +1941,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkTier(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -1973,8 +1973,8 @@ func testAccComputeInstance_disks_encryption(bootEncryptionKey string, diskNameT
 	}
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2061,8 +2061,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2097,8 +2097,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2133,8 +2133,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2170,8 +2170,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_addAttachedDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2217,8 +2217,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_detachDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2260,8 +2260,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_updateAttachedDiskEncryptionKey(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2298,8 +2298,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2327,8 +2327,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2356,8 +2356,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_type(instance string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2382,8 +2382,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_scratchDisk(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "scratch" {
@@ -2416,8 +2416,8 @@ resource "google_compute_instance" "scratch" {
 func testAccComputeInstance_service_account(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2449,8 +2449,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_scheduling(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2478,8 +2478,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_auto(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2511,8 +2511,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_custom(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2551,8 +2551,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_xpn(org, billingId, projectName, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_project" "host_project" {
@@ -2629,8 +2629,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_address_auto(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2665,8 +2665,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_address_custom(instance, address string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2702,8 +2702,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_private_image_family(disk, family, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_disk" "foobar" {
@@ -2743,8 +2743,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2783,8 +2783,8 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2871,8 +2871,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRange(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2913,8 +2913,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeUpdate(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_network" "inst-test-network" {
@@ -2955,8 +2955,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2992,8 +2992,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -3028,8 +3028,8 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foobar" {

--- a/google/resource_compute_region_autoscaler_test.go
+++ b/google/resource_compute_region_autoscaler_test.go
@@ -152,6 +152,11 @@ func testAccCheckComputeRegionAutoscalerUpdated(n string, max int64) resource.Te
 
 func testAccComputeRegionAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -159,7 +164,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -212,6 +217,11 @@ resource "google_compute_region_autoscaler" "foobar" {
 
 func testAccComputeRegionAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -219,7 +229,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_region_autoscaler_test.go
+++ b/google/resource_compute_region_autoscaler_test.go
@@ -153,7 +153,7 @@ func testAccCheckComputeRegionAutoscalerUpdated(n string, max int64) resource.Te
 func testAccComputeRegionAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 
@@ -218,7 +218,7 @@ resource "google_compute_region_autoscaler" "foobar" {
 func testAccComputeRegionAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -308,7 +308,7 @@ func testAccComputeRegionBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -307,6 +307,11 @@ resource "google_compute_health_check" "one" {
 func testAccComputeRegionBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
@@ -338,7 +343,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "${data.google_compute_image.my_image.self_link}"
     auto_delete  = true
     boot         = true
   }

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -308,8 +308,8 @@ func testAccComputeRegionBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_region_backend_service" "lipsum" {

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -660,6 +660,11 @@ func testAccCheckRegionInstanceGroupManagerTemplateTags(n string, tags []string)
 
 func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -667,7 +672,7 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -714,6 +719,11 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 
 func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -721,7 +731,7 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -751,6 +761,11 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 
 func testAccRegionInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -758,7 +773,7 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -800,6 +815,11 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 // Change IGM's instance template and target size
 func testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		name = "%s"
 		machine_type = "n1-standard-1"
@@ -807,7 +827,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -844,7 +864,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -886,13 +906,18 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 
 func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-update" {
 		machine_type = "n1-standard-1"
 		can_ip_forward = false
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -926,13 +951,18 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 
 func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
+	data "google_compute_image" "my_image" {
+	       name    = "debian-9"
+	       project = "debian-cloud"
+	}
+
 	resource "google_compute_instance_template" "igm-basic" {
 		machine_type = "n1-standard-1"
 		can_ip_forward = false
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "${data.google_compute_image.my_image.self_link}"
 			auto_delete = true
 			boot = true
 		}
@@ -972,13 +1002,18 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 
 func testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1023,13 +1058,18 @@ resource "google_compute_http_health_check" "zero" {
 }
 func testAccRegionInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-primary" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1050,7 +1090,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1090,13 +1130,18 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-basic" {
 	name = "%s"
 	machine_type = "n1-standard-1"
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -1122,13 +1167,18 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 
 func testAccRegionInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-update-strategy" {
 	machine_type   = "n1-standard-1"
 	can_ip_forward = false
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete  = true
 		boot         = true
 	}
@@ -1163,13 +1213,18 @@ resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
 
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	machine_type   = "n1-standard-1"
 	can_ip_forward = false
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete  = true
 		boot         = true
 	}
@@ -1214,13 +1269,18 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	machine_type   = "n1-standard-1"
 	can_ip_forward = false
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete  = true
 		boot         = true
 	}

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -661,8 +661,8 @@ func testAccCheckRegionInstanceGroupManagerTemplateTags(n string, tags []string)
 func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -720,8 +720,8 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -762,8 +762,8 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 func testAccRegionInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -816,8 +816,8 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 func testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -907,8 +907,8 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-update" {
@@ -952,8 +952,8 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       family  = "debian-9"
-	       project = "debian-cloud"
+		family  = "debian-9"
+		project = "debian-cloud"
 	}
 
 	resource "google_compute_instance_template" "igm-basic" {
@@ -1003,8 +1003,8 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 func testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-basic" {
@@ -1059,8 +1059,8 @@ resource "google_compute_http_health_check" "zero" {
 func testAccRegionInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-primary" {
@@ -1131,8 +1131,8 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-basic" {
@@ -1168,8 +1168,8 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-update-strategy" {
@@ -1214,8 +1214,8 @@ resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-rolling-update-policy" {
@@ -1270,8 +1270,8 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_instance_template" "igm-rolling-update-policy" {

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -661,7 +661,7 @@ func testAccCheckRegionInstanceGroupManagerTemplateTags(n string, tags []string)
 func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -720,7 +720,7 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -762,7 +762,7 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 func testAccRegionInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -816,7 +816,7 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 func testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -907,7 +907,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -952,7 +952,7 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-	       name    = "debian-9"
+	       family  = "debian-9"
 	       project = "debian-cloud"
 	}
 
@@ -1003,7 +1003,7 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 func testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1059,7 +1059,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccRegionInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1131,7 +1131,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1168,7 +1168,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_updateStrategy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1214,7 +1214,7 @@ resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 
@@ -1270,7 +1270,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -173,8 +173,8 @@ resource "google_compute_route" "foobar" {
 func testAccComputeRoute_hopInstance(instanceName, zone string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_instance" "foo" {

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -173,7 +173,7 @@ resource "google_compute_route" "foobar" {
 func testAccComputeRoute_hopInstance(instanceName, zone string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -172,6 +172,11 @@ resource "google_compute_route" "foobar" {
 
 func testAccComputeRoute_hopInstance(instanceName, zone string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance" "foo" {
   name         = "%s"
   machine_type = "n1-standard-1"
@@ -179,7 +184,7 @@ resource "google_compute_instance" "foo" {
 
   boot_disk {
     initialize_params{
-      image = "debian-cloud/debian-8"
+      image = "${data.google_compute_image.my_image.self_link}"
     }
   }
 

--- a/google/resource_compute_snapshot_test.go
+++ b/google/resource_compute_snapshot_test.go
@@ -211,7 +211,7 @@ func testAccCheckComputeSnapshotExists(n string, snapshot *compute.Snapshot) res
 func testAccComputeSnapshot_basic(snapshotName, diskName, labelValue string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 
@@ -237,7 +237,7 @@ func testAccComputeSnapshot_encryption(snapshotName string, diskName string) str
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 data "google_compute_image" "my_image" {
-	name    = "debian-9"
+	family  = "debian-9"
 	project = "debian-cloud"
 }
 

--- a/google/resource_compute_snapshot_test.go
+++ b/google/resource_compute_snapshot_test.go
@@ -210,9 +210,14 @@ func testAccCheckComputeSnapshotExists(n string, snapshot *compute.Snapshot) res
 
 func testAccComputeSnapshot_basic(snapshotName, diskName, labelValue string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160921"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -231,8 +236,13 @@ resource "google_compute_snapshot" "foobar" {
 func testAccComputeSnapshot_encryption(snapshotName string, diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
+data "google_compute_image" "my_image" {
+	name    = "debian-9"
+	project = "debian-cloud"
+}
+
 	name = "%s"
-	image = "debian-8-jessie-v20160921"
+	image = "${data.google_compute_image.my_image.self_link}"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"

--- a/google/resource_compute_snapshot_test.go
+++ b/google/resource_compute_snapshot_test.go
@@ -235,12 +235,12 @@ resource "google_compute_snapshot" "foobar" {
 
 func testAccComputeSnapshot_encryption(snapshotName string, diskName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_disk" "foobar" {
 data "google_compute_image" "my_image" {
 	family  = "debian-9"
 	project = "debian-cloud"
 }
 
+resource "google_compute_disk" "foobar" {
 	name = "%s"
 	image = "${data.google_compute_image.my_image.self_link}"
 	size = 10

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -106,7 +106,7 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 func testAccComputeTargetPool_basic() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       name    = "debian-9"
+       family  = "debian-9"
        project = "debian-cloud"
 }
 

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -106,8 +106,8 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 func testAccComputeTargetPool_basic() string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-       family  = "debian-9"
-       project = "debian-cloud"
+	family  = "debian-9"
+	project = "debian-cloud"
 }
 
 resource "google_compute_http_health_check" "foobar" {

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -105,6 +105,11 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 
 func testAccComputeTargetPool_basic() string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+       name    = "debian-9"
+       project = "debian-cloud"
+}
+
 resource "google_compute_http_health_check" "foobar" {
 	name = "healthcheck-test-%s"
 	host = "example.com"
@@ -117,7 +122,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "${data.google_compute_image.my_image.self_link}"
 		}
 	}
 


### PR DESCRIPTION
Update our tests to use debian-8 instead of debian-9, mostly addressing #1729. I took the opportunity to sub in the data source instead of hardcoding names, too.

PR to fix documentation and examples incoming, as well.