### PR TITLE
Correctly update regional resource.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1192,7 +1192,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := func() error {
-			op, err := config.clientContainerBeta.Projects.Zones.Clusters.Update(project, location, clusterName, req).Do()
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(project, location, clusterName, req).Do()
 			if err != nil {
 				return err
 			}

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1192,7 +1192,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := func() error {
-			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(project, location, clusterName, req).Do()
+			name := containerClusterFullName(project, location, clusterName)
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(name, req).Do()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Container cluster should use the `Projects.Locations` instead of `Projects.Zones` calls.

Fixes #1833.