### PR TITLE
Encourage users to set lifecycle hooks on kms_crypto_key resources

### DIFF
--- a/website/docs/r/google_kms_crypto_key.html.markdown
+++ b/website/docs/r/google_kms_crypto_key.html.markdown
@@ -16,8 +16,13 @@ and
 A CryptoKey is an interface to key material which can be used to encrypt and decrypt data. A CryptoKey belongs to a
 Google Cloud KMS KeyRing.
 
-~> Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed CryptoKey will remove it
-from state and delete all CryptoKeyVersions, rendering the key unusable, but **will not delete the resource on the server**.
+~> Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
+Terraform-managed CryptoKey will remove it from state and delete all
+CryptoKeyVersions, rendering the key unusable, but **will not delete the
+resource on the server**. When Terraform destroys these keys, any data
+previously encrypted with these keys will be irrecoverable. For this reason, it
+is strongly recommended that you add lifecycle hooks to the resource to prevent
+accidental destruction.
 
 ## Example Usage
 
@@ -32,6 +37,10 @@ resource "google_kms_crypto_key" "my_crypto_key" {
   name            = "my-crypto-key"
   key_ring        = "${google_kms_key_ring.my_key_ring.id}"
   rotation_period = "100000s"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 ```
 


### PR DESCRIPTION
@michaelharo suggested this would be a good best practice for this particular resource to prevent users from accidentally deleting a bunch of encryption keys on a -/+ and losing data, and I agree.

This commit adds a quick documentation blurb saying what actually happens if those crypto key versions are destroyed and also updates the snippet to showcase a lifecycle hook.