### PR TITLE
Fix panic on empty list for authorized masters' `cidr_blocks`

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1543,9 +1543,6 @@ func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetw
 	if c == nil {
 		return nil
 	}
-	if len(c.CidrBlocks) == 0 {
-		return nil
-	}
 	result := make(map[string]interface{})
 	if c.Enabled {
 		cidrBlocks := make([]interface{}, 0, len(c.CidrBlocks))

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1381,16 +1381,17 @@ func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta
 	result := &containerBeta.MasterAuthorizedNetworksConfig{}
 	if len(configured.([]interface{})) > 0 {
 		result.Enabled = true
-		config := configured.([]interface{})[0].(map[string]interface{})
-		if _, ok := config["cidr_blocks"]; ok {
-			cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
-			result.CidrBlocks = make([]*containerBeta.CidrBlock, 0)
-			for _, v := range cidrBlocks {
-				cidrBlock := v.(map[string]interface{})
-				result.CidrBlocks = append(result.CidrBlocks, &containerBeta.CidrBlock{
-					CidrBlock:   cidrBlock["cidr_block"].(string),
-					DisplayName: cidrBlock["display_name"].(string),
-				})
+		if config, ok := configured.([]interface{})[0].(map[string]interface{}); ok {
+			if _, ok := config["cidr_blocks"]; ok {
+				cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
+				result.CidrBlocks = make([]*containerBeta.CidrBlock, 0)
+				for _, v := range cidrBlocks {
+					cidrBlock := v.(map[string]interface{})
+					result.CidrBlocks = append(result.CidrBlocks, &containerBeta.CidrBlock{
+						CidrBlock:   cidrBlock["cidr_block"].(string),
+						DisplayName: cidrBlock["display_name"].(string),
+					})
+				}
 			}
 		}
 	}

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -235,7 +235,16 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"8.8.8.8/32"}),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{}, "cidr_blocks = []"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
+						"master_authorized_networks_config.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
+						"master_authorized_networks_config.0.cidr_blocks.#", "0"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"8.8.8.8/32"}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
 						"master_authorized_networks_config.0.cidr_blocks.#", "1"),
@@ -248,7 +257,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportStateIdPrefix: "us-central1-a/",
 			},
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"10.0.0.0/8", "8.8.8.8/32"}),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"10.0.0.0/8", "8.8.8.8/32"}, ""),
 			},
 			{
 				ResourceName:        "google_container_cluster.with_master_authorized_networks",
@@ -257,7 +266,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportStateIdPrefix: "us-central1-a/",
 			},
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{}),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_cluster.with_master_authorized_networks",
 						"master_authorized_networks_config.0.cidr_blocks"),
@@ -1490,9 +1499,9 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 }`, clusterName)
 }
 
-func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName string, cidrs []string) string {
+func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName string, cidrs []string, emptyValue string) string {
 
-	cidrBlocks := ""
+	cidrBlocks := emptyValue
 	if len(cidrs) > 0 {
 		var buf bytes.Buffer
 		buf.WriteString("cidr_blocks = [")


### PR DESCRIPTION
Upon providing

```HCL
master_authorized_networks_config {
  cidr_blocks = []
}
```

the logic asserts that `[nil]` conforms to `[]interface{}` which will cause a run-time panic.

Initially, I modified the test cases to walk through a case in which `cidr_blocks` is set to an empty list. For this, I had to modify the test to accept the argument `emptyValue` which contains the string value which is interpolated into the HCL snippet under test only when the `cidrs` array is empty. Since `emptyValue` is set to an empty string for the original test cases, they exhibit the exact same behavior as they did prior to the changes I'm introducing here i.e.: when `cidrs` is empty they interpolate an empty string into the part of the HCL snippet where the `cidr_blocks` element would otherwise be presented, subsequently producing

```HCL
master_authorized_networks_config {
}
```

which is why the empty list scenario wasn't originally tested.

In a Terraform configuration where `cidr_blocks` is populated through a variable of the list type which can't just be set to an empty string, the variable `gke_authorized_cidr_blocks` declared as

```HCL
variable "gke_authorized_cidr_blocks" {
  type = "list",
  default = [{cidr_block="0.0.0.0/0", display_name = "Looking to get hacked"}]
}
```

and referenced as

```HCL
master_authorized_networks_config {
  cidr_blocks = "${vars.gke_authorized_cidr_blocks}"
}
```

would not be settable to `""` without violating the validations on the HCL list type, thus one may easily find oneself in a scenario where the panic is bound to happen.

Furthermore, I've modified `flattenMasterAuthorizedNetworksConfig` to be able to deal with the idea that CidrBlocks may now be an empty array. Instead of returning `nil` in that case, the logic simply allows the function to continue and return a map with `cidr_blocks` set to an empty array.