### PR TITLE
Document a default in google_storage_bucket

### DIFF
--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -117,7 +117,7 @@ The `logging` block supports:
 * `log_bucket` - (Required) The bucket that will receive log objects.
 
 * `log_object_prefix` - (Optional, Computed) The object prefix for log objects. If it's not provided,
-    by default GCS sets this to the log_bucket's name.
+    by default GCS sets this to this bucket's name.
 
 The `encryption` block supports:
 


### PR DESCRIPTION
The default of the log_object_prefix is the name of the bucket we are
enabling logging on, not the name of the bucket that receives the logs.

I couldn't find this documented anywhere in the GCP API, but we observed
this to be true.