### PR TITLE
[WIP] Add support for firewall logging

### DIFF
--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -111,6 +111,11 @@ func resourceComputeFirewall() *schema.Resource {
 				Optional: true,
 			},
 
+			"enable_logging": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -266,6 +271,7 @@ func resourceComputeFirewallRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("network", ConvertSelfLinkToV1(firewall.Network))
 	d.Set("direction", firewall.Direction)
 	d.Set("description", firewall.Description)
+	d.Set("enable_logging", firewall.EnableLogging)
 	d.Set("project", project)
 	d.Set("source_ranges", firewall.SourceRanges)
 	d.Set("source_tags", firewall.SourceTags)
@@ -418,6 +424,7 @@ func resourceFirewall(d *schema.ResourceData, meta interface{}) (*computeBeta.Fi
 		SourceServiceAccounts: convertStringSet(d.Get("source_service_accounts").(*schema.Set)),
 		TargetServiceAccounts: convertStringSet(d.Get("target_service_accounts").(*schema.Set)),
 		Disabled:              d.Get("disabled").(bool),
-		ForceSendFields:       []string{"Disabled", "Allowed", "Denied", "SourceRanges", "SourceTags", "DestinationRanges", "TargetTags"},
+		EnableLogging:         d.Get("enable_logging").(bool),
+		ForceSendFields:       []string{"Disabled", "Allowed", "Denied", "EnableLogging", "SourceRanges", "SourceTags", "DestinationRanges", "TargetTags"},
 	}, nil
 }

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `description` - (Optional) Textual description field.
 
+* `enable_logging` - (Optional) Denotes whether to enable logging for a particular firewall rule. If logging is enabled, logs will be exported to Stackdriver.
+
 * `disabled` - (Optional) Denotes whether the firewall rule is disabled, i.e not applied to the network it is associated with.
     When set to true, the firewall rule is not enforced and the network behaves as if it did not exist.
 


### PR DESCRIPTION
Hi,

I have need for the `enableLogging` feature in the beta `compute.Firewall` API (https://cloud.google.com/compute/docs/reference/rest/beta/firewalls). I haven't seen it discussed in the tracker anywhere, or referenced in a branch that I could find, so I thought I'd add support.

It looks like the `google_compute_firewall` resource might be in a sort of in-flight state; the implementation appears to use the beta package, but the tests are currently written against v1.

With that in mind, I've made a best effort at trying to fit test coverage in, but please let me know if I'm completely off base here, or if you'd prefer it done differently. This is my first contribution back; thanks for all the work!

```
$ make testacc TEST=./google TESTARGS='-run=TestAccComputeFirewallBeta_enableLogging'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v -run=TestAccComputeFirewallBeta_enableLogging -timeout 120m
=== RUN   TestAccComputeFirewallBeta_enableLogging
=== PAUSE TestAccComputeFirewallBeta_enableLogging
=== CONT  TestAccComputeFirewallBeta_enableLogging
--- PASS: TestAccComputeFirewallBeta_enableLogging (106.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	(cached)
```
 