### PR TITLE
Naive move from debian 8 to debian 9.

### DIFF
--- a/google/data_source_google_compute_instance_group_test.go
+++ b/google/data_source_google_compute_instance_group_test.go
@@ -200,7 +200,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 
@@ -238,7 +238,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 
@@ -284,7 +284,7 @@ resource "google_compute_instance_template" "igm-basic" {
   machine_type = "n1-standard-1"
 
   disk {
-    source_image = "debian-cloud/debian-8-jessie-v20160803"
+    source_image = "debian-cloud/debian-9-stretch-v20180806"
     auto_delete = true
     boot = true
   }

--- a/google/image_test.go
+++ b/google/image_test.go
@@ -64,11 +64,11 @@ func testAccCheckComputeImageResolution(n string) resource.TestCheckFunc {
 		link := rs.Primary.Attributes["self_link"]
 
 		images := map[string]string{
-			"family/debian-8":                                               "projects/debian-cloud/global/images/family/debian-8",
-			"projects/debian-cloud/global/images/debian-8-jessie-v20170110": "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
-			"debian-8":                                                                                            "projects/debian-cloud/global/images/family/debian-8",
-			"debian-8-jessie-v20170110":                                                                           "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
-			"https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170110": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+			"family/debian-9":                                               "projects/debian-cloud/global/images/family/debian-9",
+			"projects/debian-cloud/global/images/debian-9-stretch-v20180806": "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			"debian-9":                                                                                            "projects/debian-cloud/global/images/family/debian-9",
+			"debian-9-stretch-v20180806":                                                                           "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			"https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 
 			"global/images/" + name:          "global/images/" + name,
 			"global/images/family/" + family: "global/images/family/" + family,
@@ -98,7 +98,7 @@ func testAccComputeImage_resolving(name, family string) string {
 resource "google_compute_disk" "foobar" {
 	name = "%s"
 	zone = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 }
 resource "google_compute_image" "foobar" {
 	name = "%s"

--- a/google/image_test.go
+++ b/google/image_test.go
@@ -64,9 +64,9 @@ func testAccCheckComputeImageResolution(n string) resource.TestCheckFunc {
 		link := rs.Primary.Attributes["self_link"]
 
 		images := map[string]string{
-			"family/debian-9":                                               "projects/debian-cloud/global/images/family/debian-9",
+			"family/debian-9":                                                "projects/debian-cloud/global/images/family/debian-9",
 			"projects/debian-cloud/global/images/debian-9-stretch-v20180806": "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
-			"debian-9":                                                                                            "projects/debian-cloud/global/images/family/debian-9",
+			"debian-9":                                                                                             "projects/debian-cloud/global/images/family/debian-9",
 			"debian-9-stretch-v20180806":                                                                           "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			"https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 

--- a/google/resource_compute_autoscaler_test.go
+++ b/google/resource_compute_autoscaler_test.go
@@ -228,7 +228,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_backend_service_test.go
+++ b/google/resource_compute_backend_service_test.go
@@ -713,7 +713,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "debian-9-stretch-v20180806"
     auto_delete  = true
     boot         = true
   }
@@ -767,7 +767,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "debian-9-stretch-v20180806"
     auto_delete  = true
     boot         = true
   }
@@ -919,7 +919,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "debian-9-stretch-v20180806"
     auto_delete  = true
     boot         = true
   }
@@ -972,7 +972,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "debian-9-stretch-v20180806"
     auto_delete  = true
     boot         = true
   }

--- a/google/resource_compute_disk_test.go
+++ b/google/resource_compute_disk_test.go
@@ -20,71 +20,71 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 	}{
 		// Full & partial links
 		"matching self_link with different api version": {
-			Old:                "https://www.googleapis.com/compute/beta/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/beta/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			ExpectDiffSuppress: true,
 		},
 		"matching image partial self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			ExpectDiffSuppress: true,
 		},
 		"matching image partial no project self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "global/images/debian-9-stretch-v20180806",
 			ExpectDiffSuppress: true,
 		},
 		"different image self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
 		"different image partial self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "projects/debian-cloud/global/images/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
 		"different image partial no project self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "global/images/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
 		// Image name
 		"matching image name": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "debian-9-stretch-v20180806",
 			ExpectDiffSuppress: true,
 		},
 		"different image name": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
 		// Image short hand
 		"matching image short hand": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian-cloud/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "debian-cloud/debian-9-stretch-v20180806",
 			ExpectDiffSuppress: true,
 		},
 		"matching image short hand but different project": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "different-cloud/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "different-cloud/debian-9-stretch-v20180806",
 			ExpectDiffSuppress: false,
 		},
 		"different image short hand": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "debian-cloud/debian-7-jessie-v20171213",
 			ExpectDiffSuppress: false,
 		},
 		// Image Family
 		"matching image family": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "family/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching image family self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching unconventional image family self link": {
@@ -93,8 +93,8 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: true,
 		},
 		"matching image family partial self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "projects/debian-cloud/global/images/family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "projects/debian-cloud/global/images/family/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching unconventional image family partial self link": {
@@ -103,18 +103,18 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: true,
 		},
 		"matching image family partial no project self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "global/images/family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "global/images/family/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching image family short hand": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian-cloud/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "debian-cloud/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching image family short hand with project short name": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "debian/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "debian/debian-9",
 			ExpectDiffSuppress: true,
 		},
 		"matching unconventional image family short hand": {
@@ -128,43 +128,43 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: true,
 		},
 		"different image family": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "family/debian-7",
 			ExpectDiffSuppress: false,
 		},
 		"different image family self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-7",
 			ExpectDiffSuppress: false,
 		},
 		"different image family partial self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "projects/debian-cloud/global/images/family/debian-7",
 			ExpectDiffSuppress: false,
 		},
 		"different image family partial no project self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "global/images/family/debian-7",
 			ExpectDiffSuppress: false,
 		},
 		"matching image family but different project in self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "https://www.googleapis.com/compute/v1/projects/other-cloud/global/images/family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "https://www.googleapis.com/compute/v1/projects/other-cloud/global/images/family/debian-9",
 			ExpectDiffSuppress: false,
 		},
 		"different image family but different project in partial self link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "projects/other-cloud/global/images/family/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "projects/other-cloud/global/images/family/debian-9",
 			ExpectDiffSuppress: false,
 		},
 		"different image family short hand": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 			New:                "debian-cloud/debian-7",
 			ExpectDiffSuppress: false,
 		},
 		"matching image family shorthand but different project": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
-			New:                "different-cloud/debian-8",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806",
+			New:                "different-cloud/debian-9",
 			ExpectDiffSuppress: false,
 		},
 	}
@@ -607,7 +607,7 @@ func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -621,7 +621,7 @@ func testAccComputeDisk_timeout() string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	type  = "pd-ssd"
 	zone  = "us-central1-a"
 
@@ -635,7 +635,7 @@ func testAccComputeDisk_updated(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 100
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -650,7 +650,7 @@ func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, d
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "d1-%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -677,7 +677,7 @@ func testAccComputeDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -689,7 +689,7 @@ func testAccComputeDisk_encryptionMigrate(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -703,7 +703,7 @@ func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foo" {
 	name = "%s"
-	image = "debian-8-jessie-v20170523"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -716,7 +716,7 @@ resource "google_compute_instance" "bar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20170523"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -734,7 +734,7 @@ func testAccComputeDisk_deleteDetachIGM(diskName, mgrName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foo" {
 	name = "%s"
-	image = "debian-8-jessie-v20170523"
+	image = "debian-9-stretch-v20180806"
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"

--- a/google/resource_compute_image_test.go
+++ b/google/resource_compute_image_test.go
@@ -324,7 +324,7 @@ func testAccComputeImage_basedondisk() string {
 resource "google_compute_disk" "foobar" {
 	name = "disk-test-%s"
 	zone = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 }
 resource "google_compute_image" "foobar" {
 	name = "image-test-%s"

--- a/google/resource_compute_instance_from_template_test.go
+++ b/google/resource_compute_instance_from_template_test.go
@@ -59,7 +59,7 @@ func testAccComputeInstanceFromTemplate_basic(instance, template string) string 
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -70,7 +70,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-cloud/debian-8"
+		source_image = "debian-cloud/debian-9"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -699,7 +699,7 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -753,7 +753,7 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -790,7 +790,7 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -839,7 +839,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -876,7 +876,7 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -924,7 +924,7 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -964,7 +964,7 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 		tags = ["terraform-testing"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -1005,7 +1005,7 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	tags = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1053,7 +1053,7 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	tags = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1097,7 +1097,7 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -1143,7 +1143,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1195,7 +1195,7 @@ resource "google_compute_instance_template" "igm-primary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1216,7 +1216,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1266,7 +1266,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_instance_group_test.go
+++ b/google/resource_compute_instance_group_test.go
@@ -315,7 +315,7 @@ func testAccComputeInstanceGroup_basic(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -365,7 +365,7 @@ func testAccComputeInstanceGroup_update(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -402,7 +402,7 @@ func testAccComputeInstanceGroup_update2(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -439,7 +439,7 @@ func testAccComputeInstanceGroup_recreateInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -476,7 +476,7 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -493,7 +493,7 @@ func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 
@@ -533,7 +533,7 @@ func testAccComputeInstanceGroup_network(instance string) string {
 
 		boot_disk {
 			initialize_params {
-				image = "debian-8-jessie-v20160803"
+				image = "debian-9-stretch-v20180806"
 			}
 		}
 

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -125,7 +125,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 		},
@@ -192,7 +192,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 		},
@@ -254,7 +254,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	diskName := fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
 	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
@@ -274,7 +274,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -334,7 +334,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	diskName := fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	disk := &compute.Disk{
 		Name:        diskName,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
 	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
@@ -354,7 +354,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -416,13 +416,13 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -449,7 +449,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-8",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone": zone,
@@ -484,13 +484,13 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{
 					RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -517,7 +517,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-8",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-9",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone": zone,
@@ -551,19 +551,19 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 				},
 			},
 		},
@@ -587,9 +587,9 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-8",
+		"disk.1.image":       "global/images/family/debian-9",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -623,19 +623,19 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 				},
 			},
 		},
@@ -659,9 +659,9 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-8-jessie-v20170110",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-9-stretch-v20180806",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-8",
+		"disk.1.image":       "global/images/family/debian-9",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -695,7 +695,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{
@@ -759,7 +759,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 			{
 				Boot: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "projects/debian-cloud/global/images/family/debian-8",
+					SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 				},
 			},
 			{

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -31,7 +31,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-9-stretch-v20180806", true, true),
 					testAccCheckComputeInstanceTemplateContainsLabel(&instanceTemplate, "my_label", "foobar"),
 				),
 			},
@@ -193,7 +193,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-9-stretch-v20180806", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
 			},
@@ -735,7 +735,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -772,7 +772,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -808,7 +808,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 	}
 
 	network_interface {
@@ -831,7 +831,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 	}
 
 	network_interface {
@@ -851,7 +851,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 	}
 
 	network_interface {
@@ -873,7 +873,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 	}
 
 	network_interface {
@@ -891,7 +891,7 @@ func testAccComputeInstanceTemplate_disks() string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "instancet-test-%s"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -902,7 +902,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true
@@ -936,7 +936,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 		machine_type = "n1-standard-1"
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-9-stretch-v20180806"
 			auto_delete = true
 			disk_size_gb = 10
 			boot = true
@@ -972,7 +972,7 @@ resource "google_compute_instance_template" "foobar" {
 	region = "us-central1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1043,7 +1043,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 		region = "us-central1"
 
 		disk {
-			source_image = "debian-8-jessie-v20160803"
+			source_image = "debian-9-stretch-v20180806"
 			auto_delete = true
 			disk_size_gb = 10
 			boot = true
@@ -1068,7 +1068,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1093,7 +1093,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1132,7 +1132,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1165,7 +1165,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true
@@ -1194,7 +1194,7 @@ resource "google_compute_instance_template" "foobar" {
 	machine_type = "n1-standard-1"
 
 	disk {
-		source_image = "debian-8-jessie-v20160803"
+		source_image = "debian-9-stretch-v20180806"
 		auto_delete = true
 		disk_size_gb = 10
 		boot = true

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1549,7 +1549,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1587,7 +1587,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8"
+			image = "debian-9"
 		}
 	}
 
@@ -1613,7 +1613,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-cloud/debian-8-jessie-v20160803"
+			image = "debian-cloud/debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1639,7 +1639,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-cloud/debian-8"
+			image = "debian-cloud/debian-9"
 		}
 	}
 
@@ -1666,7 +1666,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1693,7 +1693,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1716,7 +1716,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803"
+			image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1739,7 +1739,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1767,7 +1767,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1804,7 +1804,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1832,7 +1832,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1860,7 +1860,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1887,7 +1887,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -1948,7 +1948,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 		disk_encryption_key_raw = "%s"
 	}
@@ -2004,7 +2004,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2035,7 +2035,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2066,7 +2066,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2105,7 +2105,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2147,7 +2147,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2179,7 +2179,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2200,7 +2200,7 @@ func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2224,7 +2224,7 @@ func testAccComputeInstance_bootDisk_sourceUrl(disk, instance string) string {
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -2252,7 +2252,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image	= "debian-8-jessie-v20160803"
+			image	= "debian-9-stretch-v20180806"
 			type	= "%s"
 		}
 	}
@@ -2273,7 +2273,7 @@ resource "google_compute_instance" "scratch" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2302,7 +2302,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2330,7 +2330,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2360,7 +2360,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2395,7 +2395,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2468,7 +2468,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2500,7 +2500,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2531,7 +2531,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2550,7 +2550,7 @@ func testAccComputeInstance_private_image_family(disk, family, instance string) 
 resource "google_compute_disk" "foobar" {
 	name  = "%s"
 	zone  = "us-central1-a"
-	image = "debian-8-jessie-v20160803"
+	image = "debian-9-stretch-v20180806"
 }
 
 resource "google_compute_image" "foobar" {
@@ -2590,7 +2590,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2625,7 +2625,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "debian-9-stretch-v20180806"
     }
   }
 
@@ -2654,7 +2654,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "debian-9-stretch-v20180806"
     }
   }
 
@@ -2675,7 +2675,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "debian-9-stretch-v20180806"
     }
   }
 
@@ -2711,7 +2711,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "debian-9-stretch-v20180806"
     }
   }
 
@@ -2748,7 +2748,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-8-jessie-v20160803"
+      image = "debian-9-stretch-v20180806"
     }
   }
 
@@ -2772,7 +2772,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2804,7 +2804,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 
@@ -2835,7 +2835,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 

--- a/google/resource_compute_region_autoscaler_test.go
+++ b/google/resource_compute_region_autoscaler_test.go
@@ -159,7 +159,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -219,7 +219,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}

--- a/google/resource_compute_region_backend_service_test.go
+++ b/google/resource_compute_region_backend_service_test.go
@@ -338,7 +338,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-8-jessie-v20160803"
+    source_image = "debian-9-stretch-v20180806"
     auto_delete  = true
     boot         = true
   }

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -667,7 +667,7 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -721,7 +721,7 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -758,7 +758,7 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -807,7 +807,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -844,7 +844,7 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -892,7 +892,7 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 		tags = ["%s"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -932,7 +932,7 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 		tags = ["foo", "bar"]
 
 		disk {
-			source_image = "debian-cloud/debian-8-jessie-v20160803"
+			source_image = "debian-cloud/debian-9-stretch-v20180806"
 			auto_delete = true
 			boot = true
 		}
@@ -978,7 +978,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1029,7 +1029,7 @@ resource "google_compute_instance_template" "igm-primary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1050,7 +1050,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1096,7 +1096,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	can_ip_forward = false
 	tags = ["foo", "bar"]
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete = true
 		boot = true
 	}
@@ -1128,7 +1128,7 @@ resource "google_compute_instance_template" "igm-update-strategy" {
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete  = true
 		boot         = true
 	}
@@ -1169,7 +1169,7 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete  = true
 		boot         = true
 	}
@@ -1220,7 +1220,7 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 	tags           = ["terraform-testing"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "debian-cloud/debian-9-stretch-v20180806"
 		auto_delete  = true
 		boot         = true
 	}

--- a/google/resource_compute_route_test.go
+++ b/google/resource_compute_route_test.go
@@ -179,7 +179,7 @@ resource "google_compute_instance" "foo" {
 
   boot_disk {
     initialize_params{
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 

--- a/google/resource_compute_snapshot_test.go
+++ b/google/resource_compute_snapshot_test.go
@@ -212,7 +212,7 @@ func testAccComputeSnapshot_basic(snapshotName, diskName, labelValue string) str
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160921"
+	image = "debian-9-stretch-v20180806"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"
@@ -232,7 +232,7 @@ func testAccComputeSnapshot_encryption(snapshotName string, diskName string) str
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
 	name = "%s"
-	image = "debian-8-jessie-v20160921"
+	image = "debian-9-stretch-v20180806"
 	size = 10
 	type = "pd-ssd"
 	zone = "us-central1-a"

--- a/google/resource_compute_target_pool_test.go
+++ b/google/resource_compute_target_pool_test.go
@@ -117,7 +117,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params{
-			image = "debian-8-jessie-v20160803"
+			image = "debian-9-stretch-v20180806"
 		}
 	}
 


### PR DESCRIPTION
I upgraded us to debian 9.  I also took the opportunity to homogenize all our `debian-8-jessie-v201X-XX-XX` into today's up-to-date `debian-9` image, not for any particular reason, just cause it'll be easier next time if it's all homogenous.

This fixes more than half of our broken tests - 🤦‍♂️.

All the image tests pass, and the Instance tests (all ~15 of them) are passing right now.