### PR TITLE
Clean up `google_project_usage_export_bucket` code and docs.

### DIFF
--- a/website/docs/r/usage_export_bucket.html.markdown
+++ b/website/docs/r/usage_export_bucket.html.markdown
@@ -3,7 +3,7 @@ layout: "google"
 page_title: "Google: google_project_usage_export_bucket"
 sidebar_current: "docs-google-project-usage-export-bucket"
 description: |-
-  Creates a dataset resource for Google BigQuery.
+  Manages a project's usage export bucket.
 ---
 
 # google_project_usage_export_bucket
@@ -16,23 +16,32 @@ For more information see the [Docs](https://cloud.google.com/compute/docs/usage-
 and for further details, the
 [API Documentation](https://cloud.google.com/compute/docs/reference/rest/beta/projects/setUsageExportBucket).
 
+~> **Note:** You should specify only one of these per project.  If there are two or more
+they will fight over which bucket the reports should be stored in.  It is
+safe to have multiple resources with the same backing bucket.
 
 ## Example Usage
 
 ```hcl
-resource "google_project_usage_export_bucket" "export" {
-  project      = "foo"
-  bucket_name  = "bar"
+resource "google_project_usage_export_bucket" "usage_export" {
+  project      = "development-project"
+  bucket_name  = "usage-tracking-bucket"
 }
 ```
 
 ## Argument Reference
-* `project`: (Required) The project to set the export bucket on.
 * `bucket_name`: (Required) The bucket to store reports in.
+
+- - -
+
 * `prefix`: (Optional) A prefix for the reports, for instance, the project name.
 
-## Note
+* `project`: (Optional) The project to set the export bucket on. If it is not provided, the provider project is used.
 
-You should specify only one of these per project.  If there are two or more
-they will fight over which bucket the reports should be stored in.  It is
-safe to have multiple resources with the same backing bucket.
+## Import
+
+A project's Usage Export Bucket can be imported using this format:
+
+```
+$ terraform import google_project_usage_export_bucket.usage_export {{project}}
+```


### PR DESCRIPTION
Trying to fix a CI test for `google_project_usage_export_bucket` - I can't repro locally, but how we were getting the project from an ID was weird. Now, we fill in `project` when importing, and properly use `getProject` instead of pulling it from the id. Hopefully the error message will change on CI as a result of this.

Also update docs to include import, and a move a note from a separate header to a note box.