### PR TITLE
fix panic on gke binauth

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -761,7 +761,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("monitoring_service", cluster.MonitoringService)
 	d.Set("network", cluster.NetworkConfig.Network)
 	d.Set("subnetwork", cluster.NetworkConfig.Subnetwork)
-	d.Set("enable_binary_authorization", cluster.BinaryAuthorization.Enabled)
+	d.Set("enable_binary_authorization", cluster.BinaryAuthorization != nil && cluster.BinaryAuthorization.Enabled)
 	if err := d.Set("node_config", flattenNodeConfig(cluster.NodeConfig)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Tests didn't catch it because we always send a binauth block on create now, but any clusters created previously will crash on plan. Verified with an old cluster I had lying around.

Fixes #1920 