### PR TITLE
Fix service account key data source name

### DIFF
--- a/google/data_source_google_service_account_key.go
+++ b/google/data_source_google_service_account_key.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"log"
 	"regexp"
 )
 
@@ -43,7 +42,6 @@ func dataSourceGoogleServiceAccountKey() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"name"},
 				Deprecated:    "Please use name to specify full service account key path projects/{project}/serviceAccounts/{serviceAccount}/keys/{keyId}",
-				ValidateFunc:  validateRegexp(ServiceAccountKeyNameRegex),
 			},
 		},
 	}
@@ -89,7 +87,8 @@ func getDataSourceServiceAccountKeyName(d *schema.ResourceData) (string, error) 
 		fullKeyName = keyFromSAId
 	}
 
-	log.Printf("[DEBUG] FULL KEY NAME: %q %q %q", fullKeyName, keyName, keyFromSAId)
+	// Validate name since interpolated values (i.e from a key or service
+	// account resource) will not get validated at plan time.
 	r := regexp.MustCompile(ServiceAccountKeyNameRegex)
 	if r.MatchString(fullKeyName) {
 		return fullKeyName, nil

--- a/google/data_source_google_service_account_key.go
+++ b/google/data_source_google_service_account_key.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"regexp"
 )
 
 func dataSourceGoogleServiceAccountKey() *schema.Resource {
@@ -12,24 +13,20 @@ func dataSourceGoogleServiceAccountKey() *schema.Resource {
 		Read: dataSourceGoogleServiceAccountKeyRead,
 
 		Schema: map[string]*schema.Schema{
-			"service_account_id": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
-			"public_key_type": &schema.Schema{
+			"public_key_type": {
 				Type:         schema.TypeString,
 				Default:      "TYPE_X509_PEM_FILE",
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"TYPE_NONE", "TYPE_X509_PEM_FILE", "TYPE_RAW_PUBLIC_KEY"}, false),
 			},
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			// Computed
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"key_algorithm": {
 				Type:     schema.TypeString,
@@ -39,6 +36,12 @@ func dataSourceGoogleServiceAccountKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"service_account_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				Deprecated:    "Please use name to specify full service account key path projects/{project}/serviceAccounts/{serviceAccount}/keys/{keyId}",
+			},
 		},
 	}
 }
@@ -46,7 +49,7 @@ func dataSourceGoogleServiceAccountKey() *schema.Resource {
 func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	serviceAccountName, err := serviceAccountFQN(d.Get("service_account_id").(string), d, config)
+	keyName, err := getDataSourceServiceAccountKeyName(d)
 	if err != nil {
 		return err
 	}
@@ -54,9 +57,9 @@ func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interfac
 	publicKeyType := d.Get("public_key_type").(string)
 
 	// Confirm the service account key exists
-	sak, err := config.clientIAM.Projects.ServiceAccounts.Keys.Get(serviceAccountName).PublicKeyType(publicKeyType).Do()
+	sak, err := config.clientIAM.Projects.ServiceAccounts.Keys.Get(keyName).PublicKeyType(publicKeyType).Do()
 	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("Service Account Key %q", serviceAccountName))
+		return handleNotFoundError(err, d, fmt.Sprintf("Service Account Key %q", keyName))
 	}
 
 	d.SetId(sak.Name)
@@ -66,4 +69,31 @@ func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interfac
 	d.Set("public_key", sak.PublicKeyData)
 
 	return nil
+}
+
+func getDataSourceServiceAccountKeyName(d *schema.ResourceData) (string, error) {
+	r := regexp.MustCompile("projects/(.+)/serviceAccounts/(.+)/keys/(.+)")
+
+	keyName := d.Get("name").(string)
+	keyFromSAId := d.Get("service_account_id").(string)
+
+	// Neither name nor service_account_id specified
+	if keyName == "" && keyFromSAId == "" {
+		return "", fmt.Errorf("please use name to specify service account key being added as this data source")
+	}
+	// Both name and service_account_id specified
+	if keyName != "" && keyFromSAId != "" {
+		return "", fmt.Errorf("please do not use both name and deprecated service_account_id fields")
+	}
+
+	fullKeyName := keyName
+	// Key name specified as incorrectly named, deprecated service account ID field
+	if keyName == "" {
+		fullKeyName = keyFromSAId
+	}
+
+	if r.MatchString(fullKeyName) {
+		return fullKeyName, nil
+	}
+	return "", fmt.Errorf("invalid key name '%s'; please use 'name' field to specify service account key name", fullKeyName)
 }

--- a/google/data_source_google_service_account_key_test.go
+++ b/google/data_source_google_service_account_key_test.go
@@ -111,7 +111,7 @@ resource "google_service_account_key" "acceptance" {
 }
 
 data "google_service_account_key" "acceptance" {
-	service_account_id = "${google_service_account_key.acceptance.id}"
+	service_account_id = "${google_service_account_key.acceptance.name}"
 }`, account)
 }
 

--- a/google/data_source_google_service_account_key_test.go
+++ b/google/data_source_google_service_account_key_test.go
@@ -70,14 +70,14 @@ func TestAccDatasourceGoogleServiceAccountKey_errors(t *testing.T) {
 					account,
 					`name = "${google_service_account.acceptance.name}"`),
 				ExpectError: regexp.MustCompile(
-					fmt.Sprintf("invalid key name '%s'", serviceAccountName)),
+					fmt.Sprintf("invalid key name %q", serviceAccountName)),
 			},
 			{
 				Config: testAccDatasourceGoogleServiceAccountKey_error(
 					account,
 					`service_account_id = "${google_service_account.acceptance.id}"`),
 				ExpectError: regexp.MustCompile(
-					fmt.Sprintf("invalid key name '%s'", serviceAccountName)),
+					fmt.Sprintf("invalid key name %q", serviceAccountName)),
 			},
 		},
 	})
@@ -95,7 +95,7 @@ resource "google_service_account_key" "acceptance" {
 }
 
 data "google_service_account_key" "acceptance" {
-	name = "${google_service_account_key.acceptance.id}"
+	name = "${google_service_account_key.acceptance.name}"
 }`, account)
 }
 

--- a/google/data_source_google_service_account_key_test.go
+++ b/google/data_source_google_service_account_key_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"strings"
 )
 
 func TestAccDatasourceGoogleServiceAccountKey_basic(t *testing.T) {
@@ -25,7 +26,7 @@ func TestAccDatasourceGoogleServiceAccountKey_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDatasourceGoogleServiceAccountKey(account),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleServiceAccountKeyExists(resourceName),
@@ -34,6 +35,49 @@ func TestAccDatasourceGoogleServiceAccountKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "key_algorithm"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
 				),
+			},
+			{
+				Config: testAccDatasourceGoogleServiceAccountKey_deprecated(account),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleServiceAccountKeyExists(resourceName),
+					// Check that the 'name' starts with the service account name
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(serviceAccountName)),
+					resource.TestCheckResourceAttrSet(resourceName, "key_algorithm"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceGoogleServiceAccountKey_errors(t *testing.T) {
+	t.Parallel()
+
+	account := acctest.RandomWithPrefix("tf-test")
+	serviceAccountName := fmt.Sprintf(
+		"projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com",
+		getTestProjectFromEnv(),
+		account,
+		getTestProjectFromEnv(),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceGoogleServiceAccountKey_error(
+					account,
+					`name = "${google_service_account.acceptance.name}"`),
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf("invalid key name '%s'", serviceAccountName)),
+			},
+			{
+				Config: testAccDatasourceGoogleServiceAccountKey_error(
+					account,
+					`service_account_id = "${google_service_account.acceptance.id}"`),
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf("invalid key name '%s'", serviceAccountName)),
 			},
 		},
 	})
@@ -51,6 +95,38 @@ resource "google_service_account_key" "acceptance" {
 }
 
 data "google_service_account_key" "acceptance" {
+	name = "${google_service_account_key.acceptance.id}"
+}`, account)
+}
+
+func testAccDatasourceGoogleServiceAccountKey_deprecated(account string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "acceptance" {
+	account_id = "%s"
+}
+
+resource "google_service_account_key" "acceptance" {
+	service_account_id = "${google_service_account.acceptance.name}"
+	public_key_type = "TYPE_X509_PEM_FILE"
+}
+
+data "google_service_account_key" "acceptance" {
 	service_account_id = "${google_service_account_key.acceptance.id}"
 }`, account)
+}
+
+func testAccDatasourceGoogleServiceAccountKey_error(account string, incorrectDataFields ...string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "acceptance" {
+	account_id = "%s"
+}
+
+resource "google_service_account_key" "acceptance" {
+	service_account_id = "${google_service_account.acceptance.name}"
+	public_key_type = "TYPE_X509_PEM_FILE"
+}
+
+data "google_service_account_key" "acceptance" {
+%s
+}`, account, strings.Join(incorrectDataFields, "\n\t"))
 }

--- a/google/validation.go
+++ b/google/validation.go
@@ -42,6 +42,8 @@ var (
 	}
 	ServiceAccountLinkRegex = ServiceAccountLinkRegexPrefix + "(" + strings.Join(PossibleServiceAccountNames, "|") + ")"
 
+	ServiceAccountKeyNameRegex = ServiceAccountLinkRegexPrefix + "(.+)/keys/(.+)"
+
 	// Format of service accounts created through the API
 	CreatedServiceAccountNameRegex = fmt.Sprintf(RFC1035NameTemplate, 4, 28) + "@" + ProjectNameInDNSFormRegex + "\\.iam\\.gserviceaccount\\.com$"
 	ProjectNameInDNSFormRegex      = "[-a-z0-9\\.]{1,63}"

--- a/website/docs/d/datasource_google_service_account_key.html.markdown
+++ b/website/docs/d/datasource_google_service_account_key.html.markdown
@@ -33,8 +33,8 @@ data "google_service_account_key" "mykey" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the service account key. This must have format
-`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}` is the email address or
-unique id of the service account.
+    `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
+    is the email address or unique id of the service account.
 
 * `project` - (Optional) The ID of the project that the service account will be created in.
     Defaults to the provider project configuration.

--- a/website/docs/d/datasource_google_service_account_key.html.markdown
+++ b/website/docs/d/datasource_google_service_account_key.html.markdown
@@ -14,17 +14,17 @@ Get service account public key. For more information, see [the official document
 ## Example Usage
 
 ```hcl
-data "google_service_account" "myaccount" {
-  account_id = "myaccount"
+resource "google_service_account" "myaccount" {
+  account_id = "dev-foo-account"
+}
+
+resource "google_service_account_key" "mykey" {
+  service_account_id = "${google_service_account.myaccount.name}"
 }
 
 data "google_service_account_key" "mykey" {
-  service_account_id = "${data.google_service_account.myaccount.name}"
+  name = "${google_service_account_key.mykey.name}"
   public_key_type = "TYPE_X509_PEM_FILE"
-}
-
-output "mykey_public_key" {
-  value = "${data.google_service_account_key.mykey.public_key}"
 }
 ```
 
@@ -32,9 +32,9 @@ output "mykey_public_key" {
 
 The following arguments are supported:
 
-* `service_account_id` - (Required) The Service account id of the Key Pair. This can be a string in the format
-`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the email address or
-unique id of the service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
+* `name` - (Required) The name of the service account key. This must have format
+`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}` is the email address or
+unique id of the service account.
 
 * `project` - (Optional) The ID of the project that the service account will be created in.
     Defaults to the provider project configuration.
@@ -44,7 +44,5 @@ unique id of the service account. If the `{ACCOUNT}` syntax is used, the project
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
-
-* `name` - The name used for this key pair
 
 * `public_key` - The public key, base64 encoded


### PR DESCRIPTION
Fixes #1909

$ make testacc TEST=./google TESTARGS='--run="TestAccDatasourceGoogleServiceAccountKey"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./google -v --run="TestAccDatasourceGoogleServiceAccountKey" -timeout 120m
=== RUN   TestAccDatasourceGoogleServiceAccountKey_basic
=== PAUSE TestAccDatasourceGoogleServiceAccountKey_basic
=== RUN   TestAccDatasourceGoogleServiceAccountKey_errors
=== PAUSE TestAccDatasourceGoogleServiceAccountKey_errors
=== CONT  TestAccDatasourceGoogleServiceAccountKey_basic
=== CONT  TestAccDatasourceGoogleServiceAccountKey_errors
--- PASS: TestAccDatasourceGoogleServiceAccountKey_errors (14.38s)
--- PASS: TestAccDatasourceGoogleServiceAccountKey_basic (18.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	18.281s