### PR TITLE
Force acceptance test failure if .Set errors

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
Many of the d.Set calls do not handle the error that comes back. This can lead
to things that appear to be set but are silently failing. This change adds a
flag to the makefile to force a panic if there are unhandled errors.

This is recommended behavior according to https://github.com/hashicorp/terraform/pull/16588