### PR TITLE
Ignore google provider binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ terraform.tfvars
 terraform.tfplan
 terraform.tfstate
 bin/
+terraform-provider-google
 modules-dev/
 /pkg/
 website/.vagrant


### PR DESCRIPTION
Running go build in the root dir will create this binary