### PR TITLE
Use beta API location for google_container_engine_versions

### DIFF
--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -79,7 +79,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	if len(location) == 0 {
-		return fmt.Errorf("Cannot determine location: set zone or region in this resource or at provider-level")
+		return fmt.Errorf("Cannot determine location: set zone or region in this data source or at provider-level")
 	}
 
 	resp, err := config.clientContainerBeta.Projects.Locations.

--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -19,6 +19,11 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"region": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"zone"},
+			},
 			"default_cluster_version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -53,12 +58,32 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	zone, err := getZone(d, meta.(*Config))
-	if err != nil {
-		return err
+	var location string
+	zone, hasZone := d.GetOk("zone")
+	if hasZone {
+		location = zone.(string)
+	}
+	region, hasRegion := d.GetOk("region")
+	if hasRegion {
+		location = region.(string)
 	}
 
-	resp, err := config.clientContainer.Projects.Zones.GetServerconfig(project, zone).Do()
+	if !hasZone && !hasRegion {
+		location, err = getZone(d, meta.(*Config))
+		if err != nil {
+			location, err = getRegion(d, meta.(*Config))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(location) == 0 {
+		return fmt.Errorf("Cannot determine location: set zone or region in this resource or at provider-level")
+	}
+
+	resp, err := config.clientContainerBeta.Projects.Locations.
+		GetServerConfig(fmt.Sprintf("projects/%s/locations/%s", project, location)).Do()
 	if err != nil {
 		return fmt.Errorf("Error retrieving available container cluster versions: %s", err.Error())
 	}
@@ -66,10 +91,13 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	d.Set("valid_master_versions", resp.ValidMasterVersions)
 	d.Set("default_cluster_version", resp.DefaultClusterVersion)
 	d.Set("valid_node_versions", resp.ValidNodeVersions)
-	d.Set("latest_master_version", resp.ValidMasterVersions[0])
-	d.Set("latest_node_version", resp.ValidNodeVersions[0])
+	if len(resp.ValidMasterVersions) > 0 {
+		d.Set("latest_master_version", resp.ValidMasterVersions[0])
+	}
+	if len(resp.ValidNodeVersions) > 0 {
+		d.Set("latest_node_version", resp.ValidNodeVersions[0])
+	}
 
 	d.SetId(time.Now().UTC().String())
-
 	return nil
 }

--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -58,32 +58,16 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	var location string
-	zone, hasZone := d.GetOk("zone")
-	if hasZone {
-		location = zone.(string)
+	location, err := getLocation(d, config)
+	if err != nil {
+		return err
 	}
-	region, hasRegion := d.GetOk("region")
-	if hasRegion {
-		location = region.(string)
-	}
-
-	if !hasZone && !hasRegion {
-		location, err = getZone(d, meta.(*Config))
-		if err != nil {
-			location, err = getRegion(d, meta.(*Config))
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	if len(location) == 0 {
 		return fmt.Errorf("Cannot determine location: set zone or region in this data source or at provider-level")
 	}
 
-	resp, err := config.clientContainerBeta.Projects.Locations.
-		GetServerConfig(fmt.Sprintf("projects/%s/locations/%s", project, location)).Do()
+	location = fmt.Sprintf("projects/%s/locations/%s", project, location)
+	resp, err := config.clientContainerBeta.Projects.Locations.GetServerConfig(location).Do()
 	if err != nil {
 		return fmt.Errorf("Error retrieving available container cluster versions: %s", err.Error())
 	}

--- a/google/data_source_google_container_engine_versions_test.go
+++ b/google/data_source_google_container_engine_versions_test.go
@@ -27,6 +27,23 @@ func TestAccContainerEngineVersions_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerEngineVersions_regional(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleContainerEngineVersionsRegionalConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleContainerEngineVersionsMeta("data.google_container_engine_versions.versions"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGoogleContainerEngineVersionsMeta(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -100,5 +117,11 @@ func testAccCheckGoogleContainerEngineVersionsMeta(n string) resource.TestCheckF
 var testAccCheckGoogleContainerEngineVersionsConfig = `
 data "google_container_engine_versions" "versions" {
   zone = "us-central1-b"
+}
+`
+
+var testAccCheckGoogleContainerEngineVersionsRegionalConfig = `
+data "google_container_engine_versions" "versions" {
+  region = "us-central1"
 }
 `

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # google\_container\_engine\_versions
 
-Provides access to available Google Container Engine versions in a zone for a given project.
+Provides access to available Google Container Engine versions in a zone or region for a given project.
 
 ```hcl
 data "google_container_engine_versions" "central1b" {
@@ -32,9 +32,22 @@ resource "google_container_cluster" "foo" {
 
 The following arguments are supported:
 
-* `zone` (required) - Zone to list available cluster versions for. Should match the zone the cluster will be deployed in.
+* `zone` (optional) - Zone to list available cluster versions for. Should match the zone the cluster will be deployed in.
+    One of zone or region must be given or inferred from provider
+
+* `region` (optional) - Region to list available cluster versions for. Should match the region the cluster will be deployed in.
+    One of zone or region must be given or inferred from provider
+
 * `project` (optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
   Defaults to the project that the provider is authenticated with.
+
+Terraform will attempt to get or infer the location (zone or region) in the following order:
+1. `zone` from data source config
+2. `region` from data source config
+3. Provider-default zone
+4. Provider-default region IF default zone is not given. If provider-default zone is given but you wish to use a
+   regional location, please specify it explicitly in the data source.
+
 
 ## Attributes Reference
 

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -44,9 +44,9 @@ The following arguments are supported:
 Terraform will attempt to get or infer the location (zone or region) in the following order:
 1. `zone` from data source config
 2. `region` from data source config
-3. Provider-default zone
-4. Provider-default region IF default zone is not given. If provider-default zone is given but you wish to use a
-   regional location, please specify it explicitly in the data source.
+3. Provider-level zone
+4. Provider-level region if no zone is given at provider-level. If provider-level zone is given but you wish to use a
+   regional location, please specify it in the data source.
 
 
 ## Attributes Reference

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -33,21 +33,13 @@ resource "google_container_cluster" "foo" {
 The following arguments are supported:
 
 * `zone` (optional) - Zone to list available cluster versions for. Should match the zone the cluster will be deployed in.
-    One of zone or region must be given or inferred from provider
+    If not specified, the provider-level zone is used.
 
 * `region` (optional) - Region to list available cluster versions for. Should match the region the cluster will be deployed in.
-    One of zone or region must be given or inferred from provider
+    For regional clusters, this value must be specified and cannot be inferred from provider-level region.
 
 * `project` (optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
   Defaults to the project that the provider is authenticated with.
-
-Terraform will attempt to get or infer the location (zone or region) in the following order:
-1. `zone` from data source config
-2. `region` from data source config
-3. Provider-level zone
-4. Provider-level region if no zone is given at provider-level. If provider-level zone is given but you wish to use a
-   regional location, please specify it in the data source.
-
 
 ## Attributes Reference
 

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -33,10 +33,11 @@ resource "google_container_cluster" "foo" {
 The following arguments are supported:
 
 * `zone` (optional) - Zone to list available cluster versions for. Should match the zone the cluster will be deployed in.
-    If not specified, the provider-level zone is used.
+    If not specified, the provider-level zone is used. One of zone, region, or provider-level zone is required.
 
 * `region` (optional) - Region to list available cluster versions for. Should match the region the cluster will be deployed in.
-    For regional clusters, this value must be specified and cannot be inferred from provider-level region.
+    For regional clusters, this value must be specified and cannot be inferred from provider-level region. One of zone,
+    region, or provider-level zone is required.
 
 * `project` (optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
   Defaults to the project that the provider is authenticated with.


### PR DESCRIPTION
v1beta1 for GKE API allows use of location (zone or region) instead of just zone for `google_container_engine_versions`

Closes #1937