### PR TITLE
Add .editorconfig configured for Go files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,15 @@
-[*.go]
+root=true
+
+[*]
 charset=utf-8
 end_of_line=lf
 insert_final_newline=false
+trim_trailing_whitespace=true
+
+[*.go]
 indent_style=tab
 tab_width=4
 
+[*.tf]
+indent_style=space
+indent_size=2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.go]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=tab
+tab_width=4
+


### PR DESCRIPTION
By using an EditorConfig file we can make sure that we have consistent editor settings regardless of what editor is being used (well, as long as they support EditorConfig 🙂).

This will primarily affect Jetbrains editors since they support it automatically; Github should also change from 8 to 4 tab-width following the config. Other editors can download plugins to enforce the settings.

Let me know if you all think this is a good idea or not! Personally I have had IntelliJ fool me as to what kind of space characters it was using across languages too many times.