### PR TITLE
updating examples in documentation for debian-9

### DIFF
--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -49,7 +49,7 @@ resource "google_compute_instance_template" "webserver" {
   }
 
   disk {
-    source_image = "debian-cloud/debian-8"
+    source_image = "debian-cloud/debian-9"
     auto_delete  = true
     boot         = true
   }

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -26,7 +26,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 

--- a/website/docs/r/compute_instance_from_template.html.markdown
+++ b/website/docs/r/compute_instance_from_template.html.markdown
@@ -26,7 +26,7 @@ resource "google_compute_instance_template" "tpl" {
   machine_type = "n1-standard-1"
 
   disk {
-    source_image = "debian-cloud/debian-8"
+    source_image = "debian-cloud/debian-9"
     auto_delete = true
     disk_size_gb = 100
     boot = true

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -38,7 +38,7 @@ resource "google_compute_instance_template" "default" {
 
   // Create a new boot disk from an image
   disk {
-    source_image = "debian-cloud/debian-8"
+    source_image = "debian-cloud/debian-9"
     auto_delete  = true
     boot         = true
   }

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -49,7 +49,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
-    source_image = "debian-cloud/debian-8"
+    source_image = "debian-cloud/debian-9"
     auto_delete  = true
     boot         = true
   }

--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -39,7 +39,7 @@ resource "google_compute_instance" "frontend" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 

--- a/website/docs/r/logging_project_sink.html.markdown
+++ b/website/docs/r/logging_project_sink.html.markdown
@@ -48,7 +48,7 @@ resource "google_compute_instance" "my-logged-instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-8"
+      image = "debian-cloud/debian-9"
     }
   }
 


### PR DESCRIPTION
Making sure that the examples in the docs don't fail due to old debian images that GCP doesn't support any more.