### PR TITLE
Setting a default update_mask for all log sinks

### DIFF
--- a/google/resource_logging_billing_account_sink.go
+++ b/google/resource_logging_billing_account_sink.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -58,7 +59,8 @@ func resourceLoggingBillingAccountSinkUpdate(d *schema.ResourceData, meta interf
 	sink := expandResourceLoggingSinkForUpdate(d)
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
-	_, err := config.clientLogging.BillingAccounts.Sinks.Patch(d.Id(), sink).UniqueWriterIdentity(true).Do()
+	_, err := config.clientLogging.BillingAccounts.Sinks.Patch(d.Id(), sink).
+		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/google/resource_logging_folder_sink.go
+++ b/google/resource_logging_folder_sink.go
@@ -77,7 +77,8 @@ func resourceLoggingFolderSinkUpdate(d *schema.ResourceData, meta interface{}) e
 	sink.ForceSendFields = append(sink.ForceSendFields, "IncludeChildren")
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
-	_, err := config.clientLogging.Folders.Sinks.Patch(d.Id(), sink).UniqueWriterIdentity(true).Do()
+	_, err := config.clientLogging.Folders.Sinks.Patch(d.Id(), sink).
+		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/google/resource_logging_organization_sink.go
+++ b/google/resource_logging_organization_sink.go
@@ -77,7 +77,8 @@ func resourceLoggingOrganizationSinkUpdate(d *schema.ResourceData, meta interfac
 	sink.ForceSendFields = append(sink.ForceSendFields, "IncludeChildren")
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
-	_, err := config.clientLogging.Organizations.Sinks.Patch(d.Id(), sink).UniqueWriterIdentity(true).Do()
+	_, err := config.clientLogging.Organizations.Sinks.Patch(d.Id(), sink).
+		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/google/resource_logging_project_sink.go
+++ b/google/resource_logging_project_sink.go
@@ -84,7 +84,8 @@ func resourceLoggingProjectSinkUpdate(d *schema.ResourceData, meta interface{}) 
 	sink := expandResourceLoggingSinkForUpdate(d)
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 
-	_, err := config.clientLogging.Projects.Sinks.Patch(d.Id(), sink).UniqueWriterIdentity(uniqueWriterIdentity).Do()
+	_, err := config.clientLogging.Projects.Sinks.Patch(d.Id(), sink).
+		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
 	if err != nil {
 		return err
 	}

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -5,6 +5,9 @@ import (
 	"google.golang.org/api/logging/v2"
 )
 
+// Empty update masks will eventually cause updates to fail, currently empty masks default to this string
+const defaultLogSinkUpdateMask = "destination,filter,includeChildren"
+
 func resourceLoggingSinkSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {

--- a/website/docs/r/logging_project_sink.html.markdown
+++ b/website/docs/r/logging_project_sink.html.markdown
@@ -14,8 +14,9 @@ Manages a project-level logging sink. For more information see
 and
 [API](https://cloud.google.com/logging/docs/reference/v2/rest/).
 
-Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
-granted to the credentials used with terraform.
+~> **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
+
+~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 
 ## Example Usage
 


### PR DESCRIPTION
[According to log sink documentation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/sinks/update)
the api will eventually throw an error if update mask isn't provided. The
default specified here is what the api is currently using when an empty mask
is passed.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/991