### PR TITLE
Update logging vendor.

### DIFF
--- a/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
@@ -1,9 +1,12 @@
 package logging
 
 import (
+	"bytes"
+	"encoding/json"
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 )
 
 type transport struct {
@@ -15,7 +18,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if IsDebugOrHigher() {
 		reqData, err := httputil.DumpRequestOut(req, true)
 		if err == nil {
-			log.Printf("[DEBUG] "+logReqMsg, t.name, string(reqData))
+			log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrintJsonLines(reqData))
 		} else {
 			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
 		}
@@ -29,7 +32,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if IsDebugOrHigher() {
 		respData, err := httputil.DumpResponse(resp, true)
 		if err == nil {
-			log.Printf("[DEBUG] "+logRespMsg, t.name, string(respData))
+			log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrintJsonLines(respData))
 		} else {
 			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
 		}
@@ -40,6 +43,20 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func NewTransport(name string, t http.RoundTripper) *transport {
 	return &transport{name, t}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 const logReqMsg = `%s API Request Details:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -633,10 +633,10 @@
 			"versionExact": "v0.11.2"
 		},
 		{
-			"checksumSHA1": "BAXV9ruAyno3aFgwYI2/wWzB2Gc=",
+			"checksumSHA1": "j8XqkwLh2W3r3i6wnCRmve07BgI=",
 			"path": "github.com/hashicorp/terraform/helper/logging",
-			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
-			"revisionTime": "2018-04-10T16:50:42Z",
+			"revision": "6dfc4d748de9cda23835bc5704307ed45e839622",
+			"revisionTime": "2018-08-15T22:00:39Z",
 			"version": "v0.11.2",
 			"versionExact": "v0.11.2"
 		},


### PR DESCRIPTION
Update the vendored version of our logging helper, so we get requests
printed.