### PR TITLE
Make it allowable to add 'network_interface' as workaround for element function

### DIFF
--- a/google/resource_compute_instance_from_template.go
+++ b/google/resource_compute_instance_from_template.go
@@ -28,9 +28,14 @@ func resourceComputeInstanceFromTemplate() *schema.Resource {
 func computeInstanceFromTemplateSchema() map[string]*schema.Schema {
 	s := resourceComputeInstance().Schema
 
-	for _, field := range []string{"boot_disk", "machine_type", "network_interface"} {
+	for _, field := range []string{"boot_disk", "machine_type"} {
 		s[field].Required = false
 	}
+
+	s["network_interface"].Required = false
+	// NOT because you should set it - it won't do anything -
+	// but as a workaround for https://github.com/terraform-providers/terraform-provider-google/issues/1805.
+	s["network_interface"].Optional = true
 
 	// Remove deprecated/removed fields that are never d.Set. We can't
 	// programatically remove all of them, because some of them still have d.Set


### PR DESCRIPTION
The `element` function, evaluated in an output or dependent resource, will fail if the thing it's referencing is a list item, and the list is only computed.  This is unfortunate in examples like #1805 - this is a somewhat silly workaround for this that I expect to be obviated when HCL2 is released.

Fixes #1805 - sort of.  :)