### PR TITLE
add warning about imports to sql database instance

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -321,3 +321,8 @@ $ terraform import google_sql_database_instance.master {{project}}/{{name}}
 $ terraform import google_sql_database_instance.master {{name}}
 
 ```
+
+Note that some fields (such as `replica_configuration`) are set in such a way that they won't
+show a diff if they are unset in config and set on the server, because GCP always returns them.
+When importing, double-check that your config has all the fields set that you expect- just seeing
+no diff isn't sufficient to know that your config could reproduce the imported resource.

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -322,7 +322,7 @@ $ terraform import google_sql_database_instance.master {{name}}
 
 ```
 
-Note that some fields (such as `replica_configuration`) are set in such a way that they won't
-show a diff if they are unset in config and set on the server, because GCP always returns them.
+~> **NOTE:** Some fields (such as `replica_configuration`) won't show a diff if they are unset in
+config and set on the server.
 When importing, double-check that your config has all the fields set that you expect- just seeing
 no diff isn't sufficient to know that your config could reproduce the imported resource.


### PR DESCRIPTION
Fixes #1998.

This just does it for the one resource, but I filed https://github.com/GoogleCloudPlatform/magic-modules/issues/452 to do it for all our generated ones.