### PR TITLE
Set correct nodepool Id using 4 part importer

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -420,6 +420,9 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 
 		d.Set("cluster", parts[2])
 		d.Set("name", parts[3])
+
+		// override the inputted ID with the <location>/<cluster>/<name> format
+		d.SetId(strings.Join(parts[1:], "/"))
 	default:
 		return nil, fmt.Errorf("Invalid container cluster specifier. Expecting {zone}/{cluster}/{name} or {project}/{zone}/{cluster}/{name}")
 	}


### PR DESCRIPTION
The ID that is created for a nodepool is 3 parts in the form of
<location>/<cluster>/<nodepool>. When we use the newer 4 part import
format the ID becomes that string. Then when checking the existence of
the nodepool the name is incorrectly parsed out of the ID.

When using the 4 part import form we need to set the correct ID so that
terraform can parse the name from the ID.

Closes: #1846