### PR TITLE
Add information about vendoring to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ govendor fetch {{path}}
 For example:
 
 ```bash
-govendor fetch cloud.google.com/go/bigtable
+govendor fetch google.golang.org/api/compute/v1
 ```
 
 When updating a vendored library, try to submit the vendoring as a separate pull request and include the commands you ran in

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,25 @@ The following are certain Google Provider-specific things to be aware of when co
 
 We aim to make the Google Provider a good steward of Go practices. See https://github.com/golang/go/wiki/CodeReviewComments for common Go mistakes that you should attempt to avoid.
 
+## Vendoring Libraries
+
+When adding support for just-released GCP features, you'll often need to vendor a new version of the Google API client and
+occasionally some of the downstream dependencies of that client. The Google Provider uses [govendor](https://github.com/kardianos/govendor)
+in order to manage dependencies. To vendor a new package or update an existing package, run:
+
+```bash
+govendor fetch {{path}}
+```
+
+For example:
+
+```bash
+govendor fetch cloud.google.com/go/bigtable
+```
+
+When updating a vendored library, try to submit the vendoring as a separate pull request and include the commands you ran in
+the pull request description.
+
 ## Tests
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ $ $GOPATH/bin/terraform-provider-google
 ...
 ```
 
-In order to test the Google provider, see the [Tests section of the contribution guidelines](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests).
+For guidance on common development practices such as testing changes or vendoring libraries, see the [contribution guidelines](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md). If you have other development questions we don't cover, please file an issue!


### PR DESCRIPTION
I've seen questions about how to vendor come up from new members of our team and from the community in some OSS issues. Let's make our tribal knowledge a documented process!