### PR TITLE
change delay in region instance group data source test

### DIFF
--- a/google/data_source_google_compute_region_instance_group_test.go
+++ b/google/data_source_google_compute_region_instance_group_test.go
@@ -78,7 +78,7 @@ resource "google_compute_region_instance_group_manager" "foo" {
 
 	auto_healing_policies {
 		health_check = "${google_compute_health_check.autohealing.self_link}"
-		initial_delay_sec = 600
+		initial_delay_sec = 10
 	}
 }
 

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -24,8 +24,8 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			State: resourceRegionInstanceGroupManagerStateImporter,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -24,8 +24,8 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			State: resourceRegionInstanceGroupManagerStateImporter,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 


### PR DESCRIPTION
We had a failure in the last CI run while waiting for this resource to be created, so let's increase the timeout.

```
------- Stdout: -------
=== RUN   TestAccDataSourceRegionInstanceGroup
--- FAIL: TestAccDataSourceRegionInstanceGroup (631.53s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* google_compute_region_instance_group_manager.foo: 1 error(s) occurred:
		
		* google_compute_region_instance_group_manager.foo: timeout while waiting for state to become 'created' (last state: 'creating', timeout: 5m0s)
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error refreshing: 1 error(s) occurred:
		
		* google_compute_region_instance_group_manager.foo: 1 error(s) occurred:
		
		* google_compute_region_instance_group_manager.foo: google_compute_region_instance_group_manager.foo: timeout while waiting for state to become 'created' (last state: 'creating', timeout: 5m0s)
		
		State: 
FAIL
```