### PR TITLE
replace dataproc preview version

### DIFF
--- a/google/resource_dataproc_cluster_test.go
+++ b/google/resource_dataproc_cluster_test.go
@@ -360,7 +360,7 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 				Config: testAccDataprocCluster_withImageVersion(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists("google_dataproc_cluster.with_image_version", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", "preview"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", "1.3.7-deb9"),
 				),
 			},
 		},
@@ -915,7 +915,7 @@ resource "google_dataproc_cluster" "with_image_version" {
 
 	cluster_config {
 		software_config {
-			image_version = "preview"
+			image_version = "1.3.7-deb9"
 		}
 	}
 }`, rnd)

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -58,7 +58,7 @@ resource "google_dataproc_cluster" "mycluster" {
 
         # Override or set some custom properties
         software_config {
-            image_version       = "preview"
+            image_version       = "1.3.7-deb9"
             override_properties = {
                 "dataproc:dataproc.allow.zero.workers" = "true"
             }
@@ -324,7 +324,7 @@ The `cluster_config.software_config` block supports:
     cluster_config {
         # Override or set some custom properties
         software_config {
-            image_version       = "preview"
+            image_version       = "1.3.7-deb9"
             override_properties = {
                 "dataproc:dataproc.allow.zero.workers" = "true"
             }


### PR DESCRIPTION
When you send dataproc the preview version, it'll return with the latest version number and show a diff. We _could_ fix this by DiffSuppressing whenever someone sends "preview", but since preview is no longer documented at https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#other_versions (it used to be!), I think it makes sense to avoid using it.

Sadly, dataproc doesn't have an API to list valid versions, so I went ahead and hardcoded. Let me know if you have a better idea.

Fixes failing CI test:
```
------- Stdout: -------
=== RUN   TestAccDataprocCluster_withImageVersion
--- FAIL: TestAccDataprocCluster_withImageVersion (183.52s)
	testing.go:518: Step 0 error: Check failed: Check 2/2 error: google_dataproc_cluster.with_image_version: Attribute 'cluster_config.0.software_config.0.image_version' expected "preview", got "1.3.7-deb9"
FAIL
```
```
$ make testacc TEST=./google TESTARGS='-run=TestAccDataprocCluster_withImageVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccDataprocCluster_withImageVersion -timeout 120m
=== RUN   TestAccDataprocCluster_withImageVersion
=== PAUSE TestAccDataprocCluster_withImageVersion
=== CONT  TestAccDataprocCluster_withImageVersion
--- PASS: TestAccDataprocCluster_withImageVersion (183.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	183.785s
```