### PR TITLE
get dataproc logs when jobs fail in test

### DIFF
--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -330,23 +330,22 @@ func testAccCheckDataprocJobCompletesSuccessfully(n string, job *dataproc.Job) r
 			if len(u) != 2 {
 				return fmt.Errorf("Job completed in ERROR state but no valid log URI found")
 			}
-			l, err := config.clientStorage.Objects.List(u[0]).Do()
+			l, err := config.clientStorage.Objects.List(u[0]).Prefix(u[1]).Do()
 			if err != nil {
 				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to list logs: {{err}}", err)
 			}
 			for _, item := range l.Items {
-				log.Printf("[DEBUG] found object %s, self_link %s", item.Name, item.SelfLink)
+				resp, err := config.clientStorage.Objects.Get(item.Bucket, item.Name).Download()
+				if err != nil {
+					return errwrap.Wrapf("Job completed in ERROR state, found error when trying to read logs: {{err}}", err)
+				}
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					return errwrap.Wrapf("Job completed in ERROR state, found error when trying to read logs: {{err}}", err)
+				}
+				log.Printf("[ERROR] Job failed, driver logs:\n%s", body)
 			}
-			resp, err := config.clientStorage.Objects.Get(u[0], u[1]).Download()
-			if err != nil {
-				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to read logs: {{err}}", err)
-			}
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to read logs: {{err}}", err)
-			}
-			log.Printf("[ERROR] Job failed, driver logs:\n%s", body)
 			return fmt.Errorf("Job completed in ERROR state, check logs for details")
 		} else if completeJob.Status.State != "DONE" {
 			return fmt.Errorf("Job did not complete successfully, instead status: %s", completeJob.Status.State)

--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -330,6 +330,13 @@ func testAccCheckDataprocJobCompletesSuccessfully(n string, job *dataproc.Job) r
 			if len(u) != 2 {
 				return fmt.Errorf("Job completed in ERROR state but no valid log URI found")
 			}
+			l, err := config.clientStorage.Objects.List(u[0]).Do()
+			if err != nil {
+				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to list logs: {{err}}", err)
+			}
+			for item := range l.Items {
+				log.Printf("[DEBUG] found object %s, self_link %s", item.Name, item.SelfLink)
+			}
 			resp, err := config.clientStorage.Objects.Get(u[0], u[1]).Download()
 			if err != nil {
 				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to read logs: {{err}}", err)

--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -334,7 +334,7 @@ func testAccCheckDataprocJobCompletesSuccessfully(n string, job *dataproc.Job) r
 			if err != nil {
 				return errwrap.Wrapf("Job completed in ERROR state, found error when trying to list logs: {{err}}", err)
 			}
-			for item := range l.Items {
+			for _, item := range l.Items {
 				log.Printf("[DEBUG] found object %s, self_link %s", item.Name, item.SelfLink)
 			}
 			resp, err := config.clientStorage.Objects.Get(u[0], u[1]).Download()

--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -326,7 +326,7 @@ func testAccCheckDataprocJobCompletesSuccessfully(n string, job *dataproc.Job) r
 			if !strings.HasPrefix(completeJob.DriverOutputResourceUri, "gs://") {
 				return fmt.Errorf("Job completed in ERROR state but no valid log URI found")
 			}
-			u := strings.SplitN(strings.TrimPrefix(completeJob.DriverOutputResourceUri, "gs://"), 2)
+			u := strings.SplitN(strings.TrimPrefix(completeJob.DriverOutputResourceUri, "gs://"), "/", 2)
 			if len(u) != 2 {
 				return fmt.Errorf("Job completed in ERROR state but no valid log URI found")
 			}


### PR DESCRIPTION
The hadoop test passes for me locally but fails in CI, so this should give some extra debugging information (my user acct doesn't have permissions to read the dataproc logs from the failing test).

WIP for now because I want to make sure this method of reading the logs works.