### PR TITLE
Reduce rig datasource test target size to 1.

### DIFF
--- a/google/data_source_google_compute_region_instance_group_test.go
+++ b/google/data_source_google_compute_region_instance_group_test.go
@@ -68,7 +68,7 @@ resource "google_compute_region_instance_group_manager" "foo" {
 	instance_template = "${google_compute_instance_template.foo.self_link}"
 	region = "us-central1"
 	target_pools = ["${google_compute_target_pool.foo.self_link}"]
-	target_size = 10
+	target_size = 1
 
 	named_port {
 		name = "web"


### PR DESCRIPTION
So, every time this test fails we are leaving behind 10 CPUs. This is a big cause of our quota problem because we are at 70!! right now. We still need to fix the test but let's also reduce this count to 1 so we leave 1/10th of the zombie instances.

Changing from a new to legacy health check also did not work so I have no clue what the issue is here. Observing the instances, they are shown as being stuck in "Instance is being verified" state for up to days.