### PR TITLE
Introduce a new Google provider landing page, complementary pages.

### DIFF
--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -31,7 +31,7 @@ provider "google" {
 }
 ```
 
-* The `project` field should include your personal project id. The `project`
+* The `project` field should be your personal project id. The `project`
 indicates the default GCP project all of your resources will be created in.
 Most Terraform resources will have a `project` field.
 * The `region` and `zone` are [locations](https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources)
@@ -55,18 +55,17 @@ identifies the provider for Terraform, `compute` indicates the GCP product
 family, and `instance` is the resource name.
 
 Google provider resources will generally, although not always, be named after
-the name used in the `gcloud`/the REST API. For example, a VM instance is called
+the name used in `gcloud`/the REST API. For example, a VM instance is called
 [`instance` in the API](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
 Most resource field names will also correspond 1:1 with their `gcloud`/REST API
 names.
 
 If you look at the [`google_compute_instance documentation`](/docs/providers/google/r/compute_instance.html),
 you'll see that `project` and `zone` (VM instances are a zonal resource) are
-listed as optional. You can omit them from a Terraform config and the provider
-defaults will be used. If any of these fields is added to a config, it will be
-used instead of the default.
+listed as optional. When present in a resource's config block, these values will
+be used. If omitted, the provider defaults will be used instead.
 
-Try adding the following to your config file:
+Add the following to your config file:
 
 ```hcl
 resource "google_compute_instance" "vm_instance" {
@@ -92,11 +91,11 @@ resource "google_compute_instance" "vm_instance" {
 credentials. If you want to try out provisioning your VM instance before
 continuing, follow the instructions in the "Adding credentials" section below.
 
-## Connecting to a VPC network
+## Linking GCP resources
 
 Like this VM instance, nearly every GCP resource will have a `name` field. They
-are used as a short way to identify resources, and their name in the Cloud
-Console will be the one defined in the `name` field.
+are used as a short way to identify resources, and a resource's display name in
+the Cloud Console will be the one defined in the `name` field.
 
 When linking resources in a Terraform config though, you'll primarily want to
 use a different field, the `self_link` of a resource. Like `name`, nearly every
@@ -106,16 +105,17 @@ resource has a `self_link`. They look like:
 {{API base url}}/projects/{{your project}}/{{location type}}/{{location}}/{{resouce type}}/{{name}}
 ```
 
-For a real example, let's look at what the instance `self_link` will be assuming
-your project is named `foo`:
+For example, the instance defined earlier in a project named `foo` will have
+the `self_link`:
 
 ```
 https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-c/instances/terraform-instance
 ```
 
 A resource's `self_link` is a unique reference to that resource. When
-connecting two resources in Terraform, you can use Terraform interpolation to
-avoid typing all that out! Let's use a `google_compute_network` to demonstrate.
+linking two resources in Terraform, you can use Terraform interpolation to
+avoid typing out the self link! Let's use a `google_compute_network` to
+demonstrate.
 
 Add this block to your config:
 
@@ -127,8 +127,8 @@ resource "google_compute_network" "vpc_network" {
 ```
 
 This will create [VPC network resource](/docs/providers/google/r/compute_network.html)
-with a subnetwork (due to auto_create_subnetworks) in each region. Then, change
-the network of the `google_compute_instance`.
+with a subnetwork in each region. Then, change the network of the
+`google_compute_instance` from the `"default"` network to the new network.
 
 ```diff
 network_interface {
@@ -140,10 +140,10 @@ network_interface {
 
 This means that when we create the VM instance, it will use
 `"terraform-network"` instead of the default VPC network for the project. If you
-run `terraform plan`, you should see that `"terraform-instance"` depends on
+run `terraform plan`, you will see that `"terraform-instance"` depends on
 `"terraform-network"`.
 
-You're ready to run `terraform apply`! Except for one last thing...
+You can now run `terraform apply`! Except for one last thing...
 
 ~> You haven't added GCP API credentials yet.
 
@@ -169,7 +169,7 @@ export GOOGLE_CLOUD_KEYFILE_JSON={{path}}
 `bashrc` to store your credentials across sessions!
 
 ## Provisioning your resources
-By now, your config should look something like:
+By now, your config will look something like:
 
 ```hcl
 provider "google" {
@@ -210,8 +210,7 @@ terraform apply
 ```
 
 Congratulations! You've gotten started using the Google provider and provisioned
-a virtual machine on Google Cloud Platform. Along the way, you've learned
-important concepts such as:
+a virtual machine on Google Cloud Platform. The key concepts unique to GCP are:
 
 * How a `project` contains resources
     * and how to use a default `project` in your provider

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -127,7 +127,7 @@ resource "google_compute_network" "vpc_network" {
 ```
 
 This will create [VPC network resource](/docs/providers/google/r/compute_network.html)
-with a subnetwork in each region. Then, change the network of the
+with a subnetwork in each region. Next, change the network of the
 `google_compute_instance` from the `"default"` network to the new network.
 
 ```diff
@@ -153,7 +153,7 @@ with Terraform is to use a [GCP service account](https://cloud.google.com/docs/a
 a "robot account" that can be granted a limited set of IAM permissions.
 
 From [the service account key page in the Cloud Console](https://pantheon.corp.google.com/apis/credentials/serviceaccountkey)
-choose an existing account, or create a new one. Then, download the JSON key
+choose an existing account, or create a new one. Next, download the JSON key
 file. Name it something you can remember, and store it somewhere secure on your
 machine.
 

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 ## Before you begin
 
-* You'll want to have created an account and project in the [Google Cloud Console](https://console.cloud.google.com/)
+* Create a project in the [Google Cloud Console](https://console.cloud.google.com/)
 and set up billing on that project. Any examples in this guide will be part of
 the [GCP "always free" tier](https://cloud.google.com/free/).
 * [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
@@ -20,7 +20,7 @@ provider.
 
 ## Configuring the Provider
 
-To configure the provider, first create a Terraform config file. Inside, you'll
+First create a Terraform config file named `"main.tf"`. Inside, you'll
 want to include the following configuration:
 
 ```hcl
@@ -34,7 +34,7 @@ provider "google" {
 * The `project` field should include your personal project id. The `project`
 indicates the default GCP project all of your resources will be created in.
 Most Terraform resources will have a `project` field.
-* The`region` and `zone` are [locations](https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources)
+* The `region` and `zone` are [locations](https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources)
 for your resources to be created in.
     * The `region` will be used to choose the default location for regional
     resources. Regional resources are spread across several zones.
@@ -55,8 +55,10 @@ identifies the provider for Terraform, `compute` indicates the GCP product
 family, and `instance` is the resource name.
 
 Google provider resources will generally, although not always, be named after
-the name used in the REST API. For example, a VM instance is called [`instance` in the API](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
-Most resource field names will also correspond 1:1 with their REST API names.
+the name used in the `gcloud`/the REST API. For example, a VM instance is called
+[`instance` in the API](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
+Most resource field names will also correspond 1:1 with their `gcloud`/REST API
+names.
 
 If you look at the [`google_compute_instance documentation`](/docs/providers/google/r/compute_instance.html),
 you'll see that `project` and `zone` (VM instances are a zonal resource) are
@@ -64,7 +66,7 @@ listed as optional. You can omit them from a Terraform config and the provider
 defaults will be used. If any of these fields is added to a config, it will be
 used instead of the default.
 
-Try adding the following to your state file:
+Try adding the following to your config file:
 
 ```hcl
 resource "google_compute_instance" "vm_instance" {
@@ -87,7 +89,7 @@ resource "google_compute_instance" "vm_instance" {
 ```
 
 ~> Note: Don't use `terraform apply` quite yet! You still need to add GCP
-credentials below. If you want to try out provisioning your VM instance before
+credentials. If you want to try out provisioning your VM instance before
 continuing, follow the instructions in the "Adding credentials" section below.
 
 ## Connecting to a VPC network
@@ -157,10 +159,10 @@ file. Name it something you can remember, and store it somewhere secure on your
 machine.
 
 You supply the key to Terraform using the environment variable
-`GOOGLE_APPLICATION_CREDENTIALS`, setting the value to the location of the file.
+`GOOGLE_CLOUD_KEYFILE_JSON`, setting the value to the location of the file.
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS={{path}}
+export GOOGLE_CLOUD_KEYFILE_JSON={{path}}
 ```
 
 -> Remember to add this line to a startup file such as `bash_profile` or

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -143,9 +143,8 @@ This means that when we create the VM instance, it will use
 run `terraform plan`, you will see that `"terraform-instance"` depends on
 `"terraform-network"`.
 
-You can now run `terraform apply`! Except for one last thing...
-
-~> You haven't added GCP API credentials yet.
+Your configuration is complete. Before you can run `terraform apply` though,
+Terraform needs GCP credentials.
 
 ## Adding credentials
 In order to make requests against the GCP API, you need to authenticate to prove

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -102,7 +102,7 @@ use a different field, the `self_link` of a resource. Like `name`, nearly every
 resource has a `self_link`. They look like:
 
 ```
-{{API base url}}/projects/{{your project}}/{{location type}}/{{location}}/{{resouce type}}/{{name}}
+{{API base url}}/projects/{{your project}}/{{location type}}/{{location}}/{{resource type}}/{{name}}
 ```
 
 For example, the instance defined earlier in a project named `foo` will have

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -224,3 +224,8 @@ Run `terraform destroy` to tear down your resources.
 
 Afterwards, check out the [provider reference](/docs/providers/google/provider_reference.html) for more details on configuring
 the provider block (including how you can eliminate it entirely!).
+
+You can also check out the [GCP Community tutorials](https://cloud.google.com/community/tutorials/)
+such as:
+* [Managing GCP Projects with Terraform](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform)
+* [Modular Load Balancing with Terraform](https://cloud.google.com/community/tutorials/modular-load-balancing-with-terraform)

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -225,5 +225,6 @@ the provider block (including how you can eliminate it entirely!).
 
 You can also check out the [GCP Community tutorials](https://cloud.google.com/community/tutorials/)
 such as:
+* [Getting started with Terraform on Google Cloud Platform](https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform)
 * [Managing GCP Projects with Terraform](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform)
 * [Modular Load Balancing with Terraform](https://cloud.google.com/community/tutorials/modular-load-balancing-with-terraform)

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -1,0 +1,224 @@
+---
+layout: "google"
+page_title: "Getting Started with the Google provider"
+sidebar_current: "docs-google-provider-getting-started"
+description: |-
+  Getting started with the Google Cloud Platform provider
+---
+
+# Getting Started with the Google Provider
+
+## Before you begin
+
+* You'll want to have created an account and project in the [Google Cloud Console](https://console.cloud.google.com/)
+and set up billing on that project. Any examples in this guide will be part of
+the [GCP "always free" tier](https://cloud.google.com/free/).
+* [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
+and read the Terraform getting started guide that follows. This guide will
+assume basic proficiency with Terraform - it is an introduction to the Google
+provider.
+
+## Configuring the Provider
+
+To configure the provider, first create a Terraform config file. Inside, you'll
+want to include the following configuration:
+
+```hcl
+provider "google" {
+  project = "{{YOUR GCP PROJECT}}"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+```
+
+* The `project` field should include your personal project id. The `project`
+indicates the default GCP project all of your resources will be created in.
+Most Terraform resources will have a `project` field.
+* The`region` and `zone` are [locations](https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources)
+for your resources to be created in.
+    * The `region` will be used to choose the default location for regional
+    resources. Regional resources are spread across several zones.
+    * The `zone` will be used to choose the default location for zonal resources.
+    Zonal resources exist in a single zone. All zones are a part of a region.
+
+Not all resources require a location. Some GCP resources are global and are
+automatically spread across all of GCP.
+
+-> Want to try out another location? Check out the [list of available regions and zones](https://cloud.google.com/compute/docs/regions-zones/#available).
+Instances created in zones outside the US are not part of the always free tier
+and could incur charges.
+
+## Creating a VM instance
+A [Google Compute Engine VM instance](https://cloud.google.com/compute/docs/instances/) is
+named `google_compute_instance` in Terraform. The `google` part of the name
+identifies the provider for Terraform, `compute` indicates the GCP product
+family, and `instance` is the resource name.
+
+Google provider resources will generally, although not always, be named after
+the name used in the REST API. For example, a VM instance is called [`instance` in the API](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
+Most resource field names will also correspond 1:1 with their REST API names.
+
+If you look at the [`google_compute_instance documentation`](/docs/providers/google/r/compute_instance.html),
+you'll see that `project` and `zone` (VM instances are a zonal resource) are
+listed as optional. You can omit them from a Terraform config and the provider
+defaults will be used. If any of these fields is added to a config, it will be
+used instead of the default.
+
+Try adding the following to your state file:
+
+```hcl
+resource "google_compute_instance" "vm_instance" {
+  name         = "terraform-instance"
+  machine_type = "f1-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network       = "default"
+    access_config = {
+    }
+  }
+}
+```
+
+~> Note: Don't use `terraform apply` quite yet! You still need to add GCP
+credentials below. If you want to try out provisioning your VM instance before
+continuing, follow the instructions in the "Adding credentials" section below.
+
+## Connecting to a VPC network
+
+Like this VM instance, nearly every GCP resource will have a `name` field. They
+are used as a short way to identify resources, and their name in the Cloud
+Console will be the one defined in the `name` field.
+
+When linking resources in a Terraform config though, you'll primarily want to
+use a different field, the `self_link` of a resource. Like `name`, nearly every
+resource has a `self_link`. They look like:
+
+```
+{{API base url}}/projects/{{your project}}/{{location type}}/{{location}}/{{resouce type}}/{{name}}
+```
+
+For a real example, let's look at what the instance `self_link` will be assuming
+your project is named `foo`:
+
+```
+https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-c/instances/terraform-instance
+```
+
+A resource's `self_link` is a unique reference to that resource. When
+connecting two resources in Terraform, you can use Terraform interpolation to
+avoid typing all that out! Let's use a `google_compute_network` to demonstrate.
+
+Add this block to your config:
+
+```hcl
+resource "google_compute_network" "vpc_network" {
+  name                    = "terraform-network"
+  auto_create_subnetworks = "true"
+}
+```
+
+This will create [VPC network resource](/docs/providers/google/r/compute_network.html)
+with a subnetwork (due to auto_create_subnetworks) in each region. Then, change
+the network of the `google_compute_instance`.
+
+```diff
+network_interface {
+-  # A default network is created for all GCP projects
+-  network = "default"
++  network = "${google_compute_network.vpc_network.self_link}"
+  access_config = {
+```
+
+This means that when we create the VM instance, it will use
+`"terraform-network"` instead of the default VPC network for the project. If you
+run `terraform plan`, you should see that `"terraform-instance"` depends on
+`"terraform-network"`.
+
+You're ready to run `terraform apply`! Except for one last thing...
+
+~> You haven't added GCP API credentials yet.
+
+## Adding credentials
+In order to make requests against the GCP API, you need to authenticate to prove
+that it's you making the request. The preferred method of provisioning resources
+with Terraform is to use a [GCP service account](https://cloud.google.com/docs/authentication/getting-started),
+a "robot account" that can be granted a limited set of IAM permissions.
+
+From [the service account key page in the Cloud Console](https://pantheon.corp.google.com/apis/credentials/serviceaccountkey)
+choose an existing account, or create a new one. Then, download the JSON key
+file. Name it something you can remember, and store it somewhere secure on your
+machine.
+
+You supply the key to Terraform using the environment variable
+`GOOGLE_APPLICATION_CREDENTIALS`, setting the value to the location of the file.
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS={{path}}
+```
+
+-> Remember to add this line to a startup file such as `bash_profile` or
+`bashrc` to store your credentials across sessions!
+
+## Provisioning your resources
+By now, your config should look something like:
+
+```hcl
+provider "google" {
+  project = "{{YOUR GCP PROJECT}}"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "terraform-instance"
+  machine_type = "f1-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network       = "${google_compute_network.vpc_network.self_link}"
+    access_config = {
+    }
+  }
+}
+
+resource "google_compute_network" "vpc_network" {
+  name                    = "terraform-network"
+  auto_create_subnetworks = "true"
+}
+```
+
+With a Terraform config and with your credentials configured, it's time to
+provision your resources:
+
+```hcl
+terraform apply
+```
+
+Congratulations! You've gotten started using the Google provider and provisioned
+a virtual machine on Google Cloud Platform. Along the way, you've learned
+important concepts such as:
+
+* How a `project` contains resources
+    * and how to use a default `project` in your provider
+* What a resource being global, regional, or zonal means on GCP
+    * and how to specify a default `region` and `zone`
+* How GCP uses `name` and `self_link` to identify resources
+* How to add GCP service account credentials to Terraform
+
+Run `terraform destroy` to tear down your resources.
+
+Afterwards, check out the [provider reference](/docs/providers/google/provider_reference.html) for more details on configuring
+the provider block (including how you can eliminate it entirely!).

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,108 +1,88 @@
 ---
 layout: "google"
-page_title: "Provider: Google Cloud"
-sidebar_current: "docs-google-index"
+page_title: "Provider: Google Cloud Platform"
+sidebar_current: "docs-google-provider-x"
 description: |-
-  The Google Cloud provider is used to interact with Google Cloud services. The provider needs to be configured with the proper credentials before it can be used.
+   The Google provider is used to configure your Google Cloud Platform infrastructure
 ---
 
-# Google Cloud Provider
+# Google Cloud Platform Provider
 
-The Google Cloud provider is used to interact with
-[Google Cloud services](https://cloud.google.com/). The provider needs
-to be configured with the proper credentials before it can be used.
+The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure. 
+See the [Getting Started](/docs/providers/google/getting_started.html) page for an introduction to using the provider. See the [provider reference](/docs/providers/google/provider_reference.html) for advanced
+details on authenticating or otherwise configuring the provider.
 
-Use the navigation to the left to read about the available resources.
+Interested in the provider's latest features, or want to make sure you're up to date?
+Check out the [changelog](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
+for version information and release notes.
 
-## Example Usage
+The Google provider is jointly maintained by:
 
-```hcl
-// Configure the Google Cloud provider
-provider "google" {
-  credentials = "${file("account.json")}"
-  project     = "my-gce-project-id"
-  region      = "us-central1"
-}
+* The [Google Cloud Graphite Team](https://cloudplatform.googleblog.com/2017/03/partnering-on-open-source-Google-and-HashiCorp-engineers-on-managing-GCP-infrastructure.html) at Google
+* The Terraform team at [HashiCorp](https://www.hashicorp.com/)
 
-// Create a new instance
-resource "google_compute_instance" "default" {
-  # ...
-}
-```
+If you have configuration questions, or general questions about using the provider, try checking out:
 
-## Configuration Reference
+* The [Google Cloud Platform Community Slack](https://gcp-slack.appspot.com/) #terraform channel
+* [Terraform's community resources](https://www.terraform.io/docs/extend/community/index.html)
+* [HashiCorp support](https://support.hashicorp.com) for Terraform Enterprise customers
 
-The following keys can be used to configure the provider.
+## Features and Bug Requests
 
-* `credentials` - (Optional) Contents of a file that contains your service
-  account private key in JSON format. You can download your existing
-  [Google Cloud service account file]
-  from the Google Cloud Console, or you can create a new one from the same page.
+The Google provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/terraform-providers/terraform-provider-google/issues).
+Please avoid "me too" or "+1" comments. Instead, use a thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
+on enhancement requests. Provider maintainers will often prioritise work based on the
+number of thumbs on an issue.
 
-  Credentials can also be specified using any of the following environment
-  variables (listed in order of precedence):
+Community input is appreciated on outstanding issues! We love to hear what use
+cases you have for new features, and want to provide the best possible
+experience for you using the Google provider.
 
-    * `GOOGLE_CREDENTIALS`
-    * `GOOGLE_CLOUD_KEYFILE_JSON`
-    * `GCLOUD_KEYFILE_JSON`
+If you can't find an existing issue for a bug or feature request you have
 
-  The [`GOOGLE_APPLICATION_CREDENTIALS`][adc]
-  environment variable can also contain the path of a file to obtain credentials
-  from.
+* and an existing resource or field is working in an unexpected way, [file a bug](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=bug.md).
 
-  If no credentials are specified, the provider will fall back to using the
-  [Google Application Default Credentials][adc].
-  If you are running Terraform from a GCE instance, see [Creating and Enabling
-  Service Accounts for Instances][gce-service-account] for details.
+* and you'd like the provider to support a new resource or field, [file an enhancement/feature request](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=enhancement.md).
 
-  On your computer, if you have made your identity available as the
-  Application Default Credentials by running [`gcloud auth application-default
-  login`][gcloud adc], the provider will use your identity.
+The provider maintainers will often use the assignee field on an issue to mark
+who is working on it.
 
-  ~> **Warning:** The gcloud method is not guaranteed to work for all APIs, and
-  [service accounts] or [GCE metadata] should be used if possible.
+* An issue assigned to an individual maintainer indicates that maintainer is working
+on the issue
+* An issue assigned to the `modular-magician` indicates the feature is being
+autogenerated by [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules)
+in the immediate future, so direct contributions to that resource are discouraged.
+* An issue assigned to `hashibot` indicates a member of the community has taken on
+the issue!
 
-* `project` - (Optional) The ID of the project to apply any resources to.  This
-  can also be specified using any of the following environment variables (listed
-  in order of precedence):
+## Contributing
 
-    * `GOOGLE_PROJECT`
-    * `GOOGLE_CLOUD_PROJECT`
-    * `GCLOUD_PROJECT`
-    * `CLOUDSDK_CORE_PROJECT`
+If you'd like to help extend the Google provider, we gladly accept community
+contributions! Check out the [provider GitHub repo README](https://github.com/terraform-providers/terraform-provider-google)
+for instructions about getting started developing, the [HashiCorp contribution guidelines](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md)
+for a Terraform provider development overview, and the [Google provider contribution guidelines](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md)
+for our provider-specific advice.
 
-* `region` - (Optional) The region to operate under, if not specified by a given resource.
-  This can also be specified using any of the following environment variables (listed in order of
-  precedence):
+## GCP API Versions
 
-    * `GOOGLE_REGION`
-    * `GCLOUD_REGION`
-    * `CLOUDSDK_COMPUTE_REGION`
+The Google provider supports generally available (GA) and Beta GCP features. We
+are focusing on filling out general GA feature coverage and on adding support
+for beta features that customers request. So if you need us to support a feature
+whether GA or beta, please [file a feature request](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=enhancement.md)!
 
-* `zone` - (Optional) The zone to operate under, if not specified by a given resource.
-  This can also be specified using any of the following environment variables (listed in order of
-  precedence):
+If you're interested in using Alpha GCP features, you should still [file a feature request](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=enhancement.md)
+or thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
+the existing request if one exists. By filing and reacting to requests, we can
+gauge your interest in yet-to-be-supported GCP features and make sure that we
+prioritise support for them when they enter Beta.
 
-    * `GOOGLE_ZONE`
-    * `GCLOUD_ZONE`
-    * `CLOUDSDK_COMPUTE_ZONE`
-
-
-## Beta Features
-
-Some Google Provider resources contain Beta features; Beta GCP Features have no
+### Beta Features
+Some resources contain Beta features; Beta GCP Features have no
 deprecation policy, and no SLA, but are otherwise considered to be feature-complete
 with only minor outstanding issues after their Alpha period. Beta is when a GCP feature
 is publicly announced, and is when they generally become publicly available. For
-more information see [the official documentation](https://cloud.google.com/terms/launch-stages).
+more information see [the official documentation on GCP launch stages](https://cloud.google.com/terms/launch-stages).
 
-Terraform resources that support beta features will always use the Beta APIs to provision
-the resource. Importing a resource that supports beta features will always import those
-features, even if the resource was created in a matter that was not explicitly beta.
-
-[Google Cloud service account file]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
-[adc]: https://cloud.google.com/docs/authentication/production
-[gce-service-account]: https://cloud.google.com/compute/docs/authentication
-[gcloud adc]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
-[service accounts]: https://cloud.google.com/docs/authentication/getting-started
-[GCE metadata]: https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions
+Terraform resources that support Beta features will always use the Beta APIs to provision
+the resource. Importing a resource that supports Beta features will always import those
+features, even if the resource was created in a matter that was not explicitly Beta.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -29,7 +29,7 @@ Check out the [changelog](https://github.com/terraform-providers/terraform-provi
 for version information and release notes.
 
 Take advantage of [Modules](https://www.terraform.io/docs/modules/index.html)
-to simplify your config by using the [Module Registry for GCP modules](https://registry.terraform.io/browse?provider=google)
+to simplify your config by browsing the [Module Registry for GCP modules](https://registry.terraform.io/browse?provider=google).
 
 The Google provider is jointly maintained by:
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -9,8 +9,20 @@ description: |-
 # Google Cloud Platform Provider
 
 The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure. 
-See the [Getting Started](/docs/providers/google/getting_started.html) page for an introduction to using the provider. See the [provider reference](/docs/providers/google/provider_reference.html) for advanced
-details on authenticating or otherwise configuring the provider.
+See the [Getting Started](/docs/providers/google/getting_started.html) page for an introduction to using the provider.
+
+A typical provider configuration will look something like:
+
+```hcl
+provider "google" {
+  credentials = "${file("account.json")}"
+  project     = "my-project-id"
+  region      = "us-central1"
+}
+```
+
+See the [provider reference](/docs/providers/google/provider_reference.html)
+for more details on authenticating or otherwise configuring the provider.
 
 Interested in the provider's latest features, or want to make sure you're up to date?
 Check out the [changelog](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
@@ -79,9 +91,9 @@ prioritise support for them when they enter Beta.
 ### Beta Features
 Some resources contain Beta features; Beta GCP Features have no
 deprecation policy, and no SLA, but are otherwise considered to be feature-complete
-with only minor outstanding issues after their Alpha period. Beta is when a GCP feature
-is publicly announced, and is when they generally become publicly available. For
-more information see [the official documentation on GCP launch stages](https://cloud.google.com/terms/launch-stages).
+with only minor outstanding issues after their Alpha period. Beta is when GCP
+features are publicly announced, and is when they generally become publicly
+available. For more information see [the official documentation on GCP launch stages](https://cloud.google.com/terms/launch-stages).
 
 Terraform resources that support Beta features will always use the Beta APIs to provision
 the resource. Importing a resource that supports Beta features will always import those

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -46,7 +46,7 @@ If you have configuration questions, or general questions about using the provid
 
 The Google provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/terraform-providers/terraform-provider-google/issues).
 Please avoid "me too" or "+1" comments. Instead, use a thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
-on enhancement requests. Provider maintainers will often prioritise work based on the
+on enhancement requests. Provider maintainers will often prioritize work based on the
 number of thumbs on an issue.
 
 Community input is appreciated on outstanding issues! We love to hear what use
@@ -89,7 +89,7 @@ If you're interested in using Alpha GCP features, you should still [file a featu
 or thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
 the existing request if one exists. By filing and reacting to requests, we can
 gauge your interest in yet-to-be-supported GCP features and make sure that we
-prioritise support for them when they enter Beta.
+prioritize support for them when they enter Beta.
 
 ### Beta Features
 Some resources contain Beta features; Beta GCP Features have no

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -28,6 +28,9 @@ Interested in the provider's latest features, or want to make sure you're up to 
 Check out the [changelog](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
 for version information and release notes.
 
+Take advantage of [Modules](https://www.terraform.io/docs/modules/index.html)
+to simplify your config by using the [Module Registry for GCP modules](https://registry.terraform.io/browse?provider=google)
+
 The Google provider is jointly maintained by:
 
 * The [Google Cloud Graphite Team](https://cloudplatform.googleblog.com/2017/03/partnering-on-open-source-Google-and-HashiCorp-engineers-on-managing-GCP-infrastructure.html) at Google

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -53,7 +53,7 @@ Community input is appreciated on outstanding issues! We love to hear what use
 cases you have for new features, and want to provide the best possible
 experience for you using the Google provider.
 
-If you can't find an existing issue for a bug or feature request you have
+If you have a bug or feature request without an existing issue
 
 * and an existing resource or field is working in an unexpected way, [file a bug](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=bug.md).
 
@@ -73,7 +73,7 @@ the issue!
 ## Contributing
 
 If you'd like to help extend the Google provider, we gladly accept community
-contributions! Check out the [provider GitHub repo README](https://github.com/terraform-providers/terraform-provider-google)
+contributions! Check out the [provider README](https://github.com/terraform-providers/terraform-provider-google)
 for instructions about getting started developing, the [HashiCorp contribution guidelines](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md)
 for a Terraform provider development overview, and the [Google provider contribution guidelines](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md)
 for our provider-specific advice.

--- a/website/docs/provider_reference.html.markdown
+++ b/website/docs/provider_reference.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # `google` provider reference
 The `google` provider block is used to configure default values for your GCP
-project, location (`zone` and `region`), and add your credentials credentials.
+project and location (`zone` and `region`), and add your credentials.
 
 -> You can avoid using a provider block by using environment variables. Every
 field of the `google` provider is optional. If you want to share configs between
@@ -19,7 +19,7 @@ environments and deploy to different projects, try it out!
 ```hcl
 provider "google" {
   credentials = "${file("account.json")}"
-  project     = "my-gce-project-id"
+  project     = "my-project-id"
   region      = "us-central1"
   zone        = "us-central1-c"
 }
@@ -29,8 +29,8 @@ provider "google" {
 
 The following keys can be used to configure the provider.
 
-* `credentials` - (Optional) Contents of a file that contains your service
-  account private key in JSON format. You can download your existing
+* `credentials` - (Optional) The path or contents of a file that contains your
+  service account private key in JSON format. You can download your existing
   [Google Cloud service account file]
   from the Google Cloud Console, or you can create a new one from the same page.
 
@@ -55,9 +55,9 @@ The following keys can be used to configure the provider.
   login`][gcloud adc], the provider will use your identity.
 
   -> [Service accounts][service accounts] are the recommended way
-  to manage GCP credentials. [GCE metadata] is also acceptable, although can
-  only be used in limited scenarios. The `gcloud` method is not guaranteed to work
-  for all APIs.
+  to manage GCP credentials. [GCE metadata] is also acceptable, although it can
+  only be used when running Terraform from within [certain GCP resources](https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions).
+  The `gcloud` method is not guaranteed to work for all APIs.
 
 * `project` - (Optional) The ID of the project to apply any resources to.  This
   can also be specified using any of the following environment variables (listed

--- a/website/docs/provider_reference.html.markdown
+++ b/website/docs/provider_reference.html.markdown
@@ -31,8 +31,8 @@ The following keys can be used to configure the provider.
 
 * `credentials` - (Optional) The path or contents of a file that contains your
   service account private key in JSON format. You can download your existing
-  [Google Cloud service account file]
-  from the Google Cloud Console, or you can create a new one from the same page.
+  [Google Cloud service account file] from the Google Cloud Console, or you can
+  create a new one from the same page.
 
   Credentials can also be specified using any of the following environment
   variables (listed in order of precedence):
@@ -57,7 +57,8 @@ The following keys can be used to configure the provider.
   -> [Service accounts][service accounts] are the recommended way
   to manage GCP credentials. [GCE metadata] is also acceptable, although it can
   only be used when running Terraform from within [certain GCP resources](https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions).
-  The `gcloud` method is not guaranteed to work for all APIs.
+  Application Default Credentials, such as those obtained through the `gcloud`
+  command above, are not guaranteed to work for all APIs.
 
 * `project` - (Optional) The ID of the project to apply any resources to.  This
   can also be specified using any of the following environment variables (listed
@@ -68,7 +69,7 @@ The following keys can be used to configure the provider.
     * `GCLOUD_PROJECT`
     * `CLOUDSDK_CORE_PROJECT`
 
-    -> `GOOGLE_CLOUD_PROJECT` is the recommended environment variable to use if
+    -> `GOOGLE_PROJECT` is the recommended environment variable to use if
     you choose to add your project using environment variables.
 
 * `region` - (Optional) The region to operate under, if not specified by a given resource.

--- a/website/docs/provider_reference.html.markdown
+++ b/website/docs/provider_reference.html.markdown
@@ -57,8 +57,7 @@ The following keys can be used to configure the provider.
   -> [Service accounts][service accounts] are the recommended way
   to manage GCP credentials. [GCE metadata] is also acceptable, although it can
   only be used when running Terraform from within [certain GCP resources](https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions).
-  Application Default Credentials, such as those obtained through the `gcloud`
-  command above, are not guaranteed to work for all APIs.
+  Credentials obtained through `gcloud` are not guaranteed to work for all APIs.
 
 * `project` - (Optional) The ID of the project to apply any resources to.  This
   can also be specified using any of the following environment variables (listed

--- a/website/docs/provider_reference.html.markdown
+++ b/website/docs/provider_reference.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "google"
+page_title: "google provider reference"
+sidebar_current: "docs-google-provider-reference"
+description: |-
+  The Google provider is used to configure your GCP project, location, and creds
+---
+
+# `google` provider reference
+The `google` provider block is used to configure default values for your GCP
+project, location (`zone` and `region`), and add your credentials credentials.
+
+-> You can avoid using a provider block by using environment variables. Every
+field of the `google` provider is optional. If you want to share configs between
+environments and deploy to different projects, try it out!
+
+## Example Usage
+
+```hcl
+provider "google" {
+  credentials = "${file("account.json")}"
+  project     = "my-gce-project-id"
+  region      = "us-central1"
+  zone        = "us-central1-c"
+}
+```
+
+## Configuration Reference
+
+The following keys can be used to configure the provider.
+
+* `credentials` - (Optional) Contents of a file that contains your service
+  account private key in JSON format. You can download your existing
+  [Google Cloud service account file]
+  from the Google Cloud Console, or you can create a new one from the same page.
+
+  Credentials can also be specified using any of the following environment
+  variables (listed in order of precedence):
+
+    * `GOOGLE_CREDENTIALS`
+    * `GOOGLE_CLOUD_KEYFILE_JSON`
+    * `GCLOUD_KEYFILE_JSON`
+
+  The [`GOOGLE_APPLICATION_CREDENTIALS`][adc]
+  environment variable can also contain the path of a file to obtain credentials
+  from.
+
+  If no credentials are specified, the provider will fall back to using the
+  [Google Application Default Credentials][adc].
+  If you are running Terraform from a GCE instance, see [Creating and Enabling
+  Service Accounts for Instances][gce-service-account] for details.
+
+  On your computer, if you have made your identity available as the
+  Application Default Credentials by running [`gcloud auth application-default
+  login`][gcloud adc], the provider will use your identity.
+
+  -> [Service accounts][service accounts] are the recommended way
+  to manage GCP credentials. [GCE metadata] is also acceptable, although can
+  only be used in limited scenarios. The `gcloud` method is not guaranteed to work
+  for all APIs.
+
+* `project` - (Optional) The ID of the project to apply any resources to.  This
+  can also be specified using any of the following environment variables (listed
+  in order of precedence):
+
+    * `GOOGLE_PROJECT`
+    * `GOOGLE_CLOUD_PROJECT`
+    * `GCLOUD_PROJECT`
+    * `CLOUDSDK_CORE_PROJECT`
+
+    -> `GOOGLE_CLOUD_PROJECT` is the recommended environment variable to use if
+    you choose to add your project using environment variables.
+
+* `region` - (Optional) The region to operate under, if not specified by a given resource.
+  This can also be specified using any of the following environment variables (listed in order of
+  precedence):
+
+    * `GOOGLE_REGION`
+    * `GCLOUD_REGION`
+    * `CLOUDSDK_COMPUTE_REGION`
+
+* `zone` - (Optional) The zone to operate under, if not specified by a given resource.
+  This can also be specified using any of the following environment variables (listed in order of
+  precedence):
+
+    * `GOOGLE_ZONE`
+    * `GCLOUD_ZONE`
+    * `CLOUDSDK_COMPUTE_ZONE`
+
+[Google Cloud service account file]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[adc]: https://cloud.google.com/docs/authentication/production
+[gce-service-account]: https://cloud.google.com/compute/docs/authentication
+[gcloud adc]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+[service accounts]: https://cloud.google.com/docs/authentication/getting-started
+[GCE metadata]: https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions

--- a/website/google.erb
+++ b/website/google.erb
@@ -6,8 +6,19 @@
     <a href="/docs/providers/index.html">All Providers</a>
     </li>
 
-    <li<%= sidebar_current("docs-google-index") %>>
-    <a href="/docs/providers/google/index.html">Google Provider</a>
+    <li<%= sidebar_current("docs-google-provider") %>>
+      <a href="/docs/providers/google/index.html">Google Provider</a>
+      <ul class="nav nav-visible">
+        <li<%= sidebar_current("docs-google-provider-x") %>>
+          <a href="/docs/providers/google/index.html">Provider Info</a>
+        </li>
+        <li<%= sidebar_current("docs-google-provider-getting-started") %>>
+          <a href="/docs/providers/google/getting_started.html">Getting Started</a>
+        </li>
+        <li<%= sidebar_current("docs-google-provider-reference") %>>
+          <a href="/docs/providers/google/provider_reference.html">google provider reference</a>
+        </li>
+      </ul>
     </li>
 
     <li<%= sidebar_current("docs-google-datasource") %>>


### PR DESCRIPTION
WANT_LGTM=ALL. Feel free to remove yourself as a reviewer if you don't have anything to add, or to add yourself if you have feelings and I haven't added you!

I've added a bunch of information to the provider page and split it in 3.

* The primary/index page contains non-technical information about being a provider user. This means things like how we work on features/bugs, when to file a bug or feature, and some information about Beta resources. It collects information from the repo README, issue templates, and a couple other places. My intention here is to have all that information available w/o looking at our GitHub repo.
	* I kept the Beta Features header unchanged because we still have a few resources linking to it.
* The Getting Started page is intended to introduce a new user to Google Provider concepts like self links, projects, regions & zones and GCP credentials while also pushing users towards using service accounts. My hope is that it is a little easier to follow than being thrown at the provider reference - a user who reads Getting Started should be ready to start using the provider w/o the reference.
	* The intended audience is users who already know how Terraform works but are not necessarily familiar with GCP. Let me know if you think I should make it more/less advanced!
* The provider reference is mostly just the contents of the old index page. I specifically call out not having a provider block because I think that's a fun piece of information.

Please review with any nitpicks you have, especially about tone & grammar, or if you think we could present the content in a better way!