### PR TITLE
Replace "Google Apps domain" with "G Suite domain"

### DIFF
--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -62,7 +62,7 @@ each accept the following arguments:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_subnetwork_iam.html.markdown
+++ b/website/docs/r/compute_subnetwork_iam.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_compute_subnetwork_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/google_folder_iam_binding.html.markdown
+++ b/website/docs/r/google_folder_iam_binding.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_folder_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/google_folder_iam_member.html.markdown
+++ b/website/docs/r/google_folder_iam_member.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Note that custom roles must be of the format
     `[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_kms_key_ring_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_project_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/google_service_account_iam.html.markdown
+++ b/website/docs/r/google_service_account_iam.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_service_account_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_pubsub_subscription_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/pubsub_topic_iam.html.markdown
+++ b/website/docs/r/pubsub_topic_iam.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_pubsub_topic_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/spanner_database_iam.html.markdown
+++ b/website/docs/r/spanner_database_iam.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_spanner_database_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/spanner_instance_iam.html.markdown
+++ b/website/docs/r/spanner_instance_iam.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Only one
     `google_spanner_instance_iam_binding` can be used per role. Note that custom roles must be of the format

--- a/website/docs/r/storage_bucket_iam.html.markdown
+++ b/website/docs/r/storage_bucket_iam.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
-  * **domain:{domain}**: A Google Apps domain name that represents all the users of that domain. For example, google.com or example.com.
+  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
 * `role` - (Required) The role that should be applied. Note that custom roles must be of the format
     `[projects|organizations]/{parent-name}/roles/{role-name}`.


### PR DESCRIPTION
## What does this PR do?
Replace "Google Apps domain" with "G Suite domain (primary, instead of alias")

## Motivations
Google Apps is a former name.

Also, I mention primary domain and domain alias. It seems I have to use the primary domain. Otherwise, GCP replaces the field to the primary one. And every time Terraform plan returns a diff about it.

I used domain alias for `members` arg in `google_project_iam_member` resource. `terraform apply` was succeeded. However, when I run modify other resources, I got a diff about the `google_project_iam_member` resource.