### PR TITLE
Remove binary_log_enabled from Postgres test, as it's unsupported

### DIFF
--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -1105,7 +1105,6 @@ resource "google_sql_database_instance" "instance" {
 
 		backup_configuration {
 			enabled = true
-			binary_log_enabled = true
 		}
 	}
 }

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -190,7 +190,7 @@ The optional `settings.database_flags` sublist supports:
 The optional `settings.backup_configuration` subblock supports:
 
 * `binary_log_enabled` - (Optional) True if binary logging is enabled. If
-    `logging` is false, this must be as well.
+    `logging` is false, this must be as well. Cannot be used with Postgres.
 
 * `enabled` - (Optional) True if backup configuration is enabled.
 


### PR DESCRIPTION
\+ update docs.

This must have silently failed in the API before? It doesn't work & is tested upstream now. Binary logs are a non-feature of Postgres.