### PR TITLE
remove containeranalysis from ignore list

### DIFF
--- a/google/resource_google_project_services.go
+++ b/google/resource_google_project_services.go
@@ -47,7 +47,6 @@ func resourceGoogleProjectServices() *schema.Resource {
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.
 var ignoreProjectServices = map[string]struct{}{
-	"containeranalysis.googleapis.com":       struct{}{},
 	"dataproc-control.googleapis.com":        struct{}{},
 	"source.googleapis.com":                  struct{}{},
 	"stackdriverprovisioning.googleapis.com": struct{}{},


### PR DESCRIPTION
Fixes #1964. The API was whitelist-only before, but now it's not.