### PR TITLE
Deprecate address in compute_instance family, undeprecate network_ip

### DIFF
--- a/google/compute_instance_helpers.go
+++ b/google/compute_instance_helpers.go
@@ -147,7 +147,8 @@ func expandNetworkInterfaces(d *schema.ResourceData, config *Config) ([]*compute
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
 		}
 
-		// network_ip is deprecated. We want address to win if both are set.
+		// address is deprecated, but address took priority over networkIP before
+		// so it should until it's removed.
 		if data["address"].(string) != "" {
 			ifaces[i].NetworkIP = data["address"].(string)
 		}

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -168,18 +168,18 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"address": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
-						},
-
-						"network_ip": &schema.Schema{
 							Type:       schema.TypeString,
 							Optional:   true,
 							ForceNew:   true,
 							Computed:   true,
-							Deprecated: "Please use address",
+							Deprecated: "Please use network_ip",
+						},
+
+						"network_ip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Computed: true,
 						},
 
 						"access_config": &schema.Schema{

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -147,11 +147,11 @@ func TestAccComputeInstanceTemplate_networkIP(t *testing.T) {
 		},
 	})
 }
-func TestAccComputeInstanceTemplate_address(t *testing.T) {
+func TestAccComputeInstanceTemplate_networkIPAddress(t *testing.T) {
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
-	address := "10.128.0.2"
+	ipAddress := "10.128.0.2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -159,13 +159,13 @@ func TestAccComputeInstanceTemplate_address(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeInstanceTemplate_address(address),
+				Config: testAccComputeInstanceTemplate_networkIPAddress(ipAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateNetwork(&instanceTemplate),
-					testAccCheckComputeInstanceTemplateAddress(
-						"google_compute_instance_template.foobar", address, &instanceTemplate),
+					testAccCheckComputeInstanceTemplateNetworkIPAddress(
+						"google_compute_instance_template.foobar", ipAddress, &instanceTemplate),
 				),
 			},
 			resource.TestStep{
@@ -648,14 +648,14 @@ func testAccCheckComputeInstanceTemplateNetworkIP(n, networkIP string, instanceT
 	}
 }
 
-func testAccCheckComputeInstanceTemplateAddress(n, address string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+func testAccCheckComputeInstanceTemplateNetworkIPAddress(n, ipAddress string, instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ip := instanceTemplate.Properties.NetworkInterfaces[0].NetworkIP
 		err := resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", ip)(s)
 		if err != nil {
 			return err
 		}
-		return resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", address)(s)
+		return resource.TestCheckResourceAttr(n, "network_interface.0.network_ip", ipAddress)(s)
 	}
 }
 
@@ -888,7 +888,7 @@ resource "google_compute_instance_template" "foobar" {
 }`, acctest.RandString(10), networkIP)
 }
 
-func testAccComputeInstanceTemplate_address(address string) string {
+func testAccComputeInstanceTemplate_networkIPAddress(ipAddress string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
 	family  = "debian-9"
@@ -906,13 +906,13 @@ resource "google_compute_instance_template" "foobar" {
 
 	network_interface {
 		network    = "default"
-		address    = "%s"
+		network_ip    = "%s"
 	}
 
 	metadata {
 		foo = "bar"
 	}
-}`, acctest.RandString(10), address)
+}`, acctest.RandString(10), ipAddress)
 }
 
 func testAccComputeInstanceTemplate_disks() string {

--- a/website/docs/d/datasource_compute_instance.html.markdown
+++ b/website/docs/d/datasource_compute_instance.html.markdown
@@ -85,7 +85,11 @@ The following arguments are supported:
 
 * `cpu_platform` - The CPU platform used by this instance.
 
-* `network_interface.0.address` - The internal ip address of the instance, either manually or dynamically assigned.
+* `network_interface.0.address` - (Deprecated) The internal ip address of the instance, either manually or dynamically assigned.
+This attribute has been deprecated. Use `network_interface.0.network_ip` instead.
+
+* `network_interface.0.network_ip` - The internal ip address of the instance, either manually or dynamically assigned.
+
 
 * `network_interface.0.access_config.0.assigned_nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
 
@@ -144,7 +148,10 @@ The `network_interface` block supports:
 
 *  `subnetwork_project` - The project in which the subnetwork belongs.
 
-* `address` - The private IP address assigned to the instance.
+* `address` - (Deprecated) The private IP address assigned to the instance.
+ This attribute has been deprecated. Use `network_interface.network_ip` instead.
+
+* `network_ip` - The private IP address assigned to the instance.
 
 * `access_config` - Access configurations, i.e. IPs via which this
     instance can be accessed via the Internet. Structure documented below.

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -202,7 +202,11 @@ The `network_interface` block supports:
    defined in the subnetwork self_link. If the `subnetwork` is a name and this
    field is not provided, the provider project is used.
 
-* `address` - (Optional) The private IP address to assign to the instance. If
+* `address` - (Optional, Deprecated) The private IP address to assign to the instance. If
+    empty, the address will be automatically assigned. This attribute has been deprecated.
+    Use `network_interface.network_ip` instead.
+
+* `network_ip` - (Optional) The private IP address to assign to the instance. If
     empty, the address will be automatically assigned.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this
@@ -287,7 +291,10 @@ exported:
 
 * `cpu_platform` - The CPU platform used by this instance.
 
-* `network_interface.0.address` - The internal ip address of the instance, either manually or dynamically assigned.
+* `network_interface.0.address` - (Deprecated) The internal ip address of the instance, either manually or dynamically assigned.
+This attribute has been deprecated. Use `network_interface.0.network_ip`instead.
+
+* `network_interface.0.network_ip` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.assigned_nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
 
@@ -305,7 +312,7 @@ exported:
 
 ## Import
 
-~> **Note:** The fields `boot_disk.0.disk_entryption_raw` and `attached_disk.*.disk_encryption_key_raw` cannot be imported automatically. The API doesn't return this information. If you are setting one of these fields in your config, you will need to update your state manually after importing the resource.
+~> **Note:** The fields `boot_disk.0.disk_encryption_raw` and `attached_disk.*.disk_encryption_key_raw` cannot be imported automatically. The API doesn't return this information. If you are setting one of these fields in your config, you will need to update your state manually after importing the resource.
 
 Instances can be imported using the `project`, `zone` and `name`, e.g.
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -286,7 +286,11 @@ The `network_interface` block supports:
 * `subnetwork_project` - (Optional) The ID of the project in which the subnetwork belongs.
     If it is not provided, the provider project is used.
 
-* `address` - (Optional) The private IP address to assign to the instance. If
+* `address` - (Optional, Deprecated) The private IP address to assign to the instance. If
+    empty, the address will be automatically assigned. This attribute has been deprecated.
+    Use `network_interface.network_ip` instead.
+
+* `network_ip` - (Optional) The private IP address to assign to the instance. If
     empty, the address will be automatically assigned.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this


### PR DESCRIPTION
Also remove a duplicate instance test I noticed for ephemeral ips.