### PR TITLE
Make schema for args of Cloud Build steps a list

### DIFF
--- a/google/resource_cloudbuild_build_trigger.go
+++ b/google/resource_cloudbuild_build_trigger.go
@@ -68,9 +68,10 @@ func resourceCloudBuildTrigger() *schema.Resource {
 										ForceNew: true,
 									},
 									"args": &schema.Schema{
-										Type:     schema.TypeString,
+										Type:     schema.TypeList,
 										Optional: true,
 										ForceNew: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},
@@ -270,7 +271,7 @@ func expandCloudbuildBuildTriggerBuild(d *schema.ResourceData) *cloudbuild.Build
 			Name: d.Get(fmt.Sprintf("build.0.step.%d.name", s)).(string),
 		}
 		if v, ok := d.GetOk(fmt.Sprintf("build.0.step.%d.args", s)); ok {
-			step.Args = strings.Split(v.(string), " ")
+			step.Args = convertStringArr(v.([]interface{}))
 		}
 		build.Steps = append(build.Steps, step)
 	}
@@ -293,7 +294,7 @@ func flattenCloudbuildBuildTriggerBuild(d *schema.ResourceData, config *Config, 
 		for i, step := range b.Steps {
 			steps[i] = map[string]interface{}{}
 			steps[i]["name"] = step.Name
-			steps[i]["args"] = strings.Join(step.Args, " ")
+			steps[i]["args"] = convertStringArrToInterface(step.Args)
 		}
 		flattened[0]["step"] = steps
 	}

--- a/google/resource_cloudbuild_build_trigger_test.go
+++ b/google/resource_cloudbuild_build_trigger_test.go
@@ -195,15 +195,15 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     tags = ["team-a", "service-b"]
     step {
       name = "gcr.io/cloud-builders/gsutil"
-      args = "cp gs://mybucket/remotefile.zip localfile.zip "
+      args = ["cp", "gs://mybucket/remotefile.zip", "localfile.zip"]
     }
     step {
       name = "gcr.io/cloud-builders/go"
-      args = "build my_package"
+      args = ["build", "my_package"]
     }
     step {
       name = "gcr.io/cloud-builders/docker"
-      args = "build -t gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA -f Dockerfile ."
+      args = ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA", "-f", "Dockerfile", "."]
     }
   }
 }


### PR DESCRIPTION
Because strings.Split cannot handle string arguments including space.

For example, "git commit -m \"New Commit\""

Thanks.

cf. https://godoc.org/google.golang.org/api/cloudbuild/v1#BuildStep