### PR TITLE
Simplify GKE cluster code

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -537,14 +537,29 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	clusterName := d.Get("name").(string)
 
 	cluster := &containerBeta.Cluster{
-		Name:             clusterName,
-		InitialNodeCount: int64(d.Get("initial_node_count").(int)),
-	}
-
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-
-	if v, ok := d.GetOk("maintenance_policy"); ok {
-		cluster.MaintenancePolicy = expandMaintenancePolicy(v)
+		Name:                           clusterName,
+		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
+		MaintenancePolicy:              expandMaintenancePolicy(d.Get("maintenance_policy")),
+		MasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(d.Get("master_authorized_networks_config")),
+		InitialClusterVersion:          d.Get("min_master_version").(string),
+		ClusterIpv4Cidr:                d.Get("cluster_ipv4_cidr").(string),
+		Description:                    d.Get("description").(string),
+		LegacyAbac: &containerBeta.LegacyAbac{
+			Enabled:         d.Get("enable_legacy_abac").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
+		LoggingService:          d.Get("logging_service").(string),
+		MonitoringService:       d.Get("monitoring_service").(string),
+		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")), // DO NOT SUBMIT check len in expander
+		AddonsConfig:            expandClusterAddonsConfig(d.Get("addons_config")),
+		EnableKubernetesAlpha:   d.Get("enable_kubernetes_alpha").(bool),
+		IpAllocationPolicy:      expandIPAllocationPolicy(d.Get("ip_allocation_policy")),
+		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
+		MasterIpv4CidrBlock:     d.Get("master_ipv4_cidr_block").(string),
+		BinaryAuthorization: &containerBeta.BinaryAuthorization{
+			Enabled:         d.Get("enable_binary_authorization").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
 	}
 
 	if v, ok := d.GetOk("master_auth"); ok {
@@ -563,14 +578,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 				}
 			}
 		}
-	}
-
-	if v, ok := d.GetOk("master_authorized_networks_config"); ok {
-		cluster.MasterAuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(v)
-	}
-
-	if v, ok := d.GetOk("min_master_version"); ok {
-		cluster.InitialClusterVersion = v.(string)
 	}
 
 	// Only allow setting node_version on create if it's set to the equivalent master version,
@@ -597,27 +604,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.Locations = convertStringSet(locationsSet)
 	}
 
-	if v, ok := d.GetOk("cluster_ipv4_cidr"); ok {
-		cluster.ClusterIpv4Cidr = v.(string)
-	}
-
-	if v, ok := d.GetOk("description"); ok {
-		cluster.Description = v.(string)
-	}
-
-	cluster.LegacyAbac = &containerBeta.LegacyAbac{
-		Enabled:         d.Get("enable_legacy_abac").(bool),
-		ForceSendFields: []string{"Enabled"},
-	}
-
-	if v, ok := d.GetOk("logging_service"); ok {
-		cluster.LoggingService = v.(string)
-	}
-
-	if v, ok := d.GetOk("monitoring_service"); ok {
-		cluster.MonitoringService = v.(string)
-	}
-
 	if v, ok := d.GetOk("network"); ok {
 		network, err := ParseNetworkFieldValue(v.(string), d, config)
 		if err != nil {
@@ -626,24 +612,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.Network = network.RelativeLink()
 	}
 
-	if v, ok := d.GetOk("network_policy"); ok && len(v.([]interface{})) > 0 {
-		cluster.NetworkPolicy = expandNetworkPolicy(v)
-	}
-
 	if v, ok := d.GetOk("subnetwork"); ok {
 		subnetwork, err := ParseSubnetworkFieldValue(v.(string), d, config)
 		if err != nil {
 			return err
 		}
 		cluster.Subnetwork = subnetwork.RelativeLink()
-	}
-
-	if v, ok := d.GetOk("addons_config"); ok {
-		cluster.AddonsConfig = expandClusterAddonsConfig(v)
-	}
-
-	if v, ok := d.GetOk("enable_kubernetes_alpha"); ok {
-		cluster.EnableKubernetesAlpha = v.(bool)
 	}
 
 	nodePoolsCount := d.Get("node_pool.#").(int)
@@ -668,21 +642,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.NodeConfig = expandNodeConfig(v)
 	}
 
-	if v, ok := d.GetOk("ip_allocation_policy"); ok {
-		cluster.IpAllocationPolicy, err = expandIPAllocationPolicy(v)
-		if err != nil {
-			return err
-		}
-	}
-
-	if v, ok := d.GetOk("pod_security_policy_config"); ok {
-		cluster.PodSecurityPolicyConfig = expandPodSecurityPolicyConfig(v)
-	}
-
-	if v, ok := d.GetOk("master_ipv4_cidr_block"); ok {
-		cluster.MasterIpv4CidrBlock = v.(string)
-	}
-
 	if v, ok := d.GetOk("private_cluster"); ok {
 		if cluster.PrivateCluster = v.(bool); cluster.PrivateCluster {
 			if cluster.MasterIpv4CidrBlock == "" {
@@ -702,11 +661,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.ResourceLabels = m
 	}
 
-	cluster.BinaryAuthorization = &containerBeta.BinaryAuthorization{
-		Enabled:         d.Get("enable_binary_authorization").(bool),
-		ForceSendFields: []string{"Enabled"},
-	}
-
 	req := &containerBeta.CreateClusterRequest{
 		Cluster: cluster,
 	}
@@ -723,6 +677,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(clusterName)
 
 	// Wait until it's created
+	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
 	waitErr := containerSharedOperationWait(config, op, project, location, "creating GKE cluster", timeoutInMinutes, 3)
 	if waitErr != nil {
 		// The resource didn't actually create
@@ -1416,7 +1371,11 @@ func getInstanceGroupUrlsFromManagerUrls(config *Config, igmUrls []string) ([]st
 }
 
 func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConfig {
-	config := configured.([]interface{})[0].(map[string]interface{})
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
 	ac := &containerBeta.AddonsConfig{}
 
 	if v, ok := config["http_load_balancing"]; ok && len(v.([]interface{})) > 0 {
@@ -1454,10 +1413,10 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 	return ac
 }
 
-func expandIPAllocationPolicy(configured interface{}) (*containerBeta.IPAllocationPolicy, error) {
+func expandIPAllocationPolicy(configured interface{}) *containerBeta.IPAllocationPolicy {
 	l := configured.([]interface{})
 	if len(l) == 0 {
-		return &containerBeta.IPAllocationPolicy{}, nil
+		return nil
 	}
 	config := l[0].(map[string]interface{})
 
@@ -1472,37 +1431,42 @@ func expandIPAllocationPolicy(configured interface{}) (*containerBeta.IPAllocati
 
 		ClusterSecondaryRangeName:  config["cluster_secondary_range_name"].(string),
 		ServicesSecondaryRangeName: config["services_secondary_range_name"].(string),
-	}, nil
+	}
 }
 
 func expandMaintenancePolicy(configured interface{}) *containerBeta.MaintenancePolicy {
-	result := &containerBeta.MaintenancePolicy{}
-	if len(configured.([]interface{})) > 0 {
-		maintenancePolicy := configured.([]interface{})[0].(map[string]interface{})
-		dailyMaintenanceWindow := maintenancePolicy["daily_maintenance_window"].([]interface{})[0].(map[string]interface{})
-		startTime := dailyMaintenanceWindow["start_time"].(string)
-		result.Window = &containerBeta.MaintenanceWindow{
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	maintenancePolicy := l[0].(map[string]interface{})
+	dailyMaintenanceWindow := maintenancePolicy["daily_maintenance_window"].([]interface{})[0].(map[string]interface{})
+	startTime := dailyMaintenanceWindow["start_time"].(string)
+	return &containerBeta.MaintenancePolicy{
+		Window: &containerBeta.MaintenanceWindow{
 			DailyMaintenanceWindow: &containerBeta.DailyMaintenanceWindow{
 				StartTime: startTime,
 			},
-		}
+		},
 	}
-	return result
 }
 
 func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
-	result := &containerBeta.MasterAuth{}
-	if len(configured.([]interface{})) > 0 {
-		masterAuth := configured.([]interface{})[0].(map[string]interface{})
-		result.Username = masterAuth["username"].(string)
-		result.Password = masterAuth["password"].(string)
-		if _, ok := masterAuth["client_certificate_config"]; ok {
-			if len(masterAuth["client_certificate_config"].([]interface{})) > 0 {
-				clientCertificateConfig := masterAuth["client_certificate_config"].([]interface{})[0].(map[string]interface{})
-				if _, ok := clientCertificateConfig["issue_client_certificate"]; ok {
-					result.ClientCertificateConfig = &containerBeta.ClientCertificateConfig{
-						IssueClientCertificate: clientCertificateConfig["issue_client_certificate"].(bool),
-					}
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	masterAuth := l[0].(map[string]interface{})
+	result := &containerBeta.MasterAuth{
+		Username: masterAuth["username"].(string),
+		Password: masterAuth["password"].(string),
+	}
+	if _, ok := masterAuth["client_certificate_config"]; ok {
+		if len(masterAuth["client_certificate_config"].([]interface{})) > 0 {
+			clientCertificateConfig := masterAuth["client_certificate_config"].([]interface{})[0].(map[string]interface{})
+			if _, ok := clientCertificateConfig["issue_client_certificate"]; ok {
+				result.ClientCertificateConfig = &containerBeta.ClientCertificateConfig{
+					IssueClientCertificate: clientCertificateConfig["issue_client_certificate"].(bool),
 				}
 			}
 		}
@@ -1511,20 +1475,23 @@ func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 }
 
 func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta.MasterAuthorizedNetworksConfig {
-	result := &containerBeta.MasterAuthorizedNetworksConfig{}
-	if len(configured.([]interface{})) > 0 {
-		result.Enabled = true
-		if config, ok := configured.([]interface{})[0].(map[string]interface{}); ok {
-			if _, ok := config["cidr_blocks"]; ok {
-				cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
-				result.CidrBlocks = make([]*containerBeta.CidrBlock, 0)
-				for _, v := range cidrBlocks {
-					cidrBlock := v.(map[string]interface{})
-					result.CidrBlocks = append(result.CidrBlocks, &containerBeta.CidrBlock{
-						CidrBlock:   cidrBlock["cidr_block"].(string),
-						DisplayName: cidrBlock["display_name"].(string),
-					})
-				}
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	result := &containerBeta.MasterAuthorizedNetworksConfig{
+		Enabled: true,
+	}
+	if config, ok := l[0].(map[string]interface{}); ok {
+		if _, ok := config["cidr_blocks"]; ok {
+			cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
+			result.CidrBlocks = make([]*containerBeta.CidrBlock, 0)
+			for _, v := range cidrBlocks {
+				cidrBlock := v.(map[string]interface{})
+				result.CidrBlocks = append(result.CidrBlocks, &containerBeta.CidrBlock{
+					CidrBlock:   cidrBlock["cidr_block"].(string),
+					DisplayName: cidrBlock["display_name"].(string),
+				})
 			}
 		}
 	}
@@ -1532,27 +1499,31 @@ func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta
 }
 
 func expandNetworkPolicy(configured interface{}) *containerBeta.NetworkPolicy {
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
 	result := &containerBeta.NetworkPolicy{}
-	if configured != nil && len(configured.([]interface{})) > 0 {
-		config := configured.([]interface{})[0].(map[string]interface{})
-		if enabled, ok := config["enabled"]; ok && enabled.(bool) {
-			result.Enabled = true
-			if provider, ok := config["provider"]; ok {
-				result.Provider = provider.(string)
-			}
+	config := l[0].(map[string]interface{})
+	if enabled, ok := config["enabled"]; ok && enabled.(bool) {
+		result.Enabled = true
+		if provider, ok := config["provider"]; ok {
+			result.Provider = provider.(string)
 		}
 	}
 	return result
 }
 
 func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSecurityPolicyConfig {
-	result := &containerBeta.PodSecurityPolicyConfig{}
-	if len(configured.([]interface{})) > 0 {
-		config := configured.([]interface{})[0].(map[string]interface{})
-		result.Enabled = config["enabled"].(bool)
-		result.ForceSendFields = []string{"Enabled"}
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
 	}
-	return result
+	config := l[0].(map[string]interface{})
+	return &containerBeta.PodSecurityPolicyConfig{
+		Enabled:         config["enabled"].(bool),
+		ForceSendFields: []string{"Enabled"},
+	}
 }
 
 func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface{} {

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -550,7 +550,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		},
 		LoggingService:          d.Get("logging_service").(string),
 		MonitoringService:       d.Get("monitoring_service").(string),
-		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")), // DO NOT SUBMIT check len in expander
+		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")),
 		AddonsConfig:            expandClusterAddonsConfig(d.Get("addons_config")),
 		EnableKubernetesAlpha:   d.Get("enable_kubernetes_alpha").(bool),
 		IpAllocationPolicy:      expandIPAllocationPolicy(d.Get("ip_allocation_policy")),


### PR DESCRIPTION
We don't need quite so many `GetOk`s since the client library will ignore any fields that are set to the zero value for that type. I left a few that involved error-handling or things that had to be set before other things, but this at least should make the code a bit nicer to look at.

Tests are passing except the ones that were already failing in CI.