### PR TITLE
Add a documentation entry for CNAME records

### DIFF
--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -117,6 +117,26 @@ resource "google_dns_managed_zone" "prod" {
 }
 ```
 
+### Adding a CNAME record
+
+The list of `rrdatas` should only contain a single string corresponding to the Canonical Name intended.
+
+```hcl
+resource "google_dns_record_set" "cname" {
+  name = "frontend.${google_dns_managed_zone.prod.dns_name}"
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+  type = "CNAME"
+  ttl  = 300
+
+  rrdatas = ["frontend.mydomain.com."]
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name        = "prod-zone"
+  dns_name    = "prod.mydomain.com."
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
CNAME records must only have a single rrdatas entry corresponding to the
intended Canonical Name of the record.