### PR TITLE
Deprecate handwritten beta fields.

### DIFF
--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -20,7 +20,7 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Optional: true,
 			},
 			"region": {
-				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"zone"},

--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -20,6 +20,7 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Optional: true,
 			},
 			"region": {
+				Deprecated:    "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"zone"},

--- a/google/data_source_google_container_engine_versions.go
+++ b/google/data_source_google_container_engine_versions.go
@@ -20,7 +20,7 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Optional: true,
 			},
 			"region": {
-				Deprecated:    "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"zone"},

--- a/google/iam_compute_subnetwork.go
+++ b/google/iam_compute_subnetwork.go
@@ -12,23 +12,26 @@ import (
 
 var IamComputeSubnetworkSchema = map[string]*schema.Schema{
 	"subnetwork": {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
+		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Type:       schema.TypeString,
+		Required:   true,
+		ForceNew:   true,
 	},
 
 	"project": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
+		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Type:       schema.TypeString,
+		Optional:   true,
+		Computed:   true,
+		ForceNew:   true,
 	},
 
 	"region": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
+		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Type:       schema.TypeString,
+		Optional:   true,
+		Computed:   true,
+		ForceNew:   true,
 	},
 }
 

--- a/google/iam_compute_subnetwork.go
+++ b/google/iam_compute_subnetwork.go
@@ -12,14 +12,14 @@ import (
 
 var IamComputeSubnetworkSchema = map[string]*schema.Schema{
 	"subnetwork": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 		Type:       schema.TypeString,
 		Required:   true,
 		ForceNew:   true,
 	},
 
 	"project": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 		Type:       schema.TypeString,
 		Optional:   true,
 		Computed:   true,
@@ -27,7 +27,7 @@ var IamComputeSubnetworkSchema = map[string]*schema.Schema{
 	},
 
 	"region": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 		Type:       schema.TypeString,
 		Optional:   true,
 		Computed:   true,

--- a/google/iam_compute_subnetwork.go
+++ b/google/iam_compute_subnetwork.go
@@ -12,14 +12,14 @@ import (
 
 var IamComputeSubnetworkSchema = map[string]*schema.Schema{
 	"subnetwork": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 		Type:       schema.TypeString,
 		Required:   true,
 		ForceNew:   true,
 	},
 
 	"project": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 		Type:       schema.TypeString,
 		Optional:   true,
 		Computed:   true,
@@ -27,7 +27,7 @@ var IamComputeSubnetworkSchema = map[string]*schema.Schema{
 	},
 
 	"region": {
-		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+		Deprecated: "This resource is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 		Type:       schema.TypeString,
 		Optional:   true,
 		Computed:   true,

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -142,7 +142,7 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"taint": {
-				Deprecated:       "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated:       "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:             schema.TypeList,
 				Optional:         true,
 				ForceNew:         true,
@@ -170,7 +170,7 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"workload_metadata_config": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				ForceNew:   true,

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -142,6 +142,7 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"taint": {
+				Deprecated:       "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
 				Type:             schema.TypeList,
 				Optional:         true,
 				ForceNew:         true,
@@ -169,10 +170,11 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"workload_metadata_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeList,
+				Optional:   true,
+				ForceNew:   true,
+				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"node_metadata": {

--- a/google/node_config.go
+++ b/google/node_config.go
@@ -142,7 +142,7 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"taint": {
-				Deprecated:       "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated:       "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:             schema.TypeList,
 				Optional:         true,
 				ForceNew:         true,
@@ -170,7 +170,7 @@ var schemaNodeConfig = &schema.Schema{
 			},
 
 			"workload_metadata_config": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				ForceNew:   true,

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -159,7 +159,7 @@ func resourceComputeBackendService() *schema.Resource {
 			},
 
 			"custom_request_headers": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeSet,
 				Optional:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -159,10 +159,11 @@ func resourceComputeBackendService() *schema.Resource {
 			},
 
 			"custom_request_headers": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Set:        schema.HashString,
 			},
 
 			"description": &schema.Schema{

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -159,7 +159,7 @@ func resourceComputeBackendService() *schema.Resource {
 			},
 
 			"custom_request_headers": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeSet,
 				Optional:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -56,10 +56,11 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			},
 
 			"labels": &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeMap,
+				Optional:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Set:        schema.HashString,
 			},
 
 			"label_fingerprint": &schema.Schema{

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -56,7 +56,7 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			},
 
 			"labels": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeMap,
 				Optional:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -56,7 +56,7 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 			},
 
 			"labels": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeMap,
 				Optional:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -38,9 +38,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"version": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -159,9 +160,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"auto_healing_policies": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"health_check": &schema.Schema{
@@ -180,9 +182,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"rolling_update_policy": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"minimal_action": &schema.Schema{

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -38,7 +38,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"version": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
@@ -160,7 +160,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"auto_healing_policies": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,
@@ -182,7 +182,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"rolling_update_policy": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -38,7 +38,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"version": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
@@ -160,7 +160,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"auto_healing_policies": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,
@@ -182,7 +182,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"rolling_update_policy": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -97,7 +97,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"region": {
-				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -202,7 +202,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_binary_authorization": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				Default:    false,
@@ -216,7 +216,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_tpu": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				ForceNew:   true,
@@ -395,7 +395,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"pod_security_policy_config": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,
@@ -505,7 +505,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"private_cluster": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				ForceNew:   true,
@@ -513,7 +513,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"master_ipv4_cidr_block": {
-				Deprecated:   "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+				Deprecated:   "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -97,7 +97,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"region": {
-				Deprecated:    "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -202,7 +202,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_binary_authorization": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				Default:    false,
@@ -216,7 +216,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_tpu": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				ForceNew:   true,
@@ -395,7 +395,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"pod_security_policy_config": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeList,
 				Optional:   true,
 				MaxItems:   1,
@@ -505,7 +505,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"private_cluster": {
-				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:       schema.TypeBool,
 				Optional:   true,
 				ForceNew:   true,
@@ -513,7 +513,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"master_ipv4_cidr_block": {
-				Deprecated:   "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Deprecated:   "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -97,6 +97,7 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"region": {
+				Deprecated:    "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -201,9 +202,10 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_binary_authorization": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    false,
 			},
 
 			"enable_kubernetes_alpha": {
@@ -214,10 +216,11 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"enable_tpu": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeBool,
+				Optional:   true,
+				ForceNew:   true,
+				Default:    false,
 			},
 
 			"enable_legacy_abac": {
@@ -392,9 +395,10 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"pod_security_policy_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -501,13 +505,15 @@ func resourceContainerCluster() *schema.Resource {
 			},
 
 			"private_cluster": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
+				Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+				Type:       schema.TypeBool,
+				Optional:   true,
+				ForceNew:   true,
+				Default:    false,
 			},
 
 			"master_ipv4_cidr_block": {
+				Deprecated:   "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -54,9 +54,10 @@ func resourceContainerNodePool() *schema.Resource {
 					ForceNew: true,
 				},
 				"region": &schema.Schema{
-					Type:     schema.TypeString,
-					Optional: true,
-					ForceNew: true,
+					Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+					Type:       schema.TypeString,
+					Optional:   true,
+					ForceNew:   true,
 				},
 			}),
 	}
@@ -85,10 +86,11 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"max_pods_per_node": &schema.Schema{
-		Type:     schema.TypeInt,
-		Optional: true,
-		ForceNew: true,
-		Computed: true,
+		Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Type:       schema.TypeInt,
+		Optional:   true,
+		ForceNew:   true,
+		Computed:   true,
 	},
 
 	"initial_node_count": &schema.Schema{

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -54,7 +54,7 @@ func resourceContainerNodePool() *schema.Resource {
 					ForceNew: true,
 				},
 				"region": &schema.Schema{
-					Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+					Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 					Type:       schema.TypeString,
 					Optional:   true,
 					ForceNew:   true,
@@ -86,7 +86,7 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"max_pods_per_node": &schema.Schema{
-		Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
+		Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 		Type:       schema.TypeInt,
 		Optional:   true,
 		ForceNew:   true,

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -54,7 +54,7 @@ func resourceContainerNodePool() *schema.Resource {
 					ForceNew: true,
 				},
 				"region": &schema.Schema{
-					Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+					Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 					Type:       schema.TypeString,
 					Optional:   true,
 					ForceNew:   true,
@@ -86,7 +86,7 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"max_pods_per_node": &schema.Schema{
-		Deprecated: "This field is in beta and will be removed from this provider. Use terraform-provider-google-beta to continue using it.",
+		Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider-versions.html for more details.",
 		Type:       schema.TypeInt,
 		Optional:   true,
 		ForceNew:   true,


### PR DESCRIPTION
Excludes `google_compute_instance_group_manager`, `google_compute_region_instance_group_manager`, `google_dns_managed_zones`.

[R]igm are being looked at by @paddycarver 
I'm converting dns managed zones to GA with #2154 