### PR TITLE
Fix error in instance template read.

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -683,12 +683,16 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	return resourceComputeInstanceTemplateRead(d, meta)
 }
 
-func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData) ([]map[string]interface{}, error) {
+func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, defaultProject string) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0, len(disks))
 	for _, disk := range disks {
 		diskMap := make(map[string]interface{})
 		if disk.InitializeParams != nil {
-			path, err := getRelativePath(disk.InitializeParams.SourceImage)
+			link, err := resolvedImageSelfLink(defaultProject, disk.InitializeParams.SourceImage)
+			if err != nil {
+				return nil, errwrap.Wrapf("Error expanding source image input to self_link: {{err}}", err)
+			}
+			path, err := getRelativePath(link)
 			if err != nil {
 				return nil, errwrap.Wrapf("Error getting relative path for source image: {{err}}", err)
 			}
@@ -760,7 +764,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting name: %s", err)
 	}
 	if instanceTemplate.Properties.Disks != nil {
-		disks, err := flattenDisks(instanceTemplate.Properties.Disks, d)
+		disks, err := flattenDisks(instanceTemplate.Properties.Disks, d, project)
 		if err != nil {
 			return fmt.Errorf("error flattening disks: %s", err)
 		}

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -688,11 +688,11 @@ func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, def
 	for _, disk := range disks {
 		diskMap := make(map[string]interface{})
 		if disk.InitializeParams != nil {
-			link, err := resolvedImageSelfLink(defaultProject, disk.InitializeParams.SourceImage)
+			selfLink, err := resolvedImageSelfLink(defaultProject, disk.InitializeParams.SourceImage)
 			if err != nil {
 				return nil, errwrap.Wrapf("Error expanding source image input to self_link: {{err}}", err)
 			}
-			path, err := getRelativePath(link)
+			path, err := getRelativePath(selfLink)
 			if err != nil {
 				return nil, errwrap.Wrapf("Error getting relative path for source image: {{err}}", err)
 			}


### PR DESCRIPTION
Flattening disks involves taking the relative link of each disk. This
only works if you start from a self_link, but we were starting from
anything that resolveImage returns, which includes several
not-self_links.

This PR adds a test that shows the failure, and then fixes it by
expanding the output back out to a self_link before getting the relative
link from it.

Tests with only test changes applied:

```
=== RUN   TestAccComputeInstanceTemplate_imageShorthand
=== PAUSE TestAccComputeInstanceTemplate_imageShorthand
=== CONT  TestAccComputeInstanceTemplate_imageShorthand
--- FAIL: TestAccComputeInstanceTemplate_imageShorthand (59.82s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

        * google_compute_instance_template.foobar: 1 error(s) occurred:

        * google_compute_instance_template.foobar: error flattening disks: Error getting relative path for source image: String was not a self link: global/images/test-li6yeo17du
    testing.go:579: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Error refreshing: 1 error(s) occurred:

        * google_compute_instance_template.foobar: google_compute_instance_template.foobar: error flattening disks: Error getting relative path for source image: String was not a self link: global/images/test-li6yeo17du

        State: <nil>
FAIL
FAIL    github.com/terraform-providers/terraform-provider-google/google 59.835s
```

Tests with whole PR applied:

```
=== RUN   TestAccComputeInstanceTemplate_imageShorthand
=== PAUSE TestAccComputeInstanceTemplate_imageShorthand
=== CONT  TestAccComputeInstanceTemplate_imageShorthand
--- PASS: TestAccComputeInstanceTemplate_imageShorthand (93.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 93.805s
```

Fixes #2067.