### PR TITLE
Bring google_dns_managed_zones to ga

### DIFF
--- a/google/dns_operation.go
+++ b/google/dns_operation.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"google.golang.org/api/dns/v1beta2"
+	"google.golang.org/api/dns/v1"
 )
 
 type DnsOperationWaiter struct {

--- a/google/resource_dns_managed_zone.go
+++ b/google/resource_dns_managed_zone.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/dns/v1"
-	dnsBeta "google.golang.org/api/dns/v1beta2"
 )
 
 func resourceDnsManagedZone() *schema.Resource {
@@ -126,7 +125,7 @@ func resourceDnsManagedZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	zone := &dnsBeta.ManagedZone{
+	zone := &dns.ManagedZone{
 		Name:        d.Get("name").(string),
 		DnsName:     d.Get("dns_name").(string),
 		Description: d.Get("description").(string),
@@ -136,12 +135,12 @@ func resourceDnsManagedZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		zone.Labels = expandLabels(d)
 	}
 
-	op, err := config.clientDnsBeta.ManagedZones.Patch(project, d.Id(), zone).Do()
+	op, err := config.clientDns.ManagedZones.Patch(project, d.Id(), zone).Do()
 	if err != nil {
 		return err
 	}
 
-	err = dnsOperationWait(config.clientDnsBeta, op, project, "Updating DNS Managed Zone")
+	err = dnsOperationWait(config.clientDns, op, project, "Updating DNS Managed Zone")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I left the beta client vendored & loaded in the client config because I don't feel strongly about removing them (and figure we will end up adding more beta fields soon enough), but let me know if you'd like them gone.