### PR TITLE
Add event_trigger to cloud functions

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -593,10 +593,10 @@ func expandEventTrigger(configured []interface{}, project string) *cloudfunction
 	if data, ok := configured[0].(map[string]interface{}); ok {
 		eventType := data["event_type"].(string)
 		shape := ""
-		switch eventType {
-		case "providers/cloud.storage/eventTypes/object.change":
+		switch {
+		case strings.HasPrefix(eventType, "providers/cloud.storage/eventTypes/"):
 			shape = "projects/%s/buckets/%s"
-		case "providers/cloud.pubsub/eventTypes/topic.publish":
+		case strings.HasPrefix(eventType, "providers/cloud.pubsub/eventTypes/"):
 			shape = "projects/%s/topics/%s"
 		}
 

--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -84,16 +84,16 @@ Deprecated. Use `event_trigger.failure_policy.retry` instead.
 The `event_trigger` block supports:
 
 * `event_type` - (Required) The type of event to observe. For example: `"providers/cloud.storage/eventTypes/object.change"`
-    and `"providers/cloud.pubsub/eventTypes/topic.publish"`  Only `"providers/cloud.storage/eventTypes/object.change"` and
-    `"providers/cloud.pubsub/eventTypes/topic.publish"` are supported at this time.
+    and `"providers/cloud.pubsub/eventTypes/topic.publish"`. See the documentation on [calling Cloud Functions](https://cloud.google.com/functions/docs/calling/)
+    for a full reference. Only Cloud Storage and Cloud Pub/Sub triggers are supported at this time.
 
 * `resource` - (Required) Required. The name of the resource from which to observe events, for example, `"myBucket"`   
 
-* `failure_policy` - (Required) Specifies policy for failed executions. Structure is documented below.
+* `failure_policy` - (Optional) Specifies policy for failed executions. Structure is documented below.
 
 The `failure_policy` block supports:
 
-* `retry` - (Optional) Whether the function should be retried on failure. Defaults to `false`.
+* `retry` - (Required) Whether the function should be retried on failure. Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -64,17 +64,36 @@ The following arguments are supported:
 
 * `entry_point` - (Optional) Name of a JavaScript function that will be executed when the Google Cloud Function is triggered.
 
+* `event_trigger` - (Optional) A source that fires events in response to a condition in another service. Structure is documented below. Cannot be used with `trigger_http`.
+
 * `trigger_http` - (Optional) Boolean variable. Any HTTP request (of a supported type) to the endpoint will trigger function execution. Supported HTTP request types are: POST, PUT, GET, DELETE, and OPTIONS. Endpoint is returned as `https_trigger_url`. Cannot be used with `trigger_bucket` and `trigger_topic`.
 
 * `trigger_bucket` - (Optional) Google Cloud Storage bucket name. Every change in files in this bucket will trigger function execution. Cannot be used with `trigger_http` and `trigger_topic`.
+Deprecated. Use `event_trigger` instead.
 
 * `trigger_topic` - (Optional) Name of Pub/Sub topic. Every message published in this topic will trigger function execution with message contents passed as input data. Cannot be used with `trigger_http` and `trigger_bucket`.
+Deprecated. Use `event_trigger` instead.
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the function.
 
 * `environment_variables` - (Optional) A set of key/value environment variable pairs to assign to the function.
 
 * `retry_on_failure` - (Optional) Whether the function should be retried on failure. This only applies to bucket and topic triggers, not HTTPS triggers.
+Deprecated. Use `event_trigger.failure_policy.retry` instead.
+
+The `event_trigger` block supports:
+
+* `event_type` - (Required) The type of event to observe. For example: `"providers/cloud.storage/eventTypes/object.change"`
+    and `"providers/cloud.pubsub/eventTypes/topic.publish"`  Only `"providers/cloud.storage/eventTypes/object.change"` and
+    `"providers/cloud.pubsub/eventTypes/topic.publish"` are supported at this time.
+
+* `resource` - (Required) Required. The name of the resource from which to observe events, for example, `"myBucket"`   
+
+* `failure_policy` - (Required) Specifies policy for failed executions. Structure is documented below.
+
+The `failure_policy` block supports:
+
+* `retry` - (Optional) Whether the function should be retried on failure. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Deprecate old `trigger_` objects, and `retry_on_failure`.

Decisions:

* Let's over-required on `failure_policy.retry` to stop weird configs
* `resource` expects *mostly* a partial self link, except gcs buckets use a different shape of self link. The shape Cloud Functions expect is not that shape. The shape they use is made up, so there is an error if you supply a gcs self link... let's be restrictive and only allow names for now. We need to specify the shape if we take in names, so we need to match against specific event_types. So let's only support the two trigger types we supported before for now (Cloud Storage, Cloud Pub/Sub)
 * Note for the future: Formats are documented [here](https://cloud.google.com/functions/docs/calling/)
* `event_type` accepts a specific pattern that is documented. It will also accept some different formats (at least a certain subset of the pattern) and is not as restrictive as it seems, but let's not document that because the Cloud Functions documentation does not. And also we need users to match specific shapes so we can format the self links correctly.
