### PR TITLE
Fix cloud function datasource

### DIFF
--- a/google/data_source_google_cloudfunctions_function.go
+++ b/google/data_source_google_cloudfunctions_function.go
@@ -41,5 +41,25 @@ func dataSourceGoogleCloudFunctionsFunctionRead(d *schema.ResourceData, meta int
 
 	d.SetId(cloudFuncId.terraformId())
 
-	return resourceCloudFunctionsRead(d, meta)
+	// terrible hack, remove when these fields are removed
+	// We're temporarily reading these fields only when they are set
+	// so we need them to be set with bad values entering read
+	// and then unset if those bad values are still there
+	d.Set("trigger_topic", "invalid")
+	d.Set("trigger_bucket", "invalid")
+
+	err = resourceCloudFunctionsRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	// terrible hack, remove when these fields are removed. see above
+	if v := d.Get("trigger_topic").(string); v == "invalid" {
+		d.Set("trigger_topic", "")
+	}
+	if v := d.Get("trigger_bucket").(string); v == "invalid" {
+		d.Set("trigger_bucket", "")
+	}
+
+	return nil
 }

--- a/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -47,7 +47,22 @@ exported:
 * `timeout` - Function execution timeout (in seconds).
 * `entry_point` - Name of a JavaScript function that will be executed when the Google Cloud Function is triggered.
 * `trigger_http` - If function is triggered by HTTP, this boolean is set.
-* `trigger_bucket` - If function is triggered by bucket, bucket name is set here.
-* `trigger_topic` - If function is triggered by Pub/Sub topic, name of topic is set here.
+* `event_trigger` - A source that fires events in response to a condition in another service. Structure is documented below.
+* `trigger_bucket` - If function is triggered by bucket, bucket name is set here. Deprecated. Use `event_trigger` instead.
+* `trigger_topic` - If function is triggered by Pub/Sub topic, name of topic is set here. Deprecated. Use `event_trigger` instead.
 * `https_trigger_url` - If function is triggered by HTTP, trigger URL is set here.
 * `labels` - A map of labels applied to this function.
+
+The `event_trigger` block contains:
+
+* `event_type` - The type of event being observed. For example: `"providers/cloud.storage/eventTypes/object.change"`
+    and `"providers/cloud.pubsub/eventTypes/topic.publish"`. See the documentation on [calling Cloud Functions](https://cloud.google.com/functions/docs/calling/)
+    for a full reference.
+
+* `resource` - The name of the resource whose events are being observed, for example, `"myBucket"`
+
+* `failure_policy` - Policy for failed executions. Structure is documented below.
+
+The `failure_policy` block supports:
+
+* `retry` - Whether the function should be retried on failure.


### PR DESCRIPTION
We conditionally read the old `trigger_` fields, so let's fake setting some values in the data source so we always read them. Also update the docs which I forgot to do.