### PR TITLE
set role entity to nil on read if it isn't in state

### DIFF
--- a/google/resource_storage_object_acl.go
+++ b/google/resource_storage_object_acl.go
@@ -152,6 +152,8 @@ func resourceStorageObjectAclRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		d.Set("role_entity", role_entity)
+	} else {
+		d.Set("role_entity", nil)
 	}
 
 	d.SetId(getObjectAclId(object))


### PR DESCRIPTION
This fixes `TestAccStorageObjectAcl_predefined`.

Even though the if statement is against predefined_acl not being set, the two are mutually exclusive so it's really checking if role_entity is set.