### PR TITLE
Add documentation for private_cluster_config.

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -136,11 +136,12 @@ output "cluster_ca_certificate" {
     for master authorized networks. Omit the nested `cidr_blocks` attribute to disallow
     external access (except the cluster node IPs, which GKE automatically whitelists).
 
-* `master_ipv4_cidr_block` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Specifies a private
+* `master_ipv4_cidr_block` - (Optional, Deprecated, [Beta](/docs/providers/google/index.html#beta-features)) Specifies a private
     [RFC1918](https://tools.ietf.org/html/rfc1918) block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC.
     The master and your cluster use VPC peering. Must be specified in CIDR notation and must be `/28` subnet.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
+    This field is deprecated, use `private_cluster_config.master_ipv4_cidr_block` instead.
 
 * `min_master_version` - (Optional) The minimum version of the master. GKE
     will auto-update the master to new versions, so this does not guarantee the
@@ -180,12 +181,18 @@ output "cluster_ca_certificate" {
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `private_cluster` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) If true, a
+* `privat_cluster_config` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) A set of options for creating
+    a private cluster. Structure is documented below.
+    This property is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
+
+* `private_cluster` - (Optional, Deprecated, [Beta](/docs/providers/google/index.html#beta-features)) If true, a
     [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) will be created, meaning
     nodes do not get public IP addresses. It is mandatory to specify `master_ipv4_cidr_block` and 
     `ip_allocation_policy` with this option.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
+    This field is deprecated, use `private_cluster_config.enable_private_nodes` instead.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -385,6 +392,23 @@ The `pod_security_policy_config` block supports:
 
 * `enabled` (Required) - Enable the PodSecurityPolicy controller for this cluster.
     If enabled, pods must be valid under a PodSecurityPolicy to be created.
+
+The `private_cluster_config` block supports:
+
+* `enable_private_endpoint` (Optional) - Whether the master's internal IP address is used as the cluster endpoint.
+
+* `enable_private_nodes` (Optional) - Whether nodes have internal IP addresses only. If enabled, all nodes are given only RFC 1918 private
+    addresses and communicate with the master via private networking.
+
+* `master_ipv4_cidr_block` (Optional) - The IP range in CIDR notation to use for the hosted master network. This range will be used for
+    assigning internal IP addresses to the master or set of masters, as well as the ILB VIP. This range must not overlap with any other ranges
+    in use within the cluster's network.
+
+In addition, the `private_cluster_config` allows access to the following read-only fields:
+
+* `private_endpoint` - The internal IP address of this cluster's master endpoint.
+
+* `public_endpoint` - The external IP address of this cluster's master endpoint.
 
 The `taint` block supports:
 


### PR DESCRIPTION
We added support for private_cluster_config to google-beta, but we need to add the documentation here so it ends up on the website.