### PR TITLE
Remove beta-features header

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,6 +8,9 @@ description: |-
 
 # Google Cloud Platform Provider
 
+-> We recently introduced the `google-beta` provider. See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html)
+for more details on how to use `google-beta`.
+
 The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure. 
 See the [Getting Started](/docs/providers/google/getting_started.html) page for an introduction to using the provider.
 
@@ -90,14 +93,3 @@ or thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull
 the existing request if one exists. By filing and reacting to requests, we can
 gauge your interest in yet-to-be-supported GCP features and make sure that we
 prioritize support for them when they enter Beta.
-
-### Beta Features
-Some resources contain Beta features; Beta GCP Features have no
-deprecation policy, and no SLA, but are otherwise considered to be feature-complete
-with only minor outstanding issues after their Alpha period. Beta is when GCP
-features are publicly announced, and is when they generally become publicly
-available. For more information see [the official documentation on GCP launch stages](https://cloud.google.com/terms/launch-stages).
-
-Terraform resources that support Beta features will always use the Beta APIs to provision
-the resource. Importing a resource that supports Beta features will always import those
-features, even if the resource was created in a matter that was not explicitly Beta.

--- a/website/docs/provider_reference.html.markdown
+++ b/website/docs/provider_reference.html.markdown
@@ -7,6 +7,10 @@ description: |-
 ---
 
 # `google` provider reference
+
+-> We recently introduced the `google-beta` provider. See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html)
+for more details on how to use `google-beta`.
+
 The `google` provider block is used to configure default values for your GCP
 project and location (`zone` and `region`), and add your credentials.
 
@@ -18,6 +22,15 @@ environments and deploy to different projects, try it out!
 
 ```hcl
 provider "google" {
+  credentials = "${file("account.json")}"
+  project     = "my-project-id"
+  region      = "us-central1"
+  zone        = "us-central1-c"
+}
+```
+
+```hcl
+provider "google-beta" {
   credentials = "${file("account.json")}"
   project     = "my-project-id"
   region      = "us-central1"

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `connection_draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections,
 but still work to finish started ones). Defaults to `300`.
 
-* `custom_request_headers` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Headers that the
+* `custom_request_headers` - (Optional) Headers that the
     HTTP/S load balancer should add to proxied requests. See [guide](https://cloud.google.com/compute/docs/load-balancing/http/backend-service#user-defined-request-headers) for details.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
@@ -102,7 +102,7 @@ but still work to finish started ones). Defaults to `300`.
 * `protocol` - (Optional) The protocol for incoming requests. Defaults to
     `HTTP`.
 
-* `security_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Name or URI of a
+* `security_policy` - (Optional) Name or URI of a
     [security policy](https://cloud.google.com/armor/docs/security-policy-concepts) to add to the backend service.
 
 * `session_affinity` - (Optional) How to distribute load. Options are `NONE` (no

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -105,7 +105,7 @@ The IP Version that will be used by this resource's address. One of `"IPV4"` or 
 
 - - -
 
-* `labels` - (Optional, [Beta](/docs/providers/google/index.html#beta-features))
+* `labels` - (Optional)
 A set of key/value label pairs to assign to the resource. This property is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
@@ -117,7 +117,8 @@ exported:
 
 * `self_link` - The URI of the created resource.
 
-* `label_fingerprint` - ([Beta](/docs/providers/google/index.html#beta-features)) The current label fingerprint.
+* `label_fingerprint` - The current label fingerprint. This property is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
 ## Import
 

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 * `update_strategy` - (Optional, Default `"REPLACE"`) If the `instance_template`
     resource is modified, a value of `"NONE"` will prevent any of the managed
     instances from being restarted by Terraform. A value of `"REPLACE"` will
-    restart all of the instances at once. `"ROLLING_UPDATE"` is supported as [Beta feature].
+    restart all of the instances at once. `"ROLLING_UPDATE"` is supported as a beta feature.
     A value of `"ROLLING_UPDATE"` requires `rolling_update_policy` block to be set
 
 * `target_size` - (Optional) The target number of running instances for this managed
@@ -140,12 +140,12 @@ The following arguments are supported:
 
 ---
 
-* `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
+* `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
 This property is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `rolling_update_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
+* `rolling_update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
 This property is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 - - -

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
     exactly one version must not specify a target size. It means that versions with
     a target size will respect the setting, and the one without target size will
     be applied to all remaining Instances (top level target_size - each version target_size).
+    This property is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
     characters long and comply with

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -121,8 +121,8 @@ The following arguments are supported:
 * `update_strategy` - (Optional, Default `"NONE"`) If the `instance_template`
     resource is modified, a value of `"NONE"` will prevent any of the managed
     instances from being restarted by Terraform. A value of `"ROLLING_UPDATE"`
-    is supported as [Beta feature]. A value of `"ROLLING_UPDATE"` requires
-    `rolling_update_policy` block to be set
+    is supported as a beta feature. A value of `"ROLLING_UPDATE"` requires
+    `rolling_update_policy` block to be set. 
 
 * `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to
@@ -138,12 +138,18 @@ The following arguments are supported:
 
 ---
 
-* `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
+* `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
+This property is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `rolling_update_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/regionInstanceGroupManagers/patch)
 
-* `distribution_policy_zones` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The distribution policy for this managed instance
+* `rolling_update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/regionInstanceGroupManagers/patch)
+This property is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
+
+
+* `distribution_policy_zones` - (Optional) The distribution policy for this managed instance
 group. You can specify one or more values. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups#selectingzones).
 - - -
 

--- a/website/docs/r/compute_security_policy.html.markdown
+++ b/website/docs/r/compute_security_policy.html.markdown
@@ -12,8 +12,6 @@ A Security Policy defines an IP blacklist or whitelist that protects load balanc
 see the [official documentation](https://cloud.google.com/armor/docs/configure-security-policies)
 and the [API](https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies).
 
-~> **Note:** This entire resource is in [Beta](/docs/providers/google/index.html#beta-features)
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/compute_subnetwork_iam.html.markdown
+++ b/website/docs/r/compute_subnetwork_iam.html.markdown
@@ -21,8 +21,6 @@ Three different resources help you manage your IAM policy for GCE subnetwork. Ea
 
 ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
 
-~> **Note:** These entire resources are in [Beta](/docs/providers/google/index.html#beta-features)
-
 ## google\_compute\_subnetwork\_iam\_policy
 
 ```hcl

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -181,7 +181,7 @@ output "cluster_ca_certificate" {
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `privat_cluster_config` - (Optional) A set of options for creating
+* `private_cluster_config` - (Optional) A set of options for creating
     a private cluster. Structure is documented below.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -136,7 +136,7 @@ output "cluster_ca_certificate" {
     for master authorized networks. Omit the nested `cidr_blocks` attribute to disallow
     external access (except the cluster node IPs, which GKE automatically whitelists).
 
-* `master_ipv4_cidr_block` - (Optional, Deprecated, [Beta](/docs/providers/google/index.html#beta-features)) Specifies a private
+* `master_ipv4_cidr_block` - (Optional, Deprecated) Specifies a private
     [RFC1918](https://tools.ietf.org/html/rfc1918) block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC.
     The master and your cluster use VPC peering. Must be specified in CIDR notation and must be `/28` subnet.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
@@ -175,18 +175,18 @@ output "cluster_ca_certificate" {
     or set to the same value as `min_master_version` on create. Defaults to the default
     version set by GKE which is not necessarily the latest version.
 
-* `pod_security_policy_config` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) Configuration for the
+* `pod_security_policy_config` - (Optional) Configuration for the
     [PodSecurityPolicy](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies) feature.
     Structure is documented below.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `privat_cluster_config` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) A set of options for creating
+* `privat_cluster_config` - (Optional) A set of options for creating
     a private cluster. Structure is documented below.
     This property is in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html) for more details on beta fields.
 
-* `private_cluster` - (Optional, Deprecated, [Beta](/docs/providers/google/index.html#beta-features)) If true, a
+* `private_cluster` - (Optional, Deprecated) If true, a
     [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) will be created, meaning
     nodes do not get public IP addresses. It is mandatory to specify `master_ipv4_cidr_block` and 
     `ip_allocation_policy` with this option.
@@ -372,7 +372,7 @@ The `node_config` block supports:
 * `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.
 
-* `taint` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) List of
+* `taint` - (Optional) List of
     [kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     to apply to each node. Structure is documented below. This property is in beta, and should be
     used with the terraform-provider-google-beta provider. See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html)

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -49,13 +49,13 @@ The following arguments are supported:
 * `charset` - (Optional) The charset value. See MySQL's
     [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and Postgres' [Character Set Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
-    for more details and supported values. Postgres databases are in [Beta](/docs/providers/google/index.html#beta-features),
+    for more details and supported values. Postgres databases are in beta
     and have limited `charset` support; they only support a value of `UTF8` at creation time.
 
 * `collation` - (Optional) The collation value. See MySQL's
     [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
     and Postgres' [Collation Support](https://www.postgresql.org/docs/9.6/static/collation.html)
-    for more details and supported values. Postgres databases are in [Beta](/docs/providers/google/index.html#beta-features),
+    for more details and supported values. Postgres databases are in beta
     and have limited `collation` support; they only support a value of `en_US.UTF8` at creation time.
 
 ## Attributes Reference

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -129,7 +129,7 @@ The following arguments are supported:
     use. Can be `MYSQL_5_6`, `MYSQL_5_7` or `POSTGRES_9_6` for second-generation
     instances, or `MYSQL_5_5` or `MYSQL_5_6` for first-generation instances.
     See [Second Generation Capabilities](https://cloud.google.com/sql/docs/1st-2nd-gen-differences)
-    for more information. `POSTGRES_9_6` support is in [Beta](/docs/providers/google/index.html#beta-features).
+    for more information. `POSTGRES_9_6` support is in beta.
 
 * `name` - (Optional, Computed) The name of the instance. If the name is left
     blank, Terraform will randomly generate one when the instance is first


### PR DESCRIPTION
Remove the `beta-features` header now that we have the provider versions page.

Also looks like RIGM doesn't have the same docs as IGM. I added the beta disclaimer to RIGM's beta fields.

Are we missing a deprecation on `update_strategy` = `ROLLING_UPDATE` on purpose? I didn't touch it since I'm not sure what the plan to document rigm/igm differences come 2.0.0 is.