### PR TITLE
Default to automatic restart on compute instance to true.

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -478,6 +478,7 @@ func resourceComputeInstance() *schema.Resource {
 
 						"automatic_restart": &schema.Schema{
 							Type:     schema.TypeBool,
+							Default:  true,
 							Optional: true,
 							Default:  true,
 						},

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -266,7 +266,7 @@ The `scheduling` block supports:
     [here](https://cloud.google.com/compute/docs/instances/setting-instance-scheduling-options)
 
 * `automatic_restart` - (Optional) Specifies if the instance should be
-    restarted if it was terminated by Compute Engine (not a user).
+    restarted if it was terminated by Compute Engine (not a user). This defaults to true.
 
 The `guest_accelerator` block supports:
 


### PR DESCRIPTION
The default for compute instances created in the UI for automatic_restart is true so matching with terraform instance creation to mirror console creation by users.