### PR TITLE
[Website] Make resource_storage_object_acl authoritative.

### DIFF
--- a/website/docs/r/storage_object_acl.html.markdown
+++ b/website/docs/r/storage_object_acl.html.markdown
@@ -8,10 +8,17 @@ description: |-
 
 # google\_storage\_object\_acl
 
-Creates a new object ACL in Google cloud storage service (GCS). For more information see 
+Authoritatively manages the access control list (ACL) for an object in a Google
+Cloud Storage (GCS) bucket. Removing a `google_storage_object_acl` sets the
+acl to the `private` [predefined ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl).
+
+For more information see 
 [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls).
+
+-> Want fine-grained control over object ACLs? Use `google_storage_object_access_control` to control individual
+role entity pairs.
 
 ## Example Usage
 
@@ -42,15 +49,21 @@ resource "google_storage_object_acl" "image-store-acl" {
 
 ## Argument Reference
 
-* `bucket` - (Required) The name of the bucket it applies to.
+* `bucket` - (Required) The name of the bucket the object is stored in.
 
-* `object` - (Required) The name of the object it applies to.
+* `object` - (Required) The name of the object to apply the acl to.
 
 - - -
 
-* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
+* `predefined_acl` - (Optional) The "canned" [predefined ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
 
-* `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details. Must be set if `predefined_acl` is not.
+* `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details.
+Must be set if `predefined_acl` is not.
+
+-> The object's creator will always have `OWNER` permissions for their object, and any attempt to modify that permission would return an error. Instead, Terraform automatically
+adds that role/entity pair to your `terraform plan` results when it is omitted in your config; `terraform plan` will show the correct final state at every point except for at
+`Create` time, where the object role/entity pair is omitted if not explicitly set.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Moved to https://github.com/GoogleCloudPlatform/magic-modules/pull/585

Note: This doesn't include import even though it's possible now - we can add it as a separate change, because it will take an `id` migration to support new-style imports and this PR is already large enough.

`resource_storage_object_acl` now authoritatively manages a storage object's access control list, setting it to a "`private`" ACL when removed. We likely want to block merging this on [adding ObjectAccessControl from MM](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/products/storage/api.yaml#L321) so that users can use Terraform to non-authoritatively manage their object ACLs. Users can also now move between `predefined_acl` and explicit `role_entity` pairs without recreates.

Instead of requiring users to explicitly define a role/entity pair for the object owner granting an OWNER role every time, Terraform implicitly adds the re pair using a `CustomizeDiff`.

Part of #1167, these changes (specifically `getRoleEntityChange`) will be mirrored to `google_storage_default_object_acl.role_entity`.
