### PR TITLE
Fix Provider Versions link target

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Google Cloud Platform Provider
 
--> We recently introduced the `google-beta` provider. See [Provider Versions](https://terraform.io/docs/provider/google/provider_versions.html)
+-> We recently introduced the `google-beta` provider. See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
 for more details on how to use `google-beta`.
 
 The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure. 


### PR DESCRIPTION
Fixes the missing `www.` in the google provider version link from https://www.terraform.io/docs/providers/google/index.html
Issue ref: [#19028](https://github.com/hashicorp/terraform/issues/19028)