### PR TITLE
Adding the missing word 'peer' to title of Compute Router Peer documentation page

### DIFF
--- a/website/docs/r/compute_router_peer.html.markdown
+++ b/website/docs/r/compute_router_peer.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Cloud Router BGP peer.
 ---
 
-# google\_compute\_router
+# google\_compute\_router\_peer
 
 Manages a Cloud Router BGP peer. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/cloudrouter)


### PR DESCRIPTION
Compute Router Peer is missing the word 'Peer' at the top of the page