### PR TITLE
adding attribute family for bigtable_table

### DIFF
--- a/google/resource_bigtable_table.go
+++ b/google/resource_bigtable_table.go
@@ -29,7 +29,7 @@ func resourceBigtableTable() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"family": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 					},
 				},

--- a/google/resource_bigtable_table.go
+++ b/google/resource_bigtable_table.go
@@ -21,10 +21,18 @@ func resourceBigtableTable() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"family": {
-				Type:     schema.TypeString,
+			"column_family": {
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"family": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 
 			"instance_name": {
@@ -85,9 +93,17 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if v, ok := d.GetOk("family"); ok {
-		if err := c.CreateColumnFamily(ctx, name, v.(string)); err != nil {
-			return fmt.Errorf("Error creating column family. %s", err)
+	if d.Get("column_family.#").(int) > 0 {
+		columns := d.Get("column_family").(*schema.Set).List()
+
+		for _, co := range columns {
+			column := co.(map[string]interface{})
+
+			if v, ok := column["family"]; ok {
+				if err := c.CreateColumnFamily(ctx, name, v.(string)); err != nil {
+					return fmt.Errorf("Error creating column family %s. %s", v, err)
+				}
+			}
 		}
 	}
 

--- a/google/resource_bigtable_table.go
+++ b/google/resource_bigtable_table.go
@@ -21,6 +21,12 @@ func resourceBigtableTable() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"family": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"instance_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -76,6 +82,12 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 		err = c.CreateTable(ctx, name)
 		if err != nil {
 			return fmt.Errorf("Error creating table. %s", err)
+		}
+	}
+
+	if v, ok := d.GetOk("family"); ok {
+		if err := c.CreateColumnFamily(ctx, name, v.(string)); err != nil {
+			return fmt.Errorf("Error creating column family. %s", err)
 		}
 	}
 

--- a/google/resource_bigtable_table_test.go
+++ b/google/resource_bigtable_table_test.go
@@ -169,7 +169,7 @@ resource "google_bigtable_instance" "instance" {
   name          = "%s"
 
   cluster {
-	cluster_id = "%s"
+    cluster_id = "%s"
     zone       = "us-central1-b"
   }
 

--- a/website/docs/r/bigtable_table.html.markdown
+++ b/website/docs/r/bigtable_table.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `split_keys` - (Optional) A list of predefined keys to split the table on.
 
-* `column_family` - (Optional) A block of column family configuration options.
+* `column_family` - (Optional) A group of columns within a table which share a common configuration. This can be specified multiple times. Structure is documented below.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.

--- a/website/docs/r/bigtable_table.html.markdown
+++ b/website/docs/r/bigtable_table.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `split_keys` - (Optional) A list of predefined keys to split the table on.
 
+* `family` - (Optional) Creates a new column family in a table.
+
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 

--- a/website/docs/r/bigtable_table.html.markdown
+++ b/website/docs/r/bigtable_table.html.markdown
@@ -41,10 +41,16 @@ The following arguments are supported:
 
 * `split_keys` - (Optional) A list of predefined keys to split the table on.
 
-* `family` - (Optional) Creates a new column family in a table.
+* `column_family` - (Optional) A block of column family configuration options.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
+
+-----
+
+`column_family` supports the following arguments:
+
+* `family` - (Optional) Creates a new column family in a table.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix #1576

make testacc TESTARGS='-run=TestAccBigtableTable'
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccBigtableTable -timeout 120m
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
=== RUN   TestAccBigtableTable_basic
=== PAUSE TestAccBigtableTable_basic
=== RUN   TestAccBigtableTable_splitKeys
=== PAUSE TestAccBigtableTable_splitKeys
=== RUN   TestAccBigtableTable_family
=== PAUSE TestAccBigtableTable_family
=== CONT  TestAccBigtableTable_basic
=== CONT  TestAccBigtableTable_family
=== CONT  TestAccBigtableTable_splitKeys
--- PASS: TestAccBigtableTable_splitKeys (16.90s)
--- PASS: TestAccBigtableTable_basic (17.84s)
--- PASS: TestAccBigtableTable_family (19.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	19.154s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-google/scripts	(cached) [no tests to run]
```