### PR TITLE
Guard against nil empty typelists.

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -586,28 +586,25 @@ func resourceCloudFunctionsDestroy(d *schema.ResourceData, meta interface{}) err
 }
 
 func expandEventTrigger(configured []interface{}, project string) *cloudfunctions.EventTrigger {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
-	if data, ok := configured[0].(map[string]interface{}); ok {
-		eventType := data["event_type"].(string)
-		shape := ""
-		switch {
-		case strings.HasPrefix(eventType, "providers/cloud.storage/eventTypes/"):
-			shape = "projects/%s/buckets/%s"
-		case strings.HasPrefix(eventType, "providers/cloud.pubsub/eventTypes/"):
-			shape = "projects/%s/topics/%s"
-		}
-
-		return &cloudfunctions.EventTrigger{
-			EventType:     eventType,
-			Resource:      fmt.Sprintf(shape, project, data["resource"].(string)),
-			FailurePolicy: expandFailurePolicy(data["failure_policy"].([]interface{})),
-		}
+	data := configured[0].(map[string]interface{})
+	eventType := data["event_type"].(string)
+	shape := ""
+	switch {
+	case strings.HasPrefix(eventType, "providers/cloud.storage/eventTypes/"):
+		shape = "projects/%s/buckets/%s"
+	case strings.HasPrefix(eventType, "providers/cloud.pubsub/eventTypes/"):
+		shape = "projects/%s/topics/%s"
 	}
 
-	return nil
+	return &cloudfunctions.EventTrigger{
+		EventType:     eventType,
+		Resource:      fmt.Sprintf(shape, project, data["resource"].(string)),
+		FailurePolicy: expandFailurePolicy(data["failure_policy"].([]interface{})),
+	}
 }
 
 func flattenEventTrigger(eventTrigger *cloudfunctions.EventTrigger) []map[string]interface{} {
@@ -626,11 +623,11 @@ func flattenEventTrigger(eventTrigger *cloudfunctions.EventTrigger) []map[string
 }
 
 func expandFailurePolicy(configured []interface{}) *cloudfunctions.FailurePolicy {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return &cloudfunctions.FailurePolicy{}
 	}
 
-	if data, ok := configured[0].(map[string]interface{}); ok && data["retry"].(bool) {
+	if data := configured[0].(map[string]interface{}); data["retry"].(bool) {
 		return &cloudfunctions.FailurePolicy{
 			Retry: &cloudfunctions.Retry{},
 		}

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -399,19 +399,17 @@ func resourceComputeBackendServiceDelete(d *schema.ResourceData, meta interface{
 }
 
 func expandIap(configured []interface{}) *computeBeta.BackendServiceIAP {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
-	if data, ok := configured[0].(map[string]interface{}); ok {
-		return &computeBeta.BackendServiceIAP{
-			Enabled:            true,
-			Oauth2ClientId:     data["oauth2_client_id"].(string),
-			Oauth2ClientSecret: data["oauth2_client_secret"].(string),
-			ForceSendFields:    []string{"Enabled", "Oauth2ClientId", "Oauth2ClientSecret"},
-		}
-	}
 
-	return nil
+	data := configured[0].(map[string]interface{})
+	return &computeBeta.BackendServiceIAP{
+		Enabled:            true,
+		Oauth2ClientId:     data["oauth2_client_id"].(string),
+		Oauth2ClientSecret: data["oauth2_client_secret"].(string),
+		ForceSendFields:    []string{"Enabled", "Oauth2ClientId", "Oauth2ClientSecret"},
+	}
 }
 
 func flattenIap(iap *computeBeta.BackendServiceIAP) []map[string]interface{} {
@@ -591,11 +589,11 @@ func expandBackendService(d *schema.ResourceData) (*computeBeta.BackendService, 
 }
 
 func expandCdnPolicy(configured []interface{}) *computeBeta.BackendServiceCdnPolicy {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
-	data := configured[0].(map[string]interface{})
 
+	data := configured[0].(map[string]interface{})
 	ckp := data["cache_key_policy"].([]interface{})
 	if len(ckp) == 0 {
 		return nil

--- a/google/resource_compute_security_policy.go
+++ b/google/resource_compute_security_policy.go
@@ -317,9 +317,10 @@ func expandSecurityPolicyRule(raw interface{}) *compute.SecurityPolicyRule {
 }
 
 func expandSecurityPolicyMatch(configured []interface{}) *compute.SecurityPolicyRuleMatcher {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
+
 	data := configured[0].(map[string]interface{})
 	return &compute.SecurityPolicyRuleMatcher{
 		VersionedExpr: data["versioned_expr"].(string),
@@ -328,9 +329,10 @@ func expandSecurityPolicyMatch(configured []interface{}) *compute.SecurityPolicy
 }
 
 func expandSecurityPolicyMatchConfig(configured []interface{}) *compute.SecurityPolicyRuleMatcherConfig {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
+
 	data := configured[0].(map[string]interface{})
 	return &compute.SecurityPolicyRuleMatcherConfig{
 		SrcIpRanges: convertStringArr(data["src_ip_ranges"].(*schema.Set).List()),

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -1363,9 +1363,10 @@ func getInstanceGroupUrlsFromManagerUrls(config *Config, igmUrls []string) ([]st
 
 func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	config := l[0].(map[string]interface{})
 	ac := &containerBeta.AddonsConfig{}
 
@@ -1406,9 +1407,10 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 
 func expandIPAllocationPolicy(configured interface{}) *containerBeta.IPAllocationPolicy {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	config := l[0].(map[string]interface{})
 
 	return &containerBeta.IPAllocationPolicy{
@@ -1427,9 +1429,10 @@ func expandIPAllocationPolicy(configured interface{}) *containerBeta.IPAllocatio
 
 func expandMaintenancePolicy(configured interface{}) *containerBeta.MaintenancePolicy {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	maintenancePolicy := l[0].(map[string]interface{})
 	dailyMaintenanceWindow := maintenancePolicy["daily_maintenance_window"].([]interface{})[0].(map[string]interface{})
 	startTime := dailyMaintenanceWindow["start_time"].(string)
@@ -1444,9 +1447,10 @@ func expandMaintenancePolicy(configured interface{}) *containerBeta.MaintenanceP
 
 func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	masterAuth := l[0].(map[string]interface{})
 	result := &containerBeta.MasterAuth{
 		Username: masterAuth["username"].(string),
@@ -1507,9 +1511,10 @@ func expandNetworkPolicy(configured interface{}) *containerBeta.NetworkPolicy {
 
 func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSecurityPolicyConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	config := l[0].(map[string]interface{})
 	return &containerBeta.PodSecurityPolicyConfig{
 		Enabled:         config["enabled"].(bool),

--- a/google/resource_google_organization_policy.go
+++ b/google/resource_google_organization_policy.go
@@ -263,7 +263,7 @@ func flattenRestoreOrganizationPolicy(restore_policy *cloudresourcemanager.Resto
 }
 
 func expandBooleanOrganizationPolicy(configured []interface{}) *cloudresourcemanager.BooleanPolicy {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -274,7 +274,7 @@ func expandBooleanOrganizationPolicy(configured []interface{}) *cloudresourceman
 }
 
 func expandRestoreOrganizationPolicy(configured []interface{}) (*cloudresourcemanager.RestoreDefault, error) {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil, nil
 	}
 
@@ -321,7 +321,7 @@ func flattenListOrganizationPolicy(policy *cloudresourcemanager.ListPolicy) []ma
 }
 
 func expandListOrganizationPolicy(configured []interface{}) (*cloudresourcemanager.ListPolicy, error) {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil, nil
 	}
 

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -214,7 +214,7 @@ func flattenPubsubSubscriptionPushConfig(pushConfig *pubsub.PushConfig) []map[st
 }
 
 func expandPubsubSubscriptionPushConfig(configured []interface{}) *pubsub.PushConfig {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		// An empty `pushConfig` indicates that the Pub/Sub system should stop pushing messages
 		// from the given subscription and allow messages to be pulled and acknowledged.
 		return &pubsub.PushConfig{}

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -522,7 +522,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 }
 
 func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool) *sqladmin.Settings {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -556,7 +556,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 }
 
 func expandReplicaConfiguration(configured []interface{}) *sqladmin.ReplicaConfiguration {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -582,7 +582,7 @@ func expandReplicaConfiguration(configured []interface{}) *sqladmin.ReplicaConfi
 }
 
 func expandMaintenanceWindow(configured []interface{}) *sqladmin.MaintenanceWindow {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -595,7 +595,7 @@ func expandMaintenanceWindow(configured []interface{}) *sqladmin.MaintenanceWind
 }
 
 func expandLocationPreference(configured []interface{}) *sqladmin.LocationPreference {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -607,7 +607,7 @@ func expandLocationPreference(configured []interface{}) *sqladmin.LocationPrefer
 }
 
 func expandIpConfiguration(configured []interface{}) *sqladmin.IpConfiguration {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 
@@ -654,7 +654,7 @@ func expandDatabaseFlags(configured []interface{}) []*sqladmin.DatabaseFlags {
 }
 
 func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfiguration {
-	if len(configured) == 0 {
+	if len(configured) == 0 || configured[0] == nil {
 		return nil
 	}
 


### PR DESCRIPTION
PR is against master as we can roll this into `1.19.1` to fix some panics. It will reach `2.0.0` on the next merge & I'll PR against tpgb after submitting this one. Also can be fixed in MM as well - I'll work on a PR for that now.

It turns out that an empty `schema.TypeList` holds a `nil` and not a `map[string]interface{}`, leading to panics when we immediately tried to cast the first element. While this only fixes a panic for lists with no `Required` elements, I don't see the harm in guarding those ones too, so I fixed every occurrence I caught in a quick grep.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2220

Note that behaviour still isn't great - we'll see a diff from `"0" => "1"`. Configs with an empty block like this are generally but not always wrong (`google_compute_instance.network_interface.#.access_config` is correct), but having a permadiff is better than a crash here.