### PR TITLE
add underscores as a valid character for 'name'

### DIFF
--- a/google/resource_spanner_database.go
+++ b/google/resource_spanner_database.go
@@ -41,9 +41,9 @@ func resourceSpannerDatabase() *schema.Resource {
 						errors = append(errors, fmt.Errorf(
 							"%q must be between 2 and 30 characters in length", k))
 					}
-					if !regexp.MustCompile("^[a-z0-9-]+$").MatchString(value) {
+					if !regexp.MustCompile("^[a-z0-9-_]+$").MatchString(value) {
 						errors = append(errors, fmt.Errorf(
-							"%q can only contain lowercase letters, numbers and hyphens", k))
+							"%q can only contain lowercase letters, numbers, underscores, and hyphens", k))
 					}
 					if !regexp.MustCompile("^[a-z]").MatchString(value) {
 						errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
Pretty straightforward. The underscore (`_`) is a valid character in the upstream API, but the regex used in the property's validation doesn't include it. This causes valid `google_spanner_database` names to error out.