### PR TITLE
Add defaultPartitionExpirationMs field to google_bigquery_dataset resource

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -75,6 +75,25 @@ func resourceBigQueryDataset() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-northeast1"}, false),
 			},
 
+			// defaultPartitionExpirationMs: [Optional] The default partition
+			// expiration for all partitioned tables in the dataset, in
+			// milliseconds. Once this property is set, all newly-created
+			// partitioned tables in the dataset will have an expirationMs
+			// property in the timePartitioning settings set to this value, and
+			// changing the value will only affect new tables, not existing ones.
+			// The storage in a partition will have an expiration time of its
+			// partition time plus this value. Setting this property overrides the
+			// use of defaultTableExpirationMs for partitioned tables: only one of
+			// defaultTableExpirationMs and defaultPartitionExpirationMs will be used
+			// for any new partitioned table. If you provide an explicit
+			// timePartitioning.expirationMs when creating or updating a partitioned
+			// table, that value takes precedence over the default partition expiration
+			// time indicated by this property.
+			"default_partition_expiration_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
 			// DefaultTableExpirationMs: [Optional] The default lifetime of all
 			// tables in the dataset, in milliseconds. The minimum value is 3600000
 			// milliseconds (one hour). Once this property is set, all newly-created
@@ -223,6 +242,10 @@ func resourceDataset(d *schema.ResourceData, meta interface{}) (*bigquery.Datase
 		dataset.Location = v.(string)
 	}
 
+	if v, ok := d.GetOk("default_partition_expiration_ms"); ok {
+		dataset.DefaultPartitionExpirationMs = int64(v.(int))
+	}
+
 	if v, ok := d.GetOk("default_table_expiration_ms"); ok {
 		dataset.DefaultTableExpirationMs = int64(v.(int))
 	}
@@ -336,6 +359,7 @@ func resourceBigQueryDatasetRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("creation_time", res.CreationTime)
 	d.Set("last_modified_time", res.LastModifiedTime)
 	d.Set("dataset_id", res.DatasetReference.DatasetId)
+	d.Set("default_partition_expiration_ms", res.DefaultPartitionExpirationMs)
 	d.Set("default_table_expiration_ms", res.DefaultTableExpirationMs)
 
 	// Older Tables in BigQuery have no Location set in the API response. This may be an issue when importing

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -111,6 +111,7 @@ resource "google_bigquery_dataset" "test" {
   friendly_name               = "foo"
   description                 = "This is a foo description"
   location                    = "EU"
+  default_partition_expiration_ms = 3600000
   default_table_expiration_ms = 3600000
 
   labels {
@@ -127,6 +128,7 @@ resource "google_bigquery_dataset" "test" {
   friendly_name               = "bar"
   description                 = "This is a bar description"
   location                    = "EU"
+  default_partition_expiration_ms = 7200000
   default_table_expiration_ms = 7200000
 
   labels {

--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -66,6 +66,21 @@ The following arguments are supported:
     The default value is multi-regional location `US`.
     Changing this forces a new resource to be created.
 
+* `default_partition_expiration_ms` - (Optional) The default partition expiration
+    for all partitioned tables in the dataset, in milliseconds.
+
+    Once this property is set, all newly-created partitioned tables in the dataset
+    will have an expirationMs property in the timePartitioning settings set to this
+    value, and changing the value will only affect new tables, not existing ones.
+    The storage in a partition will have an expiration time of its partition time
+    plus this value. Setting this property overrides the use of
+    `defaultTableExpirationMs` for partitioned tables: only one of
+    `defaultTableExpirationMs` and `defaultPartitionExpirationMs` will be used for
+    any new partitioned table. If you provide an explicit
+    `timePartitioning.expirationMs` when creating or updating a partitioned table,
+    that value takes precedence over the default partition expiration time
+    indicated by this property.
+
 * `default_table_expiration_ms` - (Optional) The default lifetime of all
     tables in the dataset, in milliseconds. The minimum value is 3600000
     milliseconds (one hour).


### PR DESCRIPTION
Add [`defaultPartitionExpirationMs`](https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets) to [google_bigquery_dataset](https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html) resource.