### PR TITLE
Support cloud composer v1.10

### DIFF
--- a/google/resource_composer_environment.go
+++ b/google/resource_composer_environment.go
@@ -178,7 +178,13 @@ func resourceComposerEnvironment() *schema.Resource {
 									},
 									"image_version": {
 										Type:     schema.TypeString,
-										Computed: true,
+										Optional: true,
+										ForceNew: true,
+									},
+									"python_version": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -540,6 +546,7 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	}
 	transformed := make(map[string]interface{})
 	transformed["image_version"] = softwareCfg.ImageVersion
+	transformed["python_version"] = softwareCfg.PythonVersion
 	transformed["airflow_config_overrides"] = softwareCfg.AirflowConfigOverrides
 	transformed["pypi_packages"] = softwareCfg.PypiPackages
 	transformed["env_variables"] = softwareCfg.EnvVariables
@@ -742,6 +749,7 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed := &composer.SoftwareConfig{}
 
 	transformed.ImageVersion = original["image_version"].(string)
+	transformed.PythonVersion = original["python_version"].(string)
 	transformed.AirflowConfigOverrides = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "airflow_config_overrides")
 	transformed.PypiPackages = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "pypi_packages")
 	transformed.EnvVariables = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "env_variables")

--- a/google/resource_composer_environment_test.go
+++ b/google/resource_composer_environment_test.go
@@ -131,6 +131,28 @@ func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
+	t.Parallel()
+
+	envName := acctest.RandomWithPrefix(testComposerEnvironmentPrefix)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_softwareCfg(envName),
+				Check:  testAccCheckComposerEnvironmentExists("google_composer_environment.test", &env),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Checks behavior of config for creation for attributes that must
 // be updated during create.
 func TestAccComposerEnvironment_withUpdateOnCreate(t *testing.T) {
@@ -304,6 +326,21 @@ resource "google_project_iam_member" "composer-worker" {
   member  = "serviceAccount:${google_service_account.test.email}"
 }
 `, environment, network, subnetwork, serviceAccount)
+}
+
+func testAccComposerEnvironment_softwareCfg(name string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name           = "%s"
+  region         = "us-central1"
+	config {
+		software_config {
+			image_version = "composer-latest-airflow-1.10"
+			python_version = "3"
+		}
+	}
+}
+`, name)
 }
 
 func testAccComposerEnvironment_updateOnlyFields(name string) string {


### PR DESCRIPTION
- Support for Python 3
- ImageVersion can be configured.

Reference: https://cloud.google.com/composer/docs/release-notes#october_24_2018_composer-130-airflow-190_composer-130-airflow-1100