### PR TITLE
Update resource_pubsub_topic.go to save project in state

### DIFF
--- a/google/resource_pubsub_topic.go
+++ b/google/resource_pubsub_topic.go
@@ -55,7 +55,7 @@ func resourcePubsubTopicCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(res.Name)
 
-	return nil
+	return resourcePubsubTopicRead(d, meta)
 }
 
 func resourcePubsubTopicRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
When "project" is not specified in the resource, it is not saved in the state file.

TESTED: make testacc TEST=./google TESTARGS='-run=TestAccPubsubTopic'