### PR TITLE
Fix regional cluster example

### DIFF
--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -102,7 +102,7 @@ resource "google_container_cluster" "regional" {
 resource "google_container_node_pool" "regional-np" {
   name       = "my-node-pool"
   region     = "us-central1"
-  cluster    = "${google_container_cluster.primary.name}"
+  cluster    = "${google_container_cluster.regional.name}"
   node_count = 1
 }
 


### PR DESCRIPTION
Update regional cluster example to point cluster to google_container_cluster.regional.name rather than google_container_cluster.primary.name