### PR TITLE
Add documentation on resource.google_container_cluster

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -362,6 +362,12 @@ The `node_config` block supports:
   * `monitoring` (`https://www.googleapis.com/auth/monitoring`),
     if `monitoring_service` points to Google
 
+  In addition to the `oauth_scopes`, the `service_account` which is used by the Node VMs
+  needs to have the corresponding IAM permissions to make use of these services. To enable
+  the logging and monitoring this means setting at least the [roles/logging.logWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_logging_roles)
+  and [roles/monitoring.metricWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_monitoring_roles)
+  roles.
+
 * `preemptible` - (Optional) A boolean that represents whether or not the underlying node VMs
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -362,18 +362,17 @@ The `node_config` block supports:
   * `monitoring` (`https://www.googleapis.com/auth/monitoring`),
     if `monitoring_service` points to Google
 
-  In addition to the `oauth_scopes`, the `service_account` which is used by the Node VMs
-  needs to have the corresponding IAM permissions to make use of these services. To enable
-  the logging and monitoring this means setting at least the [roles/logging.logWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_logging_roles)
-  and [roles/monitoring.metricWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_monitoring_roles)
-  roles.
-
 * `preemptible` - (Optional) A boolean that represents whether or not the underlying node VMs
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
 * `service_account` - (Optional) The service account to be used by the Node VMs.
     If not specified, the "default" service account is used.
+    In order to use the configured `oauth_scopes` for logging and monitoring, the service account being used needs the
+    [roles/logging.logWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_logging_roles) and
+    [roles/monitoring.metricWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_monitoring_roles) roles.
+
+    -> Projects that enable the [Cloud Compute Engine API](https://cloud.google.com/compute/) with Terraform may need these roles added manually to the service account. Projects that enable the API in the Cloud Console should have them added automatically.
 
 * `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.


### PR DESCRIPTION
When a google_container_cluster is created using terraform the oauth_scope needs to be set to allow authentication of the VM service account on the google services. In addition, the default service account will need the IAM permissions for doing so.

The default service account will have this permissions if the project is created and the service is enabled using the Google Cloud Console. If those are done using terraform, the default account will not have this permissions.

I added some documentation regarding this issue, as it took me quite some time to figure out what was missing.

I hope, I placed this addition at the correct spot in the documentation.