### PR TITLE
Add new version.go file + linker flags.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
 
 vet:
 	@echo "go vet ."

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// ProviderVersion is set during the release process to the release version of the binary
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
Hey Paul!

We're interested in getting the binary version of the Google provider(s) in our user agent strings, similar to the change you made in https://github.com/terraform-providers/terraform-provider-azurerm/pull/2032.

Your comment mentions that the version is set during the release process. Is that something that we automatically pick up across `google` and `google-beta` with similar changes, or will you/ @paddycarver need to do something manual on your side?

This PR sets up the `version.go` file, I've made a PR with Magic Modules to exclude that file from our generation, and I'll send a PR using the new value as a followup (unfortunately, I think I can only send out that PR after this one lands because we only generate if the provider can successfully build).
