### PR TITLE
support firestore cloud function triggers

### DIFF
--- a/google/test-fixtures/cloudfunctions/firestore_trigger.js
+++ b/google/test-fixtures/cloudfunctions/firestore_trigger.js
@@ -1,0 +1,13 @@
+/**
+ * Background Cloud Function to be triggered by Firestore.
+ *
+ * @param {object} event The Cloud Functions event.
+ * @param {function} callback The callback function.
+ */
+exports.helloFirestore = function (event, callback) {
+    const messageId = event.params.messageId;
+
+    console.log(`Received message ${messageId}`);
+
+    callback();
+};

--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -78,9 +78,9 @@ The `event_trigger` block supports:
 
 * `event_type` - (Required) The type of event to observe. For example: `"google.storage.object.finalize"`.
 See the documentation on [calling Cloud Functions](https://cloud.google.com/functions/docs/calling/) for a full reference.
-Only Cloud Storage and Cloud Pub/Sub triggers are supported at this time.
-Legacy Cloud Storage and Cloud Pub/Sub triggers are also supported, such as `"providers/cloud.storage/eventTypes/object.change"`
-and `"providers/cloud.pubsub/eventTypes/topic.publish"`.
+Cloud Storage, Cloud Pub/Sub and Cloud Firestore triggers are supported at this time.
+Legacy triggers are supported, such as `"providers/cloud.storage/eventTypes/object.change"`, 
+`"providers/cloud.pubsub/eventTypes/topic.publish"` and `"providers/cloud.firestore/eventTypes/document.create"`.
 
 * `resource` - (Required) Required. The name of the resource from which to observe events, for example, `"myBucket"`   
 


### PR DESCRIPTION
This PR adds support for firestore event triggers for cloud functions.

The docs for firestore events can be found here: https://cloud.google.com/functions/docs/calling/cloud-firestore