### PR TITLE
Add support for data source 'google_iam_role'

### DIFF
--- a/google/data_source_google_iam_role.go
+++ b/google/data_source_google_iam_role.go
@@ -1,0 +1,48 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleIamRole() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleIamRoleRead,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"included_permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"stage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleIamRoleRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	roleName := d.Get("name").(string)
+	role, err := config.clientIAM.Roles.Get(roleName).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Error reading IAM Role %s: %s", roleName, err))
+	}
+
+	d.SetId(GetResourceNameFromSelfLink(role.Name))
+	d.Set("title", role.Title)
+	d.Set("stage", role.Stage)
+	d.Set("included_permissions", role.IncludedPermissions)
+
+	return nil
+}

--- a/google/data_source_google_iam_role.go
+++ b/google/data_source_google_iam_role.go
@@ -39,7 +39,7 @@ func dataSourceGoogleIamRoleRead(d *schema.ResourceData, meta interface{}) error
 		return handleNotFoundError(err, d, fmt.Sprintf("Error reading IAM Role %s: %s", roleName, err))
 	}
 
-	d.SetId(GetResourceNameFromSelfLink(role.Name))
+	d.SetId(role.Name)
 	d.Set("title", role.Title)
 	d.Set("stage", role.Stage)
 	d.Set("included_permissions", role.IncludedPermissions)

--- a/google/data_source_google_iam_role_test.go
+++ b/google/data_source_google_iam_role_test.go
@@ -1,0 +1,51 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceIAMRole(t *testing.T) {
+	name := "roles/viewer"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleIamRoleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleIAMRoleCheck("data.google_iam_role.role"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleIAMRoleCheck(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find iam role data source: %s", n)
+		}
+
+		_, ok = ds.Primary.Attributes["included_permissions.#"]
+		if !ok {
+			return errors.New("can't find 'included_permissions' attribute")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGoogleIamRoleConfig(name string) string {
+	return fmt.Sprintf(`
+data "google_iam_role" "role" {
+	name = "%s"
+}
+`, name)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -87,6 +87,7 @@ func Provider() terraform.ResourceProvider {
 			"google_container_registry_repository":   dataSourceGoogleContainerRepo(),
 			"google_container_registry_image":        dataSourceGoogleContainerImage(),
 			"google_iam_policy":                      dataSourceGoogleIamPolicy(),
+			"google_iam_role":                        dataSourceGoogleIamRole(),
 			"google_kms_secret":                      dataSourceGoogleKmsSecret(),
 			"google_folder":                          dataSourceGoogleFolder(),
 			"google_netblock_ip_ranges":              dataSourceGoogleNetblockIpRanges(),

--- a/website/docs/d/datasource_google_iam_role.html.markdown
+++ b/website/docs/d/datasource_google_iam_role.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_iam_role"
-sidebar_current: "docs-google-datasource-folder"
+sidebar_current: "docs-google-datasource-iam-role"
 description: |-
   Get information about a Google IAM Role.
 ---
@@ -25,13 +25,12 @@ output "the_role_permissions" {
 
 The following arguments are supported:
 
-* `name` (Required) - The name of the Role to lookup.
+* `name` (Required) - The name of the Role to lookup in the form `roles/{ROLE_NAME}`, `organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}` or `projects/{PROJECT_ID}/roles/{ROLE_NAME}`
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `name` - The resource name of the Role.
 * `title` - is a friendly title for the role, such as "Role Viewer"
 * `included_permissions` - specifies the list of one or more permissions to include in the custom role, such as - `iam.roles.get`
 * `stage` -  indicates the stage of a role in the launch lifecycle, such as `GA`, `BETA` or `ALPHA`.

--- a/website/docs/r/datasource_google_iam_role.html.markdown
+++ b/website/docs/r/datasource_google_iam_role.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "google"
+page_title: "Google: google_iam_role"
+sidebar_current: "docs-google-datasource-folder"
+description: |-
+  Get information about a Google IAM Role.
+---
+
+# google\_iam\_role
+
+Use this data source to get information about a Google IAM Role.
+
+```hcl
+data "google_iam_role" "roleinfo" {
+  name = "roles/compute.viewer"
+}
+
+output "the_role_permissions" {
+  value = "${data.google_iam_role.roleinfo.included_permissions}"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` (Required) - The name of the Role to lookup.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The resource name of the Role.
+* `title` - is a friendly title for the role, such as "Role Viewer"
+* `included_permissions` - specifies the list of one or more permissions to include in the custom role, such as - `iam.roles.get`
+* `stage` -  indicates the stage of a role in the launch lifecycle, such as `GA`, `BETA` or `ALPHA`.

--- a/website/google.erb
+++ b/website/google.erb
@@ -114,6 +114,9 @@
       <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-iam-role") %>>
+      <a href="/docs/providers/google/d/datasource_google_iam_role.html">google_iam_role</a>
+      </li>
       <li<%= sidebar_current("docs-google-kms-secret") %>>
       <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
       </li>


### PR DESCRIPTION
Add `google_iam_role` data source to be able to fetch and query for GCP IAM roles permissions.
