### PR TITLE
Specify that attach_disk can be used multiple times

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `allow_stopping_for_update` - (Optional) If true, allows Terraform to stop the instance to update its properties.
   If you try to update a property that requires stopping the instance without setting this field, the update will fail.
 
-* `attached_disk` - (Optional) List of disks to attach to the instance. Structure is documented below.
+* `attached_disk` - (Optional) Additional disks to attach to the instance. Can be repeated multiple times for multiple disks. Structure is documented below.
 
 * `can_ip_forward` - (Optional) Whether to allow sending and receiving of
     packets with non-matching source or destination IPs.


### PR DESCRIPTION
I'm actually still largely unclear if that's a proper usage of the `attach_disk` block, as current docs mention it's a "list" of disks - though, that didn't see to work for me, at least judging by the plan terraform spit out.