### PR TITLE
Additional bigquery locations

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -72,7 +72,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "US",
-				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-northeast1", "europe-west2", "australia-southeast1", "asia-southeast1"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-east1", "asia-northeast1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west2", "us-east4"}, false),
 			},
 
 			// defaultPartitionExpirationMs: [Optional] The default partition

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -72,7 +72,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "US",
-				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-northeast1", "europe-west2", "australia-southeast1"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-northeast1", "europe-west2", "australia-southeast1", "asia-southeast1"}, false),
 			},
 
 			// defaultPartitionExpirationMs: [Optional] The default partition

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -94,6 +94,9 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 	datasetID2 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	datasetID3 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	datasetID4 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID5 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID6 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID7 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -101,7 +104,7 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryDatasetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-northeast1"),
+				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-east1"),
 			},
 			{
 				ResourceName:      "google_bigquery_dataset.test",
@@ -109,7 +112,7 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryRegionalDataset(datasetID2, "australia-southeast1"),
+				Config: testAccBigQueryRegionalDataset(datasetID2, "asia-northeast1"),
 			},
 			{
 				ResourceName:      "google_bigquery_dataset.test",
@@ -125,7 +128,31 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryRegionalDataset(datasetID4, "europe-west2"),
+				Config: testAccBigQueryRegionalDataset(datasetID4, "australia-southeast1"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID5, "europe-north1"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID6, "europe-west2"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID7, "us-east4"),
 			},
 			{
 				ResourceName:      "google_bigquery_dataset.test",

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -87,6 +87,55 @@ func TestAccBigQueryDataset_access(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
+	t.Parallel()
+
+	datasetID1 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID2 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID3 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID4 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryDatasetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-northeast1"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID2, "australia-southeast1"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID3, "asia-southeast1"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryRegionalDataset(datasetID4, "europe-west2"),
+			},
+			{
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBigQueryDatasetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -136,6 +185,22 @@ resource "google_bigquery_dataset" "test" {
     default_table_expiration_ms = 7200000
   }
 }`, datasetID)
+}
+
+func testAccBigQueryRegionalDataset(datasetID string, location string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id                  = "%s"
+  friendly_name               = "foo"
+  description                 = "This is a foo description"
+  location                    = "%s"
+  default_table_expiration_ms = 3600000
+
+  labels {
+    env                         = "foo"
+    default_table_expiration_ms = 3600000
+  }
+}`, datasetID, location)
 }
 
 func testAccBigQueryDatasetWithOneAccess(datasetID string) string {

--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -60,7 +60,9 @@ The following arguments are supported:
     multi-regional location is a large geographic area, such as the United States,
     that contains at least two geographic places
 
-    Possible regional values include: `asia-northeast1`
+    Possible regional values include: `asia-northeast1`, `australia-southeast1`,
+     `asia-southeast1` and `europe-west2`
+
     Possible multi-regional values:`EU` and `US`.
 
     The default value is multi-regional location `US`.

--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -60,8 +60,8 @@ The following arguments are supported:
     multi-regional location is a large geographic area, such as the United States,
     that contains at least two geographic places
 
-    Possible regional values include: `asia-northeast1`, `australia-southeast1`,
-     `asia-southeast1` and `europe-west2`
+    Possible regional values include: `asia-east1`, `asia-northeast1`, `asia-southeast1`
+     `australia-southeast1`, `europe-north1`, `europe-west2` and `us-east4`.
 
     Possible multi-regional values:`EU` and `US`.
 


### PR DESCRIPTION
The resource validation of `location` is restricted to three known locations however there are three more regional locations that can be used. This PR expands the validation to include these and adds a new test to explicitly test the creation in the regional locations. The documentation has also been updated to list the three additional locations.

```$ make testacc TEST=./google TESTARGS='-run=TestAccBigQueryDataset'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccBigQueryDataset -timeout 120m
=== RUN   TestAccBigQueryDataset_basic
=== RUN   TestAccBigQueryDataset_access
=== RUN   TestAccBigQueryDataset_regionalLocation
--- PASS: TestAccBigQueryDataset_basic (6.91s)
--- PASS: TestAccBigQueryDataset_access (12.78s)
--- PASS: TestAccBigQueryDataset_regionalLocation (51.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 51.371s
```