### PR TITLE
Clarify account_id param

### DIFF
--- a/website/docs/d/datasource_google_service_account.html.markdown
+++ b/website/docs/d/datasource_google_service_account.html.markdown
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "google-application-credentials" {
 
 The following arguments are supported:
 
-* `account_id` - (Required) The Service account id.
+* `account_id` - (Required) The Service account id.  (This is the part of the service account's email field that comes before the @ symbol.)
 
 * `project` - (Optional) The ID of the project that the service account will be created in.
     Defaults to the provider project configuration.


### PR DESCRIPTION
Service accounts do not have a field named `id`, but they have a few fields with `Id` in the name.  This clarifies what terraform actually needs.