### PR TITLE
Fix monitoring alert policy example

### DIFF
--- a/website/docs/r/monitoring_alert_policy.html.markdown
+++ b/website/docs/r/monitoring_alert_policy.html.markdown
@@ -41,6 +41,7 @@ To get more information about AlertPolicy, see:
 resource "google_monitoring_alert_policy" "basic" {
   display_name = "Test Policy Basic"
   combiner = "OR"
+  enabled = "true"
   conditions = [
     {
       display_name = "test condition"


### PR DESCRIPTION
Enabled is a require parameter so it makes sense to put it in the example.