### PR TITLE
Generate consistent `id` value for `data.google_compute_default_service_account`

### DIFF
--- a/google/data_source_google_compute_default_service_account.go
+++ b/google/data_source_google_compute_default_service_account.go
@@ -34,7 +34,7 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 		return handleNotFoundError(err, d, "GCE service account not found")
 	}
 
-	d.SetId(projectCompResource.DefaultServiceAccount)
+	d.SetId("projects/" + project + "/serviceAccounts/" + projectCompResource.DefaultServiceAccount)
 	d.Set("email", projectCompResource.DefaultServiceAccount)
 	d.Set("project", project)
 	return nil


### PR DESCRIPTION
Fixes #2611 

Sets `id` field on the `data.google_compute_default_service_account` to be in the same format as for `google_service_account` resource.

The pattern is the same as for the `name` attribute as extracted by Google Cloud SDK:
```
$ gcloud iam service-accounts describe 777777777777-compute@developer.gserviceaccount.com --project=production
displayName: Compute Engine default service account
email: 777777777777-compute@developer.gserviceaccount.com
etag: <...>
name: projects/production/serviceAccounts/777777777777-compute@developer.gserviceaccount.com
oauth2ClientId: '<...>'
projectId: production
uniqueId: '<...>'
```

With this change, `data.google_compute_default_service_account.<...>.id` can be used to populate `google_service_account_iam_member.service_account_id` attribute without the need for additional string concatenation.