### PR TITLE
Generate consistent `id` value for `data.google_compute_default_service_account`

### DIFF
--- a/google/data_source_google_compute_default_service_account.go
+++ b/google/data_source_google_compute_default_service_account.go
@@ -34,7 +34,7 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 		return handleNotFoundError(err, d, "GCE service account not found")
 	}
 
-	d.SetId(projectCompResource.DefaultServiceAccount)
+	d.SetId("projects/" + project + "/serviceAccounts/" + projectCompResource.DefaultServiceAccount)
 	d.Set("email", projectCompResource.DefaultServiceAccount)
 	d.Set("project", project)
 	return nil


### PR DESCRIPTION
A backport of #2615 into master.