### PR TITLE
Add an example versioned module using google and google-beta

### DIFF
--- a/examples/example-versioned-module/README.md
+++ b/examples/example-versioned-module/README.md
@@ -1,0 +1,17 @@
+# Terraform Google Cloud Platform Provider - Example Versioned Module
+
+The `google` and `google-beta` split requires users to explicitly set
+the version of the Google provider for Terraform that they are using;
+see the [Google Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
+page for more details.
+
+This has complicated module creation as the schema between `google`
+and `google-beta` often differs; specifying a Beta feature with
+the `google` provider will give an error. This example module
+demonstrates how to create a "versioned" module that detects the
+necessary version for a resource based on the fields specified.
+
+This example only solves the simple case of a single beta field
+in a single resource, but should give module developers the right
+ideas on how to develop more complex modules intermixing `google`
+and `google-beta`.

--- a/examples/example-versioned-module/ip/main.tf
+++ b/examples/example-versioned-module/ip/main.tf
@@ -1,0 +1,16 @@
+resource "google_compute_address" "ip_address" {
+  # We'll only generate this block if the value of
+  # has_labels is 0! Effectively an if statement.
+  count = "${1 - local.has_labels}"
+
+  name = "${var.name}"
+}
+
+resource "google_compute_address" "ip_address_beta" {
+  # And this block is only present if we have
+  # at least one entry, effectively an elif.
+  count = "${local.has_labels}"
+
+  name   = "${var.name}"
+  labels = "${var.labels}"
+}

--- a/examples/example-versioned-module/ip/outputs.tf
+++ b/examples/example-versioned-module/ip/outputs.tf
@@ -1,0 +1,8 @@
+output "address" {
+  description = "The generated address of the ip address"
+
+  value = "${coalesce(
+		element(concat(google_compute_address.ip_address.*.address, list("")), 0),
+		element(concat(google_compute_address.ip_address_beta.*.address, list("")), 0)
+		)}"
+}

--- a/examples/example-versioned-module/ip/variables.tf
+++ b/examples/example-versioned-module/ip/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  description = "A name for the ip address resource"
+}
+
+variable "labels" {
+  type        = "map"
+  description = "A map of key:value labels to apply to the ip address resource"
+  default     = {}
+}
+
+locals {
+  # This ends up being a boolean
+  # 1 if there are any entries
+  # 0 otherwise
+  has_labels = "${min(1, length(var.labels))}"
+}

--- a/examples/example-versioned-module/main.tf
+++ b/examples/example-versioned-module/main.tf
@@ -1,0 +1,51 @@
+# This will use the `google` provider
+module "ip" {
+  source = "./ip"
+  name   = "ipv4"
+}
+
+
+# The following modules will use the `google-beta` provider
+# Because it has been aliased to the `google` name
+module "ip-beta" {
+  source = "./ip"
+
+  name   = "ipv4-beta"
+  labels = {
+    "hello" = "world"
+    "foo"   = "bar"
+  }
+
+  providers {
+    google = "google-beta"
+  }
+}
+
+module "ip-beta-no-labels" {
+  source = "./ip"
+
+  name   = "ipv4-beta-no-labels"
+
+  providers {
+    google = "google-beta"
+  }
+}
+
+# Using the `google-beta` provider in a config requires
+# the `google-beta` provider block
+provider "google-beta" {
+}
+
+
+# Display outputs from each block
+output "ip_address" {
+  value = "${module.ip.address}"
+}
+
+output "ip_address_beta" {
+  value = "${module.ip-beta.address}"
+}
+
+output "ip_address_beta_no_labels" {
+  value = "${module.ip-beta-no-labels.address}"
+}


### PR DESCRIPTION
Writing modules against tpg/tpgb is hard - introduce an example of how to use beta features with both providers in a single module.