### PR TITLE
Introduce a google_kms_key_ring data source

### DIFF
--- a/google/data_source_google_kms_key_ring.go
+++ b/google/data_source_google_kms_key_ring.go
@@ -1,0 +1,36 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleKmsKeyRing() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(resourceKmsKeyRing().Schema)
+
+	addRequiredFieldsToSchema(dsSchema, "name", "location")
+
+	return &schema.Resource{
+		Read:   datasourceGoogleKmsKeyRingRead,
+		Schema: dsSchema,
+	}
+}
+
+func datasourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	keyRing := &kmsKeyRingId{
+		Project:  project,
+		Location: d.Get("location").(string),
+		Name:     d.Get("name").(string),
+	}
+
+	d.SetId(keyRing.keyRingId())
+
+	return resourceKmsKeyRingRead(d, meta)
+}

--- a/google/data_source_google_kms_key_ring.go
+++ b/google/data_source_google_kms_key_ring.go
@@ -9,6 +9,7 @@ func dataSourceGoogleKmsKeyRing() *schema.Resource {
 	dsSchema := datasourceSchemaFromResourceSchema(resourceKmsKeyRing().Schema)
 
 	addRequiredFieldsToSchema(dsSchema, "name", "location")
+	addOptionalFieldsToSchema(dsSchema, "project")
 
 	return &schema.Resource{
 		Read:   datasourceGoogleKmsKeyRingRead,

--- a/google/data_source_google_kms_key_ring_test.go
+++ b/google/data_source_google_kms_key_ring_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -11,15 +12,16 @@ import (
 func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
 	projectId := "terraform-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
-	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	billingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	folderId := os.Getenv("GOOGLE_FOLDER_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Config: testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, billingAccount, folderId, keyRingName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceMatchesResourceCheck("data.google_kms_key_ring.test", "google_kms_key_ring.project", []string{"project", "location", "self_link"}),
 				),
@@ -28,12 +30,36 @@ func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
+func testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, billingAccount string, folderId string, keyRingName string) string {
+	var parent string
+	if len(folderId) != 0 {
+		parent = fmt.Sprintf(`folder_id = "%s"`, folderId)
+	} else if len(projectOrg) != 0 {
+		parent = fmt.Sprintf(`org_id = "%s"`, projectOrg)
+	}
+
 	return fmt.Sprintf(`
-%s
+resource "google_project" "project" {
+  project_id      = "%s"
+  name            = "%s"
+  billing_account = "%s"
+  %s
+}
+
+resource "google_project_service" "acceptance" {
+  project  = "${google_project.project.project_id}"
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = "${google_project_service.acceptance.project}"
+  name     = "%s"
+  location = "us-central1"
+}
 
 data "google_kms_key_ring" "test" {
   name     = "${google_kms_key_ring.key_ring.name}"
+  project  = "${google_project.project.project_id}"
   location = "us-central1"
-}`, testGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName))
+}`, projectId, projectId, billingAccount, parent, keyRingName)
 }

--- a/google/data_source_google_kms_key_ring_test.go
+++ b/google/data_source_google_kms_key_ring_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, billingAccount, folderId, keyRingName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceMatchesResourceCheck("data.google_kms_key_ring.test", "google_kms_key_ring.project", []string{"project", "location", "self_link"}),
+					testAccDataSourceMatchesResourceCheck("data.google_kms_key_ring.test", "google_kms_key_ring.key_ring", []string{"project", "location", "self_link"}),
 				),
 			},
 		},

--- a/google/data_source_google_kms_key_ring_test.go
+++ b/google/data_source_google_kms_key_ring_test.go
@@ -1,0 +1,39 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
+	projectId := "terraform-" + acctest.RandString(10)
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceMatchesResourceCheck("data.google_kms_key_ring.test", "google_kms_key_ring.project", []string{"project", "location", "self_link"}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleKmsKeyRingConfig(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "google_kms_key_ring" "test" {
+  name     = "${google_kms_key_ring.key_ring.name}"
+  location = "us-central1"
+}`, testGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName))
+}

--- a/google/data_source_google_project_test.go
+++ b/google/data_source_google_project_test.go
@@ -6,13 +6,21 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceGoogleProject_basic(t *testing.T) {
 	t.Parallel()
 	org := getTestOrgFromEnv(t)
 	project := "terraform-" + acctest.RandString(10)
+
+	projectAttrToCheck := []string{
+		"project_id",
+		"name",
+		"billing_account",
+		"org_id",
+		"folder_id",
+		"number",
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -21,50 +29,11 @@ func TestAccDataSourceGoogleProject_basic(t *testing.T) {
 			{
 				Config: testAccCheckGoogleProjectConfig(project, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceGoogleProjectCheck("data.google_project.project", "google_project.project"),
+					testAccDataSourceMatchesResourceCheck("data.google_project.project", "google_project.key_ring", projectAttrToCheck),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceGoogleProjectCheck(dataSourceName string, resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		ds, ok := s.RootModule().Resources[dataSourceName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", dataSourceName)
-		}
-
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("can't find %s in state", resourceName)
-		}
-
-		dsAttr := ds.Primary.Attributes
-		rsAttr := rs.Primary.Attributes
-
-		projectAttrToCheck := []string{
-			"project_id",
-			"name",
-			"billing_account",
-			"org_id",
-			"folder_id",
-			"number",
-		}
-
-		for _, attr := range projectAttrToCheck {
-			if dsAttr[attr] != rsAttr[attr] {
-				return fmt.Errorf(
-					"%s is %s; want %s",
-					attr,
-					dsAttr[attr],
-					rsAttr[attr],
-				)
-			}
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckGoogleProjectConfig(project, org string) string {

--- a/google/data_source_google_project_test.go
+++ b/google/data_source_google_project_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceGoogleProject_basic(t *testing.T) {
 			{
 				Config: testAccCheckGoogleProjectConfig(project, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceMatchesResourceCheck("data.google_project.project", "google_project.key_ring", projectAttrToCheck),
+					testAccDataSourceMatchesResourceCheck("data.google_project.project", "google_project.project", projectAttrToCheck),
 				),
 			},
 		},

--- a/google/provider.go
+++ b/google/provider.go
@@ -89,6 +89,7 @@ func Provider() terraform.ResourceProvider {
 			"google_iam_policy":                               dataSourceGoogleIamPolicy(),
 			"google_iam_role":                                 dataSourceGoogleIamRole(),
 			"google_kms_secret":                               dataSourceGoogleKmsSecret(),
+			"google_kms_key_ring":                             dataSourceGoogleKmsKeyRing(),
 			"google_folder":                                   dataSourceGoogleFolder(),
 			"google_netblock_ip_ranges":                       dataSourceGoogleNetblockIpRanges(),
 			"google_organization":                             dataSourceGoogleOrganization(),

--- a/website/docs/d/google_kms_key_ring.html.markdown
+++ b/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "google"
+page_title: "Google: google_kms_key_ring"
+sidebar_current: "docs-google-kms-key-ring"
+description: |-
+  Provides read access to key rings in Google Cloud KMS
+---
+
+# google\_kms\_key\_ring
+
+This data source allows you to query key ring by name in Google Cloud KMS
+within your resource definitions.
+
+## Example Usage
+
+```hcl
+resource "google_kms_key_ring" "main" {
+  project  = "my-project"
+  name     = "my-key-ring"
+  location = "us-central1"
+}
+
+data "google_kms_secret" "info" {
+  name = "${google_kms_key_ring.main.name}"
+}
+
+output "key_self_link" {
+  value = "${data.google_kms_secret.info.self_link}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The KeyRing's name. A KeyRing’s name must be unique within a location and match the regular expression `[a-zA-Z0-9_-]{1,63}`
+* `location` - (Required) The Google Cloud Platform location for the KeyRing. A full list of valid locations can be found by running `gcloud kms locations list`.
+* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `self_link` - The self link of the created KeyRing. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}`.

--- a/website/google.erb
+++ b/website/google.erb
@@ -117,6 +117,9 @@
       <li<%= sidebar_current("docs-google-datasource-iam-role") %>>
       <a href="/docs/providers/google/d/datasource_google_iam_role.html">google_iam_role</a>
       </li>
+      <li<%= sidebar_current("docs-google-kms-key-ring") %>>
+      <a href="/docs/providers/google/d/google_kms_key_ring.html">google_kms_key_ring</a>
+      </li>
       <li<%= sidebar_current("docs-google-kms-secret") %>>
       <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
       </li>


### PR DESCRIPTION
This introduces a `google_kms_key_ring` data source that allows you to pull in KMS key ring information based on location and name.

I've also made a more generic `testAccDataSourceMatchesResourceCheck` function based on the one that was in the `google_project` data source. Due to the way my GCP organization is structured I've also introduced logic to allow `folder_id` to be used instead of `org_id` in my test.

I've tried running acceptance tests locally, but my GCP organization is structure in a way that's preventing me from running them. I'm PR'ing this now in the hopes that acceptance tests will run on the PR. 

In the meantime, I need to figure out how to fix this error, which I'm 99% sure is unrelated to anything in this PR:

```
Error setting billing account "XXXXXX-YYYYYY-ZZZZZZ" for project "projects/terraform-gf2qlqy307": googleapi: Error 400: Precondition check failed., failedPrecondition
```