### PR TITLE
Added missing `monitoring-read` scope

### DIFF
--- a/google/service_scope.go
+++ b/google/service_scope.go
@@ -15,6 +15,7 @@ func canonicalizeServiceScope(scope string) string {
 		"datastore":             "https://www.googleapis.com/auth/datastore",
 		"logging-write":         "https://www.googleapis.com/auth/logging.write",
 		"monitoring":            "https://www.googleapis.com/auth/monitoring",
+		"monitoring-read":       "https://www.googleapis.com/auth/monitoring.read",
 		"monitoring-write":      "https://www.googleapis.com/auth/monitoring.write",
 		"pubsub":                "https://www.googleapis.com/auth/pubsub",
 		"service-control":       "https://www.googleapis.com/auth/servicecontrol",


### PR DESCRIPTION
This scope can be useful in read-only monitoring cases. 
<https://www.googleapis.com/auth/monitoring.read> it exists, so it can be used.
More info: https://developers.google.com/identity/protocols/googlescopes#monitoringv3