### PR TITLE
Add detail to google_project_iam_member import example

### DIFF
--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -114,6 +114,12 @@ IAM resources can be imported using the `project_id`, role, and account.
 $ terraform import google_project_iam_policy.my_project your-project-id
 
 $ terraform import google_project_iam_binding.my_project "your-project-id roles/viewer"
+```
 
-$ terraform import google_project_iam_member.my_project "your-project-id roles/viewer foo@example.com"
+In the case of `google_project_iam_member` resources, the type of user must be specified.
+
+For service accounts:
+
+```
+$ terraform import google_project_iam_member.my_project "your-project-id roles/viewer serviceAccount:foo@example.com"
 ```


### PR DESCRIPTION
The previous import example for objects of type google_project_iam_member generates an error (foo@example.com is not a valid resource Id). In order to clarify, I've added additional information for the case of importing service accounts.