### PR TITLE
Fix compute metadata error

### DIFF
--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -94,11 +94,13 @@ func resourceComputeProjectMetadataCreate(d *schema.ResourceData, meta interface
 func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	if d.Id() == "" {
-		projectID, err := getProject(d, config)
-		if err != nil {
-			return err
-		}
+	projectID, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" || d.Id() != projectID {
+		log.Printf("[DEBUG] Setting ID to: %s", projectID)
 		d.SetId(projectID)
 	}
 


### PR DESCRIPTION
This resolves the following issue happening on `v1.20.0`:
``` 
Error: Error refreshing state: 1 error(s) occurred:

* google_compute_project_metadata.default: 1 error(s) occurred:

2019-01-08T17:58:17.186+0100 [DEBUG] plugin.terraform-provider-gsuite:
2019/01/08 17:58:17 [ERR] plugin: plugin server: accept unix
/tmp/plugin123032284: use of closed network connection
* google_compute_project_metadata.default:
google_compute_project_metadata.default: Error reading Project metadata
for project "common_metadata": googleapi: Error 400: Invalid value
'common_metadata'. Values must match the following regular expression:
'(?:(?:[-a-z0-9]{1,63}\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?))',
invalidParameter
```

This occurs when a resource exists that has "common_metadata" as the ID,
probably set by a previous provider version.

Not sure if this has been fixed in latest master or 2.0 already, though.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2699