### PR TITLE
Correct typo in google_compute_security_policy docs

### DIFF
--- a/website/docs/r/compute_security_policy.html.markdown
+++ b/website/docs/r/compute_security_policy.html.markdown
@@ -24,7 +24,7 @@ resource "google_compute_security_policy" "policy" {
     match {
       versioned_expr = "SRC_IPS_V1"
       config {
-        src_ip_ranges = ["9.9.9.9/32"]
+        src_ip_ranges = ["9.9.9.0/24"]
       }
     }
     description = "Deny access to IPs in 9.9.9.0/24"


### PR DESCRIPTION
Bring the example code in-line with the description further down.