### PR TITLE
Fix incorrect arguments for `google_compute_instance` data source

### DIFF
--- a/google/data_source_google_compute_instance.go
+++ b/google/data_source_google_compute_instance.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -9,11 +10,8 @@ func dataSourceGoogleComputeInstance() *schema.Resource {
 	// Generate datasource schema from resource
 	dsSchema := datasourceSchemaFromResourceSchema(resourceComputeInstance().Schema)
 
-	// Set 'Required' schema elements
-	addRequiredFieldsToSchema(dsSchema, "name")
-
 	// Set 'Optional' schema elements
-	addOptionalFieldsToSchema(dsSchema, "project", "zone")
+	addOptionalFieldsToSchema(dsSchema, "name", "self_link", "project", "zone")
 
 	return &schema.Resource{
 		Read:   dataSourceGoogleComputeInstanceRead,

--- a/google/data_source_google_compute_instance_test.go
+++ b/google/data_source_google_compute_instance_test.go
@@ -129,5 +129,9 @@ data "google_compute_instance" "bar" {
 	name = "${google_compute_instance.foo.name}"
 	zone = "us-central1-a"
 }
+
+data "google_compute_instance" "baz" {
+	self_link = "${google_compute_instance.foo.self_link}"
+}
 `, instanceName)
 }


### PR DESCRIPTION
Fixes #2535

I ran the test with:

```bash
GOOGLE_REGION="us-central1" GOOGLE_ZONE="us-central1-a" \
GOOGLE_PROJECT="xxx" GOOGLE_CREDENTIALS=xxx.json \
make testacc TEST=./google TESTARGS='-run=TestAccDataSourceComputeInstance_basic'
```
and the test passes:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccDataSourceComputeInstance_basic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceComputeInstance_basic
=== PAUSE TestAccDataSourceComputeInstance_basic
=== CONT  TestAccDataSourceComputeInstance_basic
--- PASS: TestAccDataSourceComputeInstance_basic (157.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	157.813s
```