### PR TITLE
feat(google/resource_compute_instance.go): adding Hostname property

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -508,6 +508,13 @@ func resourceComputeInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"hostname": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"cpu_platform": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -666,6 +673,7 @@ func expandComputeInstance(project string, zone *compute.Zone, d *schema.Resourc
 		MachineType:        machineTypeUrl,
 		Metadata:           metadata,
 		Name:               d.Get("name").(string),
+		Hostname:           d.Get("hostname").(string),
 		NetworkInterfaces:  networkInterfaces,
 		Tags:               resourceInstanceTags(d),
 		Labels:             expandLabels(d),
@@ -892,6 +900,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("project", project)
 	d.Set("zone", GetResourceNameFromSelfLink(instance.Zone))
 	d.Set("name", instance.Name)
+	d.Set("hostname", instance.Hostname)
 	d.SetId(instance.Name)
 
 	return nil


### PR DESCRIPTION
Hello maintainers :wave: 

This is my first contribution to Terraform so please bear with me!

I'm sending this PR to add `Hostname` to Google Compute Instance, which was recently added: https://cloud.google.com/compute/docs/instances/custom-hostname-vm

This property is:

  - Optional
  - String
  - Read-only (cannot be updated once the instance is created)
  - Only valid if `[a-z]([-a-z0-9]*[a-z0-9])?`

Please let me know if you want me to add any more tails and/or tests to this PR.

