### PR TITLE
Updated bigquery regions

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -72,7 +72,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "US",
-				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-east1", "asia-northeast1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west2", "us-east4"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-east1", "asia-east2", "asia-south1", "asia-northeast1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west2", "us-east4", "us-west2", "northamerica-northeast1", false),
 			},
 
 			// defaultPartitionExpirationMs: [Optional] The default partition


### PR DESCRIPTION
Added new regions to bigquery data set validation location options, as per https://cloud.google.com/bigquery/docs/locations

Specifically, added asia-east2, asia-northeast1, us-west2.