### PR TITLE
Add force_destroy option to bigquery dataset

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -184,6 +184,9 @@ func resourceBigQueryDataset() *schema.Resource {
 				},
 			},
 
+			//Delete Contents on Destroy: [Optional] If True, delete all the tables in the dataset.
+			// If False and the dataset contains tables, the request will fail.
+			// Default is False.
 			"delete_contents_on_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -188,9 +188,10 @@ func resourceBigQueryDataset() *schema.Resource {
 			// If False and the dataset contains tables, the request will fail.
 			// Default is False.
 			"delete_contents_on_destroy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				DiffSuppressFunc: emptyOrDefaultStringSuppress("false"),
 			},
 
 			// SelfLink: [Output-only] A URL that can be used to access the resource

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -184,6 +184,12 @@ func resourceBigQueryDataset() *schema.Resource {
 				},
 			},
 
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			// SelfLink: [Output-only] A URL that can be used to access the resource
 			// again. You can use this URL in Get or Update requests to the
 			// resource.
@@ -407,7 +413,8 @@ func resourceBigQueryDatasetDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if err := config.clientBigQuery.Datasets.Delete(id.Project, id.DatasetId).Do(); err != nil {
+	force := d.Get("force_delete").(bool)
+	if err := config.clientBigQuery.Datasets.Delete(id.Project, id.DatasetId).DeleteContents(force).Do(); err != nil {
 		return err
 	}
 

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -184,7 +184,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				},
 			},
 
-			//Delete Contents on Destroy: [Optional] If True, delete all the tables in the dataset.
+			// Delete Contents on Destroy: [Optional] If True, delete all the tables in the dataset.
 			// If False and the dataset contains tables, the request will fail.
 			// Default is False.
 			"delete_contents_on_destroy": {

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -184,7 +184,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				},
 			},
 
-			"force_delete": {
+			"force_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -413,7 +413,7 @@ func resourceBigQueryDatasetDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	force := d.Get("force_delete").(bool)
+	force := d.Get("force_destroy").(bool)
 	if err := config.clientBigQuery.Datasets.Delete(id.Project, id.DatasetId).DeleteContents(force).Do(); err != nil {
 		return err
 	}

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -184,7 +184,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				},
 			},
 
-			"force_destroy": {
+			"delete_contents_on_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -413,8 +413,8 @@ func resourceBigQueryDatasetDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	force := d.Get("force_destroy").(bool)
-	if err := config.clientBigQuery.Datasets.Delete(id.Project, id.DatasetId).DeleteContents(force).Do(); err != nil {
+	deleteContents := d.Get("delete_contents_on_destroy").(bool)
+	if err := config.clientBigQuery.Datasets.Delete(id.Project, id.DatasetId).DeleteContents(deleteContents).Do(); err != nil {
 		return err
 	}
 

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/bigquery/v2"
 )
 
 func TestAccBigQueryDataset_basic(t *testing.T) {
@@ -23,17 +24,44 @@ func TestAccBigQueryDataset_basic(t *testing.T) {
 				Config: testAccBigQueryDataset(datasetID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryDatasetUpdated(datasetID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccBigQueryDataset_datasetWithContents(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryDatasetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetDeleteContents(datasetID),
+				Check:  testAccAddTable(datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.contents_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 		},
 	})
@@ -55,33 +83,37 @@ func TestAccBigQueryDataset_access(t *testing.T) {
 				Config: testAccBigQueryDatasetWithOneAccess(datasetID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.access_test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.access_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryDatasetWithTwoAccess(datasetID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.access_test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.access_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryDatasetWithOneAccess(datasetID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.access_test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.access_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryDatasetWithViewAccess(datasetID, otherDatasetID, otherTableID),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.access_test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.access_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 		},
 	})
@@ -107,57 +139,64 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-east1"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID2, "asia-northeast1"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID3, "asia-southeast1"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID4, "australia-southeast1"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID5, "europe-north1"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID6, "europe-west2"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID7, "us-east4"),
 			},
 			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
 			},
 		},
 	})
@@ -178,6 +217,25 @@ func testAccCheckBigQueryDatasetDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAddTable(datasetID string, tableID string) resource.TestCheckFunc {
+	// Not actually a check, but adds a table independently of terraform
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		table := &bigquery.Table{
+			TableReference: &bigquery.TableReference{
+				DatasetId: datasetID,
+				TableId:   tableID,
+				ProjectId: config.Project,
+			},
+		}
+		_, err := config.clientBigQuery.Tables.Insert(config.Project, datasetID, table).Do()
+		if err != nil {
+			return fmt.Errorf("Could not create table")
+		}
+		return nil
+	}
 }
 
 func testAccBigQueryDataset(datasetID string) string {
@@ -205,11 +263,29 @@ resource "google_bigquery_dataset" "test" {
   description                 = "This is a bar description"
   location                    = "EU"
   default_partition_expiration_ms = 7200000
-  default_table_expiration_ms = 7200000
+	default_table_expiration_ms = 7200000
 
   labels = {
     env                         = "bar"
     default_table_expiration_ms = 7200000
+  }
+}`, datasetID)
+}
+
+func testAccBigQueryDatasetDeleteContents(datasetID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "contents_test" {
+  dataset_id                  = "%s"
+  friendly_name               = "foo"
+  description                 = "This is a foo description"
+  location                    = "EU"
+  default_partition_expiration_ms = 3600000
+	default_table_expiration_ms = 3600000
+	delete_contents_on_destroy = true
+
+  labels = {
+    env                         = "foo"
+    default_table_expiration_ms = 3600000
   }
 }`, datasetID)
 }

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -24,19 +24,17 @@ func TestAccBigQueryDataset_basic(t *testing.T) {
 				Config: testAccBigQueryDataset(datasetID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryDatasetUpdated(datasetID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -83,37 +81,33 @@ func TestAccBigQueryDataset_access(t *testing.T) {
 				Config: testAccBigQueryDatasetWithOneAccess(datasetID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.access_test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.access_test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryDatasetWithTwoAccess(datasetID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.access_test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.access_test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryDatasetWithOneAccess(datasetID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.access_test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.access_test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryDatasetWithViewAccess(datasetID, otherDatasetID, otherTableID),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.access_test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.access_test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -139,64 +133,57 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-east1"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID2, "asia-northeast1"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID3, "asia-southeast1"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID4, "australia-southeast1"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID5, "europe-north1"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID6, "europe-west2"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBigQueryRegionalDataset(datasetID7, "us-east4"),
 			},
 			{
-				ResourceName:            "google_bigquery_dataset.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_contents_on_destroy"},
+				ResourceName:      "google_bigquery_dataset.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -263,7 +250,7 @@ resource "google_bigquery_dataset" "test" {
   description                 = "This is a bar description"
   location                    = "EU"
   default_partition_expiration_ms = 7200000
-	default_table_expiration_ms = 7200000
+  default_table_expiration_ms = 7200000
 
   labels = {
     env                         = "bar"
@@ -280,8 +267,8 @@ resource "google_bigquery_dataset" "contents_test" {
   description                 = "This is a foo description"
   location                    = "EU"
   default_partition_expiration_ms = 3600000
-	default_table_expiration_ms = 3600000
-	delete_contents_on_destroy = true
+  default_table_expiration_ms = 3600000
+  delete_contents_on_destroy = true
 
   labels = {
     env                         = "foo"


### PR DESCRIPTION
Added the `force_destroy` option for bigquery datasets, as described in #2050.

