### PR TITLE
update GCE API documentation URL

### DIFF
--- a/website/docs/r/compute_health_check.html.markdown
+++ b/website/docs/r/compute_health_check.html.markdown
@@ -36,7 +36,7 @@ healthy again and can receive new connections.
 
 To get more information about HealthCheck, see:
 
-* [API documentation](https://cloud.google.com/compute/docs/reference/rest/latest/healthChecks)
+* [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks)
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
 


### PR DESCRIPTION
Previous URL is no longer available