### PR TITLE
Docs update: container_node_pool allows min_node_count of zero

### DIFF
--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -138,7 +138,7 @@ resource "google_container_cluster" "primary" {
 
 The `autoscaling` block supports:
 
-* `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=1 and
+* `min_node_count` - (Required) Minimum number of nodes in the NodePool. Must be >=0 and
     <= `max_node_count`.
 
 * `max_node_count` - (Required) Maximum number of nodes in the NodePool. Must be >= min_node_count.


### PR DESCRIPTION
I was pleasantly surprised to find that it works ok to set `min_node_count` to zero. But the docs say it must be at least one, so this PR proposes a tweak to update that.

More context, from https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler:

> Beginning with Kubernetes version 1.7, you can specify a minimum size of zero for your node pool. This allows your node pool to scale down completely if the instances within aren't required to run your workloads. However, while a node pool can scale to a zero size, the overall cluster size does not scale down to zero nodes (as at least one node is always required to run system Pods).