### PR TITLE
Add custom Service Account support to Dataflow Job resource

### DIFF
--- a/google/resource_dataflow_job.go
+++ b/google/resource_dataflow_job.go
@@ -90,6 +90,12 @@ func resourceDataflowJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"service_account_email": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -115,9 +121,10 @@ func resourceDataflowJobCreate(d *schema.ResourceData, meta interface{}) error {
 	params := expandStringMap(d, "parameters")
 
 	env := dataflow.RuntimeEnvironment{
-		TempLocation: d.Get("temp_gcs_location").(string),
-		Zone:         zone,
-		MaxWorkers:   int64(d.Get("max_workers").(int)),
+		TempLocation:        d.Get("temp_gcs_location").(string),
+		Zone:                zone,
+		MaxWorkers:          int64(d.Get("max_workers").(int)),
+		ServiceAccountEmail: d.Get("service_account_email").(string),
 	}
 
 	request := dataflow.CreateJobFromTemplateRequest{

--- a/google/resource_dataflow_job.go
+++ b/google/resource_dataflow_job.go
@@ -91,7 +91,7 @@ func resourceDataflowJob() *schema.Resource {
 				Computed: true,
 			},
 
-			"service_account_email": &schema.Schema{
+			"service_account_email": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,

--- a/google/resource_dataflow_job_test.go
+++ b/google/resource_dataflow_job_test.go
@@ -55,7 +55,7 @@ func TestAccDataflowJobCreateWithServiceAccount(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDataflowJobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataflowJobWithServiceAccount,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(

--- a/website/docs/r/dataflow_job.html.markdown
+++ b/website/docs/r/dataflow_job.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `on_delete` - (Optional) One of "drain" or "cancel".  Specifies behavior of deletion during `terraform destroy`.  See above note.
 * `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
 * `zone` - (Optional) The zone in which the created job should run. If it is not provided, the provider zone is used.
+* `service_account_email` - (Optional) The Service Account email used to create the job.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #2072
Supersedes #2071

I've taken @migibert's commit and added the test that was asked for in [review](https://github.com/terraform-providers/terraform-provider-google/pull/2071#discussion_r219317433). Since there doesn't appear to be a canonical way of getting the service account from Dataflow directly, this test uses the unique labels set by Dataflow to find the associated instance template and verifies that it contains the custom service account.