### PR TITLE
Documentation note about creating TXT records longer than 255 characters.

### DIFF
--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `name` - (Required) The DNS name this record set will apply to.
 
 * `rrdatas` - (Required) The string data for the records in this record set
-    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces.
+    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g. `"first255characters\"\"morecharacters"`).
 
 * `ttl` - (Required) The time-to-live of this record set (seconds).
 


### PR DESCRIPTION
Common issue with 2048-bit DKIM records.