### PR TITLE
Documentation: fixed TF syntax in google_iam_policy example

### DIFF
--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -36,13 +36,13 @@ data "google_iam_policy" "admin" {
       log_type = "DATA_READ",
       exempted_members = ["user:you@domain.com"]
     }
-    
+
     audit_log_configs {
-      "logType": "DATA_WRITE",
+      log_type = "DATA_WRITE",
     }
-    
+
     audit_log_configs {
-      "logType": "ADMIN_READ",
+      log_type = "ADMIN_READ",
     }
   }
 }


### PR DESCRIPTION
I found some TF syntax errors in google_iam_policy data source, so here's the fix.