### PR TITLE
Fix compute_network import

### DIFF
--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -15,7 +15,7 @@ func resourceComputeNetwork() *schema.Resource {
 		Update: resourceComputeNetworkUpdate,
 		Delete: resourceComputeNetworkDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceComputeNetworkImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -210,4 +210,20 @@ func deleteComputeNetwork(project, network string, config *Config) error {
 		return err
 	}
 	return nil
+}
+
+func resourceComputeNetworkImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/global/networks/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -64,8 +64,10 @@ exported:
 
 ## Import
 
-Networks can be imported using the `name`, e.g.
+Networks can be imported using any of these accepted formats:
 
 ```
-$ terraform import google_compute_network.default foobar
+$ terraform import google_compute_network.default projects/{{project}}/global/networks/{{name}}
+$ terraform import google_compute_network.default {{project}}/{{name}}
+$ terraform import google_compute_network.default {{name}}
 ```


### PR DESCRIPTION
The import for compute_network was broken (the project wasn't being set on the resource, if the default provider project wasn't set).

This fixes it with a basic parser, so if you specific the project in the object import string, it will import.

This was done manually, as this resource isn't managed by MM.