### PR TITLE
Fix code block for dns_record_set

### DIFF
--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -118,8 +118,10 @@ resource "google_dns_managed_zone" "prod" {
 ```
 
 ### Adding a CNAME record
+
  The list of `rrdatas` should only contain a single string corresponding to the Canonical Name intended.
- ```hcl
+
+```hcl
 resource "google_dns_record_set" "cname" {
   name = "frontend.${google_dns_managed_zone.prod.dns_name}"
   managed_zone = "${google_dns_managed_zone.prod.name}"


### PR DESCRIPTION
This reverts the following PR #2495 

Fixes the following broken code block

<img width="907" alt="screenshot 2019-02-20 17 22 47" src="https://user-images.githubusercontent.com/237513/53106898-44c76300-3534-11e9-8429-c6e114d67c5b.png">

Is this the correct place to fix it? or is this file generated magically?