### PR TITLE
fix binary_log_enabled description

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -226,7 +226,8 @@ The optional `settings.database_flags` sublist supports:
 The optional `settings.backup_configuration` subblock supports:
 
 * `binary_log_enabled` - (Optional) True if binary logging is enabled. If
-    `logging` is false, this must be as well. Cannot be used with Postgres.
+    `settings.backup_configuration.enabled` is false, this must be as well. 
+    Cannot be used with Postgres.
 
 * `enabled` - (Optional) True if backup configuration is enabled.
 


### PR DESCRIPTION
the binary_log_enabled description was referencing an invalid field.

The text from the proto definition on [cloud.google.com](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert) is "Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well."