### PR TITLE
Clarify network_policy_config default

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -289,7 +289,7 @@ The `addons_config` block supports:
 * `network_policy_config` - (Optional) Whether we should enable the network policy addon
     for the master.  This must be enabled in order to enable network policy for the nodes.
     It can only be disabled if the nodes already do not have network policies enabled.
-    Set `disabled = true` to disable.
+    Defaults to disabled; set `disabled = false` to enable.
     
 * `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)).
     Structure is documented below.


### PR DESCRIPTION
network_policy_config defaults to `disabled = true`.  To enable it, the user must explicitly add `disabled = false`.

Fixes #1709 