### PR TITLE
compute_instance_template: Remove copy/paste typo in docs

### DIFF
--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -190,8 +190,6 @@ The following arguments are supported:
 
 * `machine_type` - (Required) The machine type to create.
 
-    **Note:** If you want to update this value (resize the VM) after initial creation, you must set [`allow_stopping_for_update`](#allow_stopping_for_update) to `true`.
-
     To create a machine with a [custom type][custom-vm-types] (such as extended memory), format the value like `custom-VCPUS-MEM_IN_MB` like `custom-6-20480` for 6 vCPU and 20GB of RAM.
 
 - - -


### PR DESCRIPTION
The `allow_stopping_for_update` argument is not defined for resource `compute_instance_template`,
so remove this typo in the docs. That field is defined for `compute_instance` resource, so I think it is a copy/paste typo.