### PR TITLE
Add GCP zone to client_config datasource

### DIFF
--- a/google/data_source_google_client_config.go
+++ b/google/data_source_google_client_config.go
@@ -20,6 +20,11 @@ func dataSourceGoogleClientConfig() *schema.Resource {
 				Computed: true,
 			},
 
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"access_token": {
 				Type:      schema.TypeString,
 				Computed:  true,
@@ -35,6 +40,7 @@ func dataSourceClientConfigRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(time.Now().UTC().String())
 	d.Set("project", config.Project)
 	d.Set("region", config.Region)
+	d.Set("zone", config.Zone)
 
 	token, err := config.tokenSource.Token()
 	if err != nil {

--- a/google/data_source_google_client_config_test.go
+++ b/google/data_source_google_client_config_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project"),
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttrSet(resourceName, "zone"),
 					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
 				),
 			},

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -51,4 +51,6 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `region` - The region to operate under.
 
+* `zone` - The zone to operate under.
+
 * `access_token` - The OAuth2 access token used by the client to authenticate against the Google Cloud API.


### PR DESCRIPTION
The datasource google_client_config currently reads the region from the gcloud config (returning empty string if unset). I need to use the currently configured zone in a system I'm working on; this PR adds that.