### PR TITLE
guard against panic during diff when storage object does not exist yet

### DIFF
--- a/google/resource_storage_object_acl.go
+++ b/google/resource_storage_object_acl.go
@@ -67,6 +67,9 @@ func resourceStorageObjectAclDiff(diff *schema.ResourceDiff, meta interface{}) e
 		// Create won't show the object owner being given
 		return nil
 	}
+	if sObject.Owner == nil {
+		return nil
+	}
 
 	objectOwner := sObject.Owner.Entity
 	ownerRole := fmt.Sprintf("%s:%s", "OWNER", objectOwner)


### PR DESCRIPTION
Given TF code such as this:

```
resource "google_storage_bucket_object" "configure-sh" {
   bucket        = "my-bucket"
   name          = "public/configure.sh"
   content       = "foo"
   cache_control = "nocache"
 }

 resource "google_storage_object_acl" "configure-sh" {
   bucket        = "my-bucket"
   object         = "${google_storage_bucket_object.configure-sh.output_name}"
   predefined_acl = "publicRead"
 }
```

If the "google_storage_bucket_object" does not exist yet the plan phase of 'google_storage_object_acl' will cause a panic in the custom diff func:

```
-----------------------------------------------------
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x228e92e]
goroutine 381 [running]:
github.com/terraform-providers/terraform-provider-google/google.resourceStorageObjectAclDiff(0xc000df0700, 0x25a85c0, 0xc000993380, 0xc0006c2700, 0xc000df0700)
       /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-google/google/resource_storage_object_acl.go:71 +0x2ae
github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema.schemaMap.Diff(0xc0009a2ed0, 0xc000b7a320, 0xc0006d2f60, 0x295d510, 0x25a85c0, 0xc000993380, 0x2616fa0, 0x0, 0x1011c01)
       /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema/schema.go:442 +0xab2
github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Diff(0xc00089ef50, 0xc000b7a320, 0xc0006d2f60, 0x25a85c0, 0xc000993380, 0x100b601, 0xc000b90b80, 0x10bdfdc)
       /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:250 +0x17c
github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Diff(0xc00089f650, 0xc000b7a2d0, 0xc000b7a320, 0xc0006d2f60, 0xc000544800, 0x18, 0x415f440)
       /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:296 +0x9c
github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Diff(0xc000587ea0, 0xc0006c2640, 0xc000c23360, 0x0, 0x0)
       /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-google/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:538 +0x57
reflect.Value.call(0xc000151140, 0xc00013a950, 0x13, 0x28f1a15, 0x4, 0xc000b90f18, 0x3, 0x3, 0xc000130040, 0xc000508cf0, ...)
       /opt/goenv/versions/1.11.5/src/reflect/value.go:447 +0x454
reflect.Value.Call(0xc000151140, 0xc00013a950, 0x13, 0xc0006ff718, 0x3, 0x3, 0x0, 0x0, 0xc0006ff7c0)
       /opt/goenv/versions/1.11.5/src/reflect/value.go:308 +0xa4
net/rpc.(*service).call(0xc00069cb40, 0xc000162500, 0xc000153c20, 0xc000153c30, 0xc0001a1500, 0xc00070a200, 0x2398ee0, 0xc0006c2640, 0x16, 0x2398f20, ...)
       /opt/goenv/versions/1.11.5/src/net/rpc/server.go:384 +0x14e
created by net/rpc.(*Server).ServeCodec
       /opt/goenv/versions/1.11.5/src/net/rpc/server.go:481 +0x47e
```

The API call made before the panic will return 404 because the object does not exist but the diff function will continue to run as if it had succeeded resulting in panic.

Proposed fix: return from the differ func if the source object owner is nil.