### PR TITLE
Add support for CloudSQL source representation instances

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -217,6 +217,7 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 			"google_spanner_database_iam_policy":           ResourceIamPolicyWithImport(IamSpannerDatabaseSchema, NewSpannerDatabaseIamUpdater, SpannerDatabaseIdParseFunc),
 			"google_sql_database":                          resourceSqlDatabase(),
 			"google_sql_database_instance":                 resourceSqlDatabaseInstance(),
+			"google_sql_source_representation_instance":    resourceSqlSourceRepresentationInstance(),
 			"google_sql_ssl_cert":                          resourceSqlSslCert(),
 			"google_sql_user":                              resourceSqlUser(),
 			"google_organization_iam_binding":              ResourceIamBindingWithImport(IamOrganizationSchema, NewOrganizationIamUpdater, OrgIdParseFunc),

--- a/google/resource_sql_source_representation_instance.go
+++ b/google/resource_sql_source_representation_instance.go
@@ -1,0 +1,227 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+func resourceSqlSourceRepresentationInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSqlSourceRepresentationInstanceCreate,
+		Read:   resourceSqlSourceRepresentationInstanceRead,
+		Delete: resourceSqlSourceRepresentationInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSqlSourceRepresentationInstanceImporter,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"database_version": {
+				Type:     schema.TypeString,
+				Default:  "MYSQL_5_7",
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"host": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"port": {
+				Type:         schema.TypeInt,
+				Default:      3306,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(0, 65535),
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSqlSourceRepresentationInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else {
+		name = resource.UniqueId()
+	}
+	d.Set("name", name)
+
+	host := d.Get("host").(string)
+	port := d.Get("port").(int)
+	hostPort := fmt.Sprintf("%s:%d", host, port)
+
+	instance := &sqladmin.DatabaseInstance{
+		Name:            name,
+		Region:          region,
+		DatabaseVersion: d.Get("database_version").(string),
+		OnPremisesConfiguration: &sqladmin.OnPremisesConfiguration{
+			HostPort: hostPort,
+		},
+	}
+
+	backoff := time.Second
+	var op *sqladmin.Operation
+	for {
+		op, err = config.clientSqlAdmin.Instances.Insert(project, instance).Do()
+		if err == nil {
+			break
+		}
+
+		// When deleting and recreating a source representation instance, the (re)create operation fails with an invalidState
+		// for a very short window after the deletion succeeds. This is easily fixed by retrying when encountering that
+		// error.
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 409 && strings.Contains(gerr.Body, "invalidState") {
+			log.Printf("[DEBUG]: Got an invalid state error, retrying after %s\n", backoff)
+			time.Sleep(backoff)
+			backoff = backoff * 2
+			if backoff > 30*time.Second {
+				return errwrap.Wrapf(fmt.Sprintf("Error, constantly failing to create source representation instance %s. Too many invalid state errors. Latest error {{err}}", instance.Name), err)
+			}
+		} else {
+			return errwrap.Wrapf(fmt.Sprintf("Failed to create source representation instance %s: {{err}}", instance.Name), err)
+		}
+	}
+
+	d.SetId(instance.Name)
+
+	err = sqladminOperationWaitTime(config, op, project, "Create Source Representation Instance", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	return resourceSqlSourceRepresentationInstanceRead(d, meta)
+}
+
+func resourceSqlSourceRepresentationInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	instance, err := config.clientSqlAdmin.Instances.Get(project, d.Id()).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("SQL Source Representation Instance %q", d.Get("name").(string)))
+	}
+
+	d.Set("name", instance.Name)
+	d.Set("region", instance.Region)
+	d.Set("database_version", instance.DatabaseVersion)
+	hostPort := strings.Split(instance.OnPremisesConfiguration.HostPort, ":")
+	d.Set("host", hostPort[0])
+
+	port, err := strconv.Atoi(hostPort[1])
+	if err != nil {
+		return err
+	}
+	d.Set("port", port)
+
+	d.Set("project", project)
+	d.Set("self_link", instance.SelfLink)
+	d.SetId(instance.Name)
+
+	return nil
+}
+
+func resourceSqlSourceRepresentationInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	var op *sqladmin.Operation
+	err = retryTimeDuration(func() error {
+		op, err = config.clientSqlAdmin.Instances.Delete(project, d.Get("name").(string)).Do()
+		return err
+	}, d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return fmt.Errorf("Error, failed to delete source representation instance %s: %s", d.Get("name").(string), err)
+	}
+
+	err = sqladminOperationWaitTime(config, op, project, "Delete Source Representation Instance", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceSqlSourceRepresentationInstanceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if err := parseImportId([]string{
+		"projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/google/resource_sql_source_representation_instance_test.go
+++ b/google/resource_sql_source_representation_instance_test.go
@@ -1,0 +1,153 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("gcp_sql_source_representation_instance", &resource.Sweeper{
+		Name: "gcp_sql_source_representation_instance",
+		F:    testSweepSourceRepresentationInstanceDatabases,
+	})
+}
+
+func testSweepSourceRepresentationInstanceDatabases(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting shared config for region: %s", err)
+	}
+
+	err = config.LoadAndValidate()
+	if err != nil {
+		log.Fatalf("error loading: %s", err)
+	}
+
+	found, err := config.clientSqlAdmin.Instances.List(config.Project).Do()
+	if err != nil {
+		log.Fatalf("error listing databases: %s", err)
+	}
+
+	if len(found.Items) == 0 {
+		log.Printf("No databases found")
+		return nil
+	}
+
+	for _, d := range found.Items {
+		if !strings.HasPrefix(d.Name, "tf-test-source-representation-instance-") {
+			continue
+		}
+
+		log.Printf("Destroying Source Representation Instance (%s)", d.Name)
+
+		// destroy instances, replicas first
+		op, err := config.clientSqlAdmin.Instances.Delete(config.Project, d.Name).Do()
+		if err != nil {
+			if strings.Contains(err.Error(), "409") {
+				// the GCP api can return a 409 error after the delete operation
+				// reaches a successful end
+				log.Printf("Operation not found, got 409 response")
+				continue
+			}
+
+			return fmt.Errorf("Error, failed to delete source representation instance %s: %s", d.Name, err)
+		}
+
+		err = sqladminOperationWait(config, op, config.Project, "Delete Source Representation Instance")
+		if err != nil {
+			if strings.Contains(err.Error(), "does not exist") {
+				log.Printf("SQL Source Representation Instance not found")
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestAccSqlSourceRepresentationInstance_minimal(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "minimal-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlSourceRepresentationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					testGoogleSqlSourceRepresentationInstance_minimal, databaseName),
+			},
+			{
+				ResourceName:      "google_sql_source_representation_instance.master",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSqlSourceRepresentationInstance_full(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "full-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlSourceRepresentationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					testGoogleSqlSourceRepresentationInstance_full, databaseName),
+			},
+			{
+				ResourceName:      "google_sql_source_representation_instance.master",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSqlSourceRepresentationInstanceDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		config := testAccProvider.Meta().(*Config)
+		if rs.Type != "google_sql_source_representation_instance" {
+			continue
+		}
+
+		_, err := config.clientSqlAdmin.Instances.Get(config.Project,
+			rs.Primary.Attributes["name"]).Do()
+		if err == nil {
+			return fmt.Errorf("Source representation instance still exists")
+		}
+	}
+
+	return nil
+}
+
+var testGoogleSqlSourceRepresentationInstance_minimal = `
+resource "google_sql_source_representation_instance" "master" {
+  name = "tf-test-source-representation-instance-%s"
+  host = "10.20.30.40"
+}
+`
+
+var testGoogleSqlSourceRepresentationInstance_full = `
+resource "google_sql_source_representation_instance" "master" {
+  name                 = "tf-test-source-representation-instance-%s"
+  database_version     = "MYSQL_5_6"
+  region               = "us-east1"
+  host                 = "10.20.30.40"
+  port                 = 33006
+}
+`

--- a/website/docs/r/sql_source_representation_instance.html.markdown
+++ b/website/docs/r/sql_source_representation_instance.html.markdown
@@ -1,0 +1,91 @@
+---
+layout: "google"
+page_title: "Google: google_sql_source_representation_instance"
+sidebar_current: "docs-google-sql-source-representation-instance"
+description: |-
+  Creates a new SQL Source Representation Instance, which holds metadata about
+  on-premises MySQL instances. This enables Google CloudSQL MySQL instances to
+  become replicas of on-premises databases.
+
+  Replicas are configured by setting the source representation instance name in
+  their `master_instance_name` value.
+
+---
+
+# google\_sql\_database\_instance
+
+Creates a new source representation Instance for Google CloudSQL.
+
+For more information, see the [official documentation](https://cloud.google.com/sql/),
+or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).
+
+~> **NOTE on `google_sql_source_representation_instance`:** - This feature is
+currently only available for MySQL databases.
+
+## Example Usage
+
+```hcl
+resource "google_sql_source_representation_instance" "on_premises_master" {
+  name = "master-instance"
+  database_version = "MYSQL_5_6"
+  region = "us-central1"
+  host = "1.2.3.4"
+  port = "3306"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host` - (Required) The host of the on-premises instance.
+
+* `region` - (Required) The region the instances replicating this database will sit in.
+    Note, Cloud SQL is not available in all regions - choose from one of the
+    options listed [here](https://cloud.google.com/sql/docs/mysql/instance-locations).
+    A valid region must be provided to use this resource. If a region is not
+    provided in the resource definition, the provider region will be used
+    instead, but this will be an apply-time error if the provider region is not
+    supported with Cloud SQL.
+    If you choose not to provide the `region` argument for this resource, make
+    sure you understand this.
+
+- - -
+
+* `database_version` - (Optional, Default: `MYSQL_5_7`) The MySQL version to use.
+    Can be `MYSQL_5_6` or `MYSQL_5_7`.
+
+* `name` - (Optional, Computed) The name of the instance. If the name is left
+    blank, Terraform will randomly generate one when the instance is first
+    created. Note that unlike regular CloudSQL instances, there are no
+    limitations on source representation instance name reuse.
+
+* `port` - (Optional, Default: `3306`) The port of the on-premises instance.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `self_link` - The URI of the created resource.
+
+## Timeouts
+
+`google_sql_source_representation_instance` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - Default is 10 minutes.
+- `delete` - Default is 10 minutes.
+
+## Import
+
+Database instances can be imported using one of any of these accepted formats:
+
+```
+$ terraform import google_sql_source_representation_instance.master projects/{{project}}/instances/{{name}}
+$ terraform import google_sql_source_representation_instance.master {{project}}/{{name}}
+$ terraform import google_sql_source_representation_instance.master {{name}}
+```


### PR DESCRIPTION
Those are metadata-only CloudSQL instances that are used for replication
of external MySQL databases.

See the following documentation links for more details:
- https://cloud.google.com/sql/docs/mysql/replication/external-server
- https://cloud.google.com/sql/docs/mysql/replication/replication-from-external