### PR TITLE
Correct source_repository.url reference

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -100,9 +100,9 @@ The `source_repository` block supports:
 
 * `url` - (Required) The URL pointing to the hosted repository where the function is defined. There are supported Cloud Source Repository URLs in the following formats:
 
-    * To refer to a specific commit: `https://source.developers.google.com/projects/*/repos/*/revisions/*/paths/*`
-    * To refer to a moveable alias (branch): `https://source.developers.google.com/projects/*/repos/*/moveable-aliases/*/paths/*`. To refer to HEAD, use the `master` moveable alias.
-    * To refer to a specific fixed alias (tag): `https://source.developers.google.com/projects/*/repos/*/fixed-aliases/*/paths/*`
+    * To refer to a specific commit: `https://source.developers.google.com/projects/*/repos/*/revisions/*/paths/`
+    * To refer to a moveable alias (branch): `https://source.developers.google.com/projects/*/repos/*/moveable-aliases/*/paths/`. To refer to HEAD, use the `master` moveable alias.
+    * To refer to a specific fixed alias (tag): `https://source.developers.google.com/projects/*/repos/*/fixed-aliases/*/paths/`
 
 ## Attributes Reference
 


### PR DESCRIPTION
https://cloud.google.com/sdk/gcloud/reference/functions/deploy

There are three stars not four in the references:
```
${PROJECT}
${REPOSITORY}
${REVISION} || ${MOVEABLE_ALIAS} || ${FIXED_ALIAS}
```

Example:
https://source.developers.google.com/projects/devops/repos/data-consumer-bigquery/fixed-aliases/v1.0.0/paths/