### PR TITLE
transport replaceVars url escape values

### DIFF
--- a/google/transport.go
+++ b/google/transport.go
@@ -166,7 +166,7 @@ func buildReplacementFunc(re *regexp.Regexp, d TerraformResourceData, config *Co
 		}
 		v, ok := d.GetOk(m)
 		if ok {
-			return fmt.Sprintf("%v", v)
+			return url.QueryEscape(fmt.Sprintf("%v", v))
 		}
 		return ""
 	}

--- a/google/transport_test.go
+++ b/google/transport_test.go
@@ -126,6 +126,14 @@ func TestReplaceVars(t *testing.T) {
 			},
 			Expected: "projects/project1/zones/zone1/instances/instance1",
 		},
+		"escape": {
+			Template: "b/{{bucket}}/o/{{object}}",
+			SchemaValues: map[string]interface{}{
+				"bucket": "bucket1",
+				"object": "path/to/object",
+			},
+			Expected: "b/bucket1/o/path%2Fto%2Fobject",
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Fixes #2895 

According to https://cloud.google.com/storage/docs/json_api/#encoding URI paths parts are supposed to be encoded.

For example in `google_storage_object_access_control` if the object name contains a `/`, the request will fail with:

```
* google_storage_object_access_control.public_rule: Error creating ObjectAccessControl: googleapi: got HTTP response code 404 with body: Not Found
```

To my knowledge, `replaceVars()` is specifically for replacing variables in URLs (as for the name of the parameter "linkTmpl"), so I'm assuming this would work globally.