### PR TITLE
replace hazardous tf patterns in docs

### DIFF
--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -59,8 +59,12 @@ data "google_kms_secret" "sql_user_password" {
   ciphertext = "CiQAqD+xX4SXOSziF4a8JYvq4spfAuWhhYSNul33H85HnVtNQW4SOgDu2UZ46dQCRFl5MF6ekabviN8xq+F+2035ZJ85B+xTYXqNf4mZs0RJitnWWuXlYQh6axnnJYu3kDU="
 }
 
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "master" {
-  name = "master-instance"
+	name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
     tier = "D0"

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -64,7 +64,7 @@ resource "random_id" "db_name_suffix" {
 }
 
 resource "google_sql_database_instance" "master" {
-	name = "master-instance-${random_id.db_name_suffix.hex}"
+  name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
     tier = "D0"

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -17,8 +17,12 @@ or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/databases)
 Example creating a SQL Database.
 
 ```hcl
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "master" {
-  name = "master-instance"
+  name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
     tier = "D0"

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -21,8 +21,12 @@ a restricted host and strong password.
 ### SQL First Generation
 
 ```hcl
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "master" {
-  name = "master-instance"
+  name = "master-instance-${random_id.db_name_suffix.hex}"
   database_version = "MYSQL_5_6"
   # First-generation instance regions are not the conventional
   # Google Compute Engine regions. See argument reference below.
@@ -91,8 +95,12 @@ data "null_data_source" "auth_netw_postgres_allowed_2" {
   }
 }
 
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "postgres" {
-  name = "postgres-instance"
+  name = "postgres-instance-${random_id.db_name_suffix.hex}"
   database_version = "POSTGRES_9_6"
 
   settings {
@@ -136,10 +144,14 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   reserved_peering_ranges = ["${google_compute_global_address.private_ip_address.name}"]
 }
 
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "instance" {
   provider = "google-beta"
 
-  name = "private-instance"
+  name = "private-instance-${random_id.db_name_suffix.hex}"
   region = "us-central1"
 
   depends_on = [

--- a/website/docs/r/sql_ssl_cert.html.markdown
+++ b/website/docs/r/sql_ssl_cert.html.markdown
@@ -18,8 +18,12 @@ Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information
 Example creating a SQL Client Certificate.
 
 ```hcl
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "master" {
-  name = "master-instance"
+  name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
     tier = "D0"

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -19,8 +19,12 @@ Creates a new Google SQL User on a Google SQL User Instance. For more informatio
 Example creating a SQL User.
 
 ```hcl
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "master" {
-  name = "master-instance"
+  name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
     tier = "D0"


### PR DESCRIPTION
Hard coding a name on a sql instance is ill advised for [reasons outlined a little ways down in the docs](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html#name). 

For folks who just read the example code and tailor it to meet their needs we should present a better pattern from the outset.