### PR TITLE
Removing validation function from BQ dataset resource 

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -68,11 +68,10 @@ func resourceBigQueryDataset() *schema.Resource {
 			// Location: [Experimental] The geographic location where the dataset
 			// should reside.
 			"location": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      "US",
-				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-east1", "asia-northeast1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west2", "us-east4"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "US",
 			},
 
 			// defaultPartitionExpirationMs: [Optional] The default partition

--- a/google/resource_bigquery_dataset_test.go
+++ b/google/resource_bigquery_dataset_test.go
@@ -117,12 +117,6 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 	t.Parallel()
 
 	datasetID1 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID2 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID3 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID4 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID5 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID6 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	datasetID7 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,55 +124,7 @@ func TestAccBigQueryDataset_regionalLocation(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryDatasetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-east1"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID2, "asia-northeast1"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID3, "asia-southeast1"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID4, "australia-southeast1"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID5, "europe-north1"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID6, "europe-west2"),
-			},
-			{
-				ResourceName:      "google_bigquery_dataset.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccBigQueryRegionalDataset(datasetID7, "us-east4"),
+				Config: testAccBigQueryRegionalDataset(datasetID1, "asia-south1"),
 			},
 			{
 				ResourceName:      "google_bigquery_dataset.test",


### PR DESCRIPTION
The validation function which does not contain all the BQ dataset locations has been removed. Also with this change, the tests for regional datasets become redundant and thus keeping only one test for a regional location. 

Since PR #2954 has been pending for two months now, I am submitting another PR with necessary  changes. This is affecting our ability to use BQ resource in "asia-south1". 