### PR TITLE
Fix typo "google_client_openid_useremail"

### DIFF
--- a/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
+++ b/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
@@ -84,7 +84,7 @@ resource "kubernetes_cluster_role_binding" "user" {
 
   subject {
     kind = "User"
-    name = "${data.google_client_openid_useremail.provider_identity.email}"
+    name = "${data.google_client_openid_userinfo.provider_identity.email}"
   }
 }
 ```


### PR DESCRIPTION
Fix typo. Rename "google_client_openid_useremail" to "google_client_openid_info"