### PR TITLE
Add a missing closing bracket in  a resource block

### DIFF
--- a/website/docs/d/datasource_google_service_account.html.markdown
+++ b/website/docs/d/datasource_google_service_account.html.markdown
@@ -36,6 +36,7 @@ resource "kubernetes_secret" "google-application-credentials" {
   data {
     credentials.json = "${base64decode(google_service_account_key.mykey.private_key)}"
   }
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
The resource "kubernetes_secret" "google-application-credentials"  block is missing the closing bracket to cause syntax error.