### PR TITLE
Add Project Field To Google Container Cluster Resource

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -22,6 +22,7 @@ plaintext. [Read more about sensitive data in state](/docs/state/sensitive-data.
 resource "google_container_cluster" "primary" {
   name     = "my-gke-cluster"
   location = "us-central1"
+  project  =  "project-name"
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default


### PR DESCRIPTION
the project field is required to run, without this, `terraform apply` throws an error
![Screenshot 2019-04-23 at 5 51 47 PM](https://user-images.githubusercontent.com/6943256/56600460-a1a4cf80-65f0-11e9-97a1-233ffe736011.png)
