### PR TITLE
Add support for creating instances with CMEK

### DIFF
--- a/google/data_source_google_compute_instance.go
+++ b/google/data_source_google_compute_instance.go
@@ -101,6 +101,7 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 			}
 			if key := disk.DiskEncryptionKey; key != nil {
 				di["disk_encryption_key_sha256"] = key.Sha256
+				di["kms_key_self_link"] = key.KmsKeyName
 			}
 			attachedDisks = append(attachedDisks, di)
 		}

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -77,9 +77,10 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"kms_key_self_link": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:          schema.TypeString,
+							Optional:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"boot_disk.0.disk_encryption_key_raw"},
 						},
 
 						"initialize_params": {
@@ -278,9 +279,8 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"kms_key_self_link": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ConflictsWith: []string{"boot_disk.0.disk_encryption_key_raw"},
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"disk_encryption_key_sha256": {

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -77,10 +77,11 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"kms_key_self_link": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ForceNew:      true,
-							ConflictsWith: []string{"boot_disk.0.disk_encryption_key_raw"},
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							ConflictsWith:    []string{"boot_disk.0.disk_encryption_key_raw"},
+							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"initialize_params": {
@@ -279,8 +280,9 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"kms_key_self_link": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"disk_encryption_key_sha256": {
@@ -877,7 +879,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 					}
 				}
 				if key.KmsKeyName != "" {
-					di["kms_key_self_link"] = key.KmsKeyName
+					// The response for crypto keys often includes the version of the key which needs to be removed
+					// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+					di["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
 				}
 				if key.Sha256 != "" {
 					di["disk_encryption_key_sha256"] = key.Sha256
@@ -1625,7 +1629,9 @@ func flattenBootDisk(d *schema.ResourceData, disk *computeBeta.AttachedDisk, con
 			result["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256
 		}
 		if disk.DiskEncryptionKey.KmsKeyName != "" {
-			result["kms_key_self_link"] = disk.DiskEncryptionKey.KmsKeyName
+			// The response for crypto keys often includes the version of the key which needs to be removed
+			// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+			result["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
 		}
 	}
 

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -1419,8 +1419,11 @@ func testAccCheckComputeInstanceDiskKmsEncryptionKey(n string, instance *compute
 			} else {
 				if disk.DiskEncryptionKey != nil {
 					expectedKey := diskNameToEncryptionKey[GetResourceNameFromSelfLink(disk.Source)].KmsKeyName
-					if disk.DiskEncryptionKey.KmsKeyName != expectedKey {
-						return fmt.Errorf("Disk %d has unexpected encryption key in GCP.\nExpected: %s\nActual: %s", i, expectedKey, disk.DiskEncryptionKey.Sha256)
+					// The response for crypto keys often includes the version of the key which needs to be removed
+					// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+					actualKey := strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
+					if actualKey != expectedKey {
+						return fmt.Errorf("Disk %d has unexpected encryption key in GCP.\nExpected: %s\nActual: %s", i, expectedKey, actualKey)
 					}
 				}
 			}

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -147,10 +147,12 @@ The `boot_disk` block supports:
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
-    to encrypt this disk.
+    to encrypt this disk. Only one of `kms_key_self_link` and `disk_encryption_key_raw`
+    may be set.
 
 * `kms_key_self_link` - (Optional) The self_link of the encryption key that is
-    stored in Google Cloud KMS to encrypt this disk.
+    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`
+    and `disk_encryption_key_raw` may be set.
 
 * `initialize_params` - (Optional) Parameters for a new disk that will be created
     alongside the new instance. Either `initialize_params` or `source` must be set.
@@ -196,10 +198,11 @@ The `attached_disk` block supports:
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
-    to encrypt this disk.
+    to encrypt this disk. Only one of `kms_key_self_link` and `disk_encryption_key_raw` may be set.
 
 * `kms_key_self_link` - (Optional) The self_link of the encryption key that is
-    stored in Google Cloud KMS to encrypt this disk.
+    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`
+    and `disk_encryption_key_raw` may be set.
 
 The `network_interface` block supports:
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -149,6 +149,9 @@ The `boot_disk` block supports:
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     to encrypt this disk.
 
+* `kms_key_self_link` - (Optional) The self_link of the encryption key that is
+    stored in Google Cloud KMS to encrypt this disk.
+
 * `initialize_params` - (Optional) Parameters for a new disk that will be created
     alongside the new instance. Either `initialize_params` or `source` must be set.
     Structure is documented below.
@@ -194,6 +197,9 @@ The `attached_disk` block supports:
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     to encrypt this disk.
+
+* `kms_key_self_link` - (Optional) The self_link of the encryption key that is
+    stored in Google Cloud KMS to encrypt this disk.
 
 The `network_interface` block supports:
 


### PR DESCRIPTION
This adds support for creating google_compute_instance with a Customer-managed encryption key. 