### PR TITLE
Fix invalid assumptions about Project ID's in BQ table

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -477,15 +477,16 @@ type bigQueryTableId struct {
 }
 
 func parseBigQueryTableId(id string) (*bigQueryTableId, error) {
-	parts := strings.FieldsFunc(id, func(r rune) bool { return r == ':' || r == '.' })
-
-	if len(parts) != 3 {
+	// Expected format is "PROJECT:DATASET.TABLE", but the project can itself have . and : in it.
+	// Those characters are not valid dataset or table components, so just split on the last two.
+	matchRegex := regexp.MustCompile("^(.+):([^:.]+)\\.([^:.]+)$")
+	subMatches := matchRegex.FindStringSubmatch(id)
+	if subMatches == nil {
 		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting {project}:{dataset-id}.{table-id}, got %s", id)
 	}
-
 	return &bigQueryTableId{
-		Project:   parts[0],
-		DatasetId: parts[1],
-		TableId:   parts[2],
+		Project:   subMatches[1],
+		DatasetId: subMatches[2],
+		TableId:   subMatches[3],
 	}, nil
 }


### PR DESCRIPTION
The bigquery table resource tries to infer the project and dataset from the table's full name. However, it does so incorrectly as it assumes that the project ID cannot have : or . characters in it, yet both are valid.

This is leading to errors like this for me when I run `terraform plan`:

```
* module.bigquery.google_bigquery_table.connect_product_analytics_table_user_search_filters: 1 error(s) occurred:

* module.bigquery.google_bigquery_table.connect_product_analytics_table_user_search_filters: google_bigquery_table.connect_product_analytics_table_user_search_filters: Invalid BigQuery table specifier. Expecting {project}:{dataset-id}.{table-id}, got outbound.io:outbound:connect_product_analytics_experiment.user_search_filters
```

As you can see, our project ID is `outbound.io:outbound`, so the string-splitting algorithm here doesn't work.

When using this branch, the plan works correctly.

Also - I'm targeting the PR against master, but we're actually still using the 1.20 version of the provider. Is there any way this fix can get backported to the 1.x series as well?

