### PR TITLE
Add SecurityGroups to google_container_cluster

### DIFF
--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -458,6 +458,29 @@ func TestAccContainerCluster_withKubernetesAlpha(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withAuthenticatorGroupsConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAuthenticatorGroupsConfig(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_authenticator_groups",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withPrivateClusterConfig(t *testing.T) {
 	t.Parallel()
 
@@ -2338,6 +2361,50 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 	initial_node_count = 1
 	ip_allocation_policy = []
 }`, cluster)
+}
+
+func testAccContainerCluster_withAuthenticatorGroupsConfig(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+	name = "container-net-%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+	name					 = "${google_compute_network.container_network.name}"
+	network					 = "${google_compute_network.container_network.name}"
+	ip_cidr_range			 = "10.0.36.0/24"
+	region					 = "us-central1"
+	private_ip_google_access = true
+
+	secondary_ip_range {
+		range_name	  = "pod"
+		ip_cidr_range = "10.0.0.0/19"
+	}
+
+	secondary_ip_range {
+		range_name	  = "svc"
+		ip_cidr_range = "10.0.32.0/22"
+	}
+}
+
+resource "google_container_cluster" "with_authenticator_groups" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+	network = "${google_compute_network.container_network.name}"
+	subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
+
+	authenticator_groups_config {
+		security_group = "gke-security-groups@mydomain.tld"
+	}
+
+	ip_allocation_policy {
+		cluster_secondary_range_name  = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.0.range_name}"
+		services_secondary_range_name = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.1.range_name}"
+	}
+}
+`, clusterName, clusterName)
 }
 
 func testAccContainerCluster_withPrivateClusterConfig(clusterName string) string {

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -286,6 +286,10 @@ to the datasource. A `region` can have a different set of supported versions tha
     [PodSecurityPolicy](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies) feature.
     Structure is documented below.
 
+* `authenticator_groups_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Configuration for the
+    [Google Groups for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#groups-setup-gsuite) feature.
+    Structure is documented below.
+
 * `private_cluster_config` - (Optional) A set of options for creating
     a private cluster. Structure is documented below.
 
@@ -368,6 +372,10 @@ The `resource_limits` block supports:
 * `minimum` - (Optional) The minimum value for the resource type specified.
 
 * `maximum` - (Optional) The maximum value for the resource type specified.
+
+The `authenticator_groups_config` block supports:
+
+* `security_group` - (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format `gke-security-groups@yourdomain.com`.
 
 The `maintenance_policy` block supports:
 


### PR DESCRIPTION
This merge request adds support for [Google Groups in GKE feature](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#groups-setup-gsuite).

I've named attributes within a block as in google.golang.org/api/container/v1beta1.AuthenticatorGroupsConfig structure and not as mentioned in #3440 to be consistent with API.

Test output:
```
$ make testacc TEST=./google TESTARGS='-run=AccContainerCluster_withAuthenticatorGroupsConfig'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=AccContainerCluster_withAuthenticatorGroupsConfig -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccContainerCluster_withAuthenticatorGroupsConfig
=== PAUSE TestAccContainerCluster_withAuthenticatorGroupsConfig
=== CONT  TestAccContainerCluster_withAuthenticatorGroupsConfig
--- PASS: TestAccContainerCluster_withAuthenticatorGroupsConfig (533.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google/google	533.655s
```

Closes #3407 #3440 