### PR TITLE
Add support for Shielded VMs to compute_instance and compute_instance_template (#3209)

### DIFF
--- a/google/compute_instance_helpers.go
+++ b/google/compute_instance_helpers.go
@@ -303,3 +303,29 @@ func resourceInstanceTags(d TerraformResourceData) *computeBeta.Tags {
 
 	return tags
 }
+
+func expandShieldedVmConfigs(d *schema.ResourceData) *computeBeta.ShieldedVmConfig {
+	if _, ok := d.GetOk("shielded_instance_config"); !ok {
+		return nil
+	}
+
+	prefix := "shielded_instance_config.0"
+	return &computeBeta.ShieldedVmConfig{
+		EnableSecureBoot:          d.Get(prefix + ".enable_secure_boot").(bool),
+		EnableVtpm:                d.Get(prefix + ".enable_vtpm").(bool),
+		EnableIntegrityMonitoring: d.Get(prefix + ".enable_integrity_monitoring").(bool),
+		ForceSendFields:           []string{"EnableSecureBoot", "EnableVtpm", "EnableIntegrityMonitoring"},
+	}
+}
+
+func flattenShieldedVmConfig(shieldedVmConfig *computeBeta.ShieldedVmConfig) []map[string]bool {
+	if shieldedVmConfig == nil {
+		return nil
+	}
+
+	return []map[string]bool{{
+		"enable_secure_boot":          shieldedVmConfig.EnableSecureBoot,
+		"enable_vtpm":                 shieldedVmConfig.EnableVtpm,
+		"enable_integrity_monitoring": shieldedVmConfig.EnableIntegrityMonitoring,
+	}}
+}

--- a/google/data_source_google_compute_instance.go
+++ b/google/data_source_google_compute_instance.go
@@ -135,6 +135,11 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	err = d.Set("shielded_instance_config", flattenShieldedVmConfig(instance.ShieldedVmConfig))
+	if err != nil {
+		return err
+	}
+
 	d.Set("attached_disk", ads)
 	d.Set("cpu_platform", instance.CpuPlatform)
 	d.Set("min_cpu_platform", instance.MinCpuPlatform)

--- a/website/docs/d/datasource_compute_instance.html.markdown
+++ b/website/docs/d/datasource_compute_instance.html.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
 
 * `cpu_platform` - The CPU platform used by this instance.
 
+* `shielded_instance_config` - The shielded vm config being used by the instance. Structure is documented below.
+
 * `network_interface.0.network_ip` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
@@ -192,3 +194,11 @@ The `guest_accelerator` block supports:
 * `count` - The number of the guest accelerator cards exposed to this instance.
 
 [network-tier]: https://cloud.google.com/network-tiers/docs/overview
+
+The `shielded_instance_config` block supports:
+
+* `enable_secure_boot` -- Whether secure boot is enabled for the instance.
+
+* `enable_vtpm` -- Whether the instance uses vTPM.
+
+* `enable_integrity_monitoring` -- Whether integrity monitoring is enabled for the instance.

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -134,6 +134,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A list of tags to attach to the instance.
 
+* `shielded_instance_config` - (Optional) Enable [Shielded VM](https://cloud.google.com/security/shielded-cloud/shielded-vm) on this instance. Shielded VM provides verifiable integrity to prevent against malware and rootkits. Defaults to disabled. Structure is documented below.
+	**Note**: [`shielded_instance_config`](#shielded_instance_config) can only be used with boot images with shielded vm support. See the complete list [here](https://cloud.google.com/compute/docs/images#shielded-images).
+
 ---
 
 The `boot_disk` block supports:
@@ -303,6 +306,14 @@ The `node_affinities` block supports:
     or `NOT` for anti-affinities.
 
 * `value` (Required) - The values for the node affinity label.
+
+The `shielded_instance_config` block supports:
+
+* `enable_secure_boot` (Optional) -- Verify the digital signature of all boot components, and halt the boot process if signature verification fails. Defaults to false.
+
+* `enable_vtpm` (Optional) -- Use a virtualized trusted platform module, which is a specialized computer chip you can use to encrypt objects like keys and certificates. Defaults to true.
+
+* `enable_integrity_monitoring` (Optional) -- Compare the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. Defaults to true.
 
 ## Attributes Reference
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -244,6 +244,9 @@ The following arguments are supported:
 * `min_cpu_platform` - (Optional) Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as
 `Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
 
+* `shielded_instance_config` - (Optional) Enable [Shielded VM](https://cloud.google.com/security/shielded-cloud/shielded-vm) on this instance. Shielded VM provides verifiable integrity to prevent against malware and rootkits. Defaults to disabled. Structure is documented below.
+	**Note**: [`shielded_instance_config`](#shielded_instance_config) can only be used with boot images with shielded vm support. See the complete list [here](https://cloud.google.com/compute/docs/images#shielded-images).
+
 The `disk` block supports:
 
 * `auto_delete` - (Optional) Whether or not the disk should be auto-deleted.
@@ -273,7 +276,7 @@ The `disk` block supports:
     read-write mode.
 
 * `source` - (Required if source_image not set) The name (**not self_link**)
-    of the disk (such as those managed by `google_compute_disk`) to attach. 
+    of the disk (such as those managed by `google_compute_disk`) to attach.
 
 * `disk_type` - (Optional) The GCE disk type. Can be either `"pd-ssd"`,
     `"local-ssd"`, or `"pd-standard"`.
@@ -372,7 +375,7 @@ The `scheduling` block supports:
 * `preemptible` - (Optional) Allows instance to be preempted. This defaults to
     false. Read more on this
     [here](https://cloud.google.com/compute/docs/instances/preemptible).
-    
+
 * `node_affinities` - (Optional) Specifies node affinities or anti-affinities
    to determine which sole-tenant nodes your instances and managed instance
    groups will use as host systems. Read more on sole-tenant node creation
@@ -393,6 +396,14 @@ The `node_affinities` block supports:
     or `NOT` for anti-affinities.
 
 * `value` (Required) - The values for the node affinity label.
+
+The `shielded_instance_config` block supports:
+
+* `enable_secure_boot` (Optional) -- Verify the digital signature of all boot components, and halt the boot process if signature verification fails. Defaults to false.
+
+* `enable_vtpm` (Optional) -- Use a virtualized trusted platform module, which is a specialized computer chip you can use to encrypt objects like keys and certificates. Defaults to true.
+
+* `enable_integrity_monitoring` (Optional) -- Compare the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. Defaults to true.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support for [Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm) to compute instances and instance templates.

Test output:
```
make testacc TEST=./google TESTARGS='-run=TestAccComputeInstance_shieldedVmConfig'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInstance_shieldedVmConfig -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstance_shieldedVmConfig
=== PAUSE TestAccComputeInstance_shieldedVmConfig
=== RUN   TestAccComputeInstance_shieldedVmConfigSkip
=== PAUSE TestAccComputeInstance_shieldedVmConfigSkip
=== CONT  TestAccComputeInstance_shieldedVmConfig
=== CONT  TestAccComputeInstance_shieldedVmConfigSkip
--- PASS: TestAccComputeInstance_shieldedVmConfigSkip (237.78s)
--- PASS: TestAccComputeInstance_shieldedVmConfig (248.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 248.853s

make testacc TEST=./google TESTARGS='-run=TestAccComputeInstance_basic'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInstance_basic -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstance_basic1
=== PAUSE TestAccComputeInstance_basic1
=== RUN   TestAccComputeInstance_basic2
=== PAUSE TestAccComputeInstance_basic2
=== RUN   TestAccComputeInstance_basic3
=== PAUSE TestAccComputeInstance_basic3
=== RUN   TestAccComputeInstance_basic4
=== PAUSE TestAccComputeInstance_basic4
=== RUN   TestAccComputeInstance_basic5
=== PAUSE TestAccComputeInstance_basic5
=== CONT  TestAccComputeInstance_basic1
=== CONT  TestAccComputeInstance_basic4
=== CONT  TestAccComputeInstance_basic3
=== CONT  TestAccComputeInstance_basic5
=== CONT  TestAccComputeInstance_basic2
--- PASS: TestAccComputeInstance_basic1 (156.77s)
--- PASS: TestAccComputeInstance_basic4 (239.65s)
--- PASS: TestAccComputeInstance_basic3 (271.10s)
--- PASS: TestAccComputeInstance_basic5 (292.26s)
--- PASS: TestAccComputeInstance_basic2 (187.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 344.041s

make testacc TEST=./google TESTARGS='-run=TestAccComputeInstanceTemplate_shieldedVmConfig'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInstanceTemplate_shieldedVmConfig -timeout 240m -ldflags="-X=github.com/terraform-p
roviders/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstanceTemplate_shieldedVmConfig
=== PAUSE TestAccComputeInstanceTemplate_shieldedVmConfig
=== RUN   TestAccComputeInstanceTemplate_shieldedVmConfigSkip
=== PAUSE TestAccComputeInstanceTemplate_shieldedVmConfigSkip
=== CONT  TestAccComputeInstanceTemplate_shieldedVmConfig
=== CONT  TestAccComputeInstanceTemplate_shieldedVmConfigSkip
--- PASS: TestAccComputeInstanceTemplate_shieldedVmConfigSkip (13.38s)
--- PASS: TestAccComputeInstanceTemplate_shieldedVmConfig (15.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 15.722s

make testacc TEST=./google TESTARGS='-run=TestAccComputeInstanceTemplate_basic'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInstanceTemplate_basic -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstanceTemplate_basic
=== PAUSE TestAccComputeInstanceTemplate_basic
=== CONT  TestAccComputeInstanceTemplate_basic
--- PASS: TestAccComputeInstanceTemplate_basic (11.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 11.372s

make testacc TEST=./google TESTARGS='-run=TestAccComputeInstanceFromTemplate_basic'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccComputeInstanceFromTemplate_basic -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstanceFromTemplate_basic
=== PAUSE TestAccComputeInstanceFromTemplate_basic
=== CONT  TestAccComputeInstanceFromTemplate_basic
--- PASS: TestAccComputeInstanceFromTemplate_basic (272.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 272.069s
```