### PR TITLE
datasource_compute_instance: Fix typo

### DIFF
--- a/website/docs/d/datasource_compute_instance.html.markdown
+++ b/website/docs/d/datasource_compute_instance.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-* `boot_disk` - The boot disk for the instance. Sructure is documented below.
+* `boot_disk` - The boot disk for the instance. Structure is documented below.
 
 * `machine_type` - The machine type to create.
 


### PR DESCRIPTION
Replace "sructure" with "structure".