### PR TITLE
Increase IAM custom role length validation to match API.

### DIFF
--- a/google/validation.go
+++ b/google/validation.go
@@ -29,7 +29,7 @@ const (
 	ComputeServiceAccountNameRegex = "[0-9]{1,20}-compute@developer.gserviceaccount.com"
 
 	// https://cloud.google.com/iam/docs/understanding-custom-roles#naming_the_role
-	IAMCustomRoleIDRegex = "^[a-zA-Z0-9_\\.\\-]{1,30}$"
+	IAMCustomRoleIDRegex = "^[a-zA-Z0-9_\\.]{3,64}$"
 )
 
 var (

--- a/google/validation_test.go
+++ b/google/validation_test.go
@@ -324,19 +324,20 @@ func TestValidateIAMCustomRoleIDRegex(t *testing.T) {
 		{TestName: "basic", Value: "foobar"},
 		{TestName: "with numbers", Value: "foobar123"},
 		{TestName: "with capipals", Value: "FooBar"},
-		{TestName: "short", Value: "f"},
-		{TestName: "long", Value: "foobarfoobarfoobarfoobarfoobar"},
-		{TestName: "has a hyphen", Value: "foo-bar"},
+		{TestName: "short", Value: "foo"},
+		{TestName: "long", Value: strings.Repeat("f", 64)},
 		{TestName: "has a dot", Value: "foo.bar"},
 		{TestName: "has an underscore", Value: "foo_bar"},
-		{TestName: "all of the above", Value: "foo.Bar-Baz_123"},
+		{TestName: "all of the above", Value: "foo.BarBaz_123"},
 
 		// With errors
 		{TestName: "empty", Value: "", ExpectError: true},
 		{TestName: "has an slash", Value: "foo/bar", ExpectError: true},
+		{TestName: "has a hyphen", Value: "foo-bar", ExpectError: true},
 		{TestName: "has a dollar", Value: "foo$", ExpectError: true},
 		{TestName: "has a space", Value: "foo bar", ExpectError: true},
-		{TestName: "too long", Value: strings.Repeat("f", 31), ExpectError: true},
+		{TestName: "too short", Value: "fo", ExpectError: true},
+		{TestName: "too long", Value: strings.Repeat("f", 65), ExpectError: true},
 	}
 
 	es := testStringValidationCases(x, validateIAMCustomRoleID)


### PR DESCRIPTION
This fixes #3658 @pdecat 

I'm still digging for the doc source which generates this misinformation: https://cloud.google.com/iam/docs/understanding-custom-roles#naming_the_role