### PR TITLE
Update IGM import documentation to list all supported id formats

### DIFF
--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -239,8 +239,10 @@ exported:
 
 ## Import
 
-Instance group managers can be imported using the `name`, e.g.
+Instance group managers can be imported using any of these accepted formats:
 
 ```
-$ terraform import google_compute_instance_group_manager.appserver appserver-igm
+$ terraform import google_compute_instance_group_manager.appserver {{project}}/{{zone}}/{{name}}
+$ terraform import google_compute_instance_group_manager.appserver {{project}}/{{name}}
+$ terraform import google_compute_instance_group_manager.appserver {{name}}
 ```


### PR DESCRIPTION
Multiple import ID formats are already supported:
https://github.com/terraform-providers/terraform-provider-google/blob/master/google/resource_compute_instance_group_manager.go#L660

However, this wasn't reflected in the documentation.