### PR TITLE
Allow container cluster to wait for status RUNNING on import.

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -51,12 +51,13 @@ import (
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
-	Credentials string
-	AccessToken string
-	Project     string
-	Region      string
-	Zone        string
-	Scopes      []string
+	Credentials  string
+	AccessToken  string
+	Project      string
+	Region       string
+	Zone         string
+	Scopes       []string
+	WaitOnImport bool
 
 	client    *http.Client
 	userAgent string

--- a/google/provider.go
+++ b/google/provider.go
@@ -74,6 +74,12 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"wait_on_import": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -283,9 +289,10 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Project: d.Get("project").(string),
-		Region:  d.Get("region").(string),
-		Zone:    d.Get("zone").(string),
+		Project:      d.Get("project").(string),
+		Region:       d.Get("region").(string),
+		Zone:         d.Get("zone").(string),
+		WaitOnImport: d.Get("wait_on_import").(bool),
 	}
 
 	// Add credential source


### PR DESCRIPTION
I think this is the simplest possible configuration that will allow Terraform to wait for a container to finish creating.  It won't generalize that well, but it will work fine in Container for now.  If it looks good I can bring it up into Magic Modules.