### PR TITLE
Replace access_config argument with block

### DIFF
--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -190,7 +190,7 @@ resource "google_compute_instance" "vm_instance" {
   network_interface {
     # A default network is created for all GCP projects
     network       = "${google_compute_network.vpc_network.self_link}"
-    access_config = {
+    access_config {
     }
   }
 }

--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -81,7 +81,7 @@ resource "google_compute_instance" "vm_instance" {
   network_interface {
     # A default network is created for all GCP projects
     network       = "default"
-    access_config = {
+    access_config {
     }
   }
 }
@@ -135,7 +135,7 @@ network_interface {
 -  # A default network is created for all GCP projects
 -  network = "default"
 +  network = "${google_compute_network.vpc_network.self_link}"
-  access_config = {
+  access_config {
 ```
 
 This means that when we create the VM instance, it will use


### PR DESCRIPTION
```
Error: Unsupported argument

  on main.tf line 21, in resource "google_compute_instance" "vm_instance":
  21:     access_config = {

An argument named "access_config" is not expected here. Did you mean to define
a block of type "access_config"?
```