### PR TITLE
Supporting Disk Labels on Instance bootDisk and InstanceTemplate disks

### DIFF
--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -114,6 +114,13 @@ func resourceComputeInstance() *schema.Resource {
 										ForceNew:         true,
 										DiffSuppressFunc: diskImageDiffSuppress,
 									},
+
+									"labels": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 								},
 							},
 						},
@@ -1650,6 +1657,10 @@ func expandBootDisk(d *schema.ResourceData, config *Config, zone *compute.Zone, 
 
 			disk.InitializeParams.SourceImage = imageUrl
 		}
+
+		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.labels"); ok {
+			disk.InitializeParams.Labels = expandStringMap(d, "boot_disk.0.initialize_params.0.labels")
+		}
 	}
 
 	return disk, nil
@@ -1680,8 +1691,9 @@ func flattenBootDisk(d *schema.ResourceData, disk *computeBeta.AttachedDisk, con
 			"type": GetResourceNameFromSelfLink(diskDetails.Type),
 			// If the config specifies a family name that doesn't match the image name, then
 			// the diff won't be properly suppressed. See DiffSuppressFunc for this field.
-			"image": diskDetails.SourceImage,
-			"size":  diskDetails.SizeGb,
+			"image":  diskDetails.SourceImage,
+			"size":   diskDetails.SizeGb,
+			"labels": diskDetails.Labels,
 		}}
 	}
 

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -99,6 +99,15 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Computed: true,
 						},
 
+						"labels": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
 						"source_image": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -598,6 +607,8 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*computeBeta.Attached
 				}
 				disk.InitializeParams.SourceImage = imageUrl
 			}
+
+			disk.InitializeParams.Labels = expandStringMap(d, prefix+".labels")
 		}
 
 		if v, ok := d.GetOk(prefix + ".interface"); ok {
@@ -783,6 +794,7 @@ func flattenDisk(disk *computeBeta.AttachedDisk, defaultProject string) (map[str
 		diskMap["disk_type"] = disk.InitializeParams.DiskType
 		diskMap["disk_name"] = disk.InitializeParams.DiskName
 		diskMap["disk_size_gb"] = disk.InitializeParams.DiskSizeGb
+		diskMap["labels"] = disk.InitializeParams.Labels
 	}
 
 	if disk.DiskEncryptionKey != nil {

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -1335,6 +1335,9 @@ resource "google_compute_instance_template" "foobar" {
 		auto_delete = true
 		disk_size_gb = 100
 		boot = true
+		labels = {
+			foo = "bar"
+		}
 	}
 
 	disk {

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -2676,6 +2676,9 @@ resource "google_compute_instance" "foobar" {
 		initialize_params {
 			image	= "${data.google_compute_image.my_image.self_link}"
 			type	= "%s"
+			labels  = {
+				foo = "bar"
+			}
 		}
 	}
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -182,6 +182,8 @@ The `initialize_params` block supports:
     For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
     These images can be referred by family name here.
 
+* `labels` - (Optional) A set of key/value label pairs to assign to the boot disk.
+
 The `scratch_disk` block supports:
 
 * `interface` - (Optional) The disk interface to use for attaching this disk; either SCSI or NVME.

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -287,6 +287,11 @@ The `disk` block supports:
 * `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
     `"PERSISTENT"`.
 
+* `labels` - (Optional) A set of key/value label pairs to assign to the disk.
+
+    If you are creating a new disk, these labels are added to the disk.
+    If you are attaching an existing disk, these labels are ignored.
+    
 * `disk_encryption_key` - (Optional) Encrypts or decrypts a disk using a customer-supplied encryption key.
 
     If you are creating a new disk, this field encrypts the new disk using an encryption key that you provide. If you are attaching an existing disk that is already encrypted, this field decrypts the disk using the customer-supplied encryption key.


### PR DESCRIPTION
This PR introduces a change that allows specifying labels in the **disk** block of a **google_compute_instance_template** resource and in the **boot_disk** block of a **google_compute_instance** resource.

The Google API allows setting labels in both of these contexts, so the change simply consists of modifying the resource schemas to allow a label map and then adding the code to retrieve the values from within the resource and set the correct parameters for the API request.