### PR TITLE
Add top-level services_ipv4_cidr to GKE clusters.

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -497,6 +497,11 @@ func resourceContainerCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"services_ipv4_cidr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"ip_allocation_policy": {
 				Type:       schema.TypeList,
 				MaxItems:   1,
@@ -902,6 +907,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("master_version", cluster.CurrentMasterVersion)
 	d.Set("node_version", cluster.CurrentNodeVersion)
 	d.Set("cluster_ipv4_cidr", cluster.ClusterIpv4Cidr)
+	d.Set("services_ipv4_cidr", cluster.ServicesIpv4Cidr)
 	d.Set("description", cluster.Description)
 	d.Set("enable_kubernetes_alpha", cluster.EnableKubernetesAlpha)
 	d.Set("enable_legacy_abac", cluster.LegacyAbac.Enabled)

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -86,6 +86,9 @@ func TestAccContainerCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerCluster_basic(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "services_ipv4_cidr"),
+				),
 			},
 			{
 				ResourceName:        "google_container_cluster.primary",

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -607,6 +607,11 @@ exported:
     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
     notation (e.g. `1.2.3.4/29`).
 
+* `services_ipv4_cidr` - The IP address range of the Kubernetes services in this
+  cluster, in [CIDR](http:en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+  notation (e.g. `1.2.3.4/29`). Service addresses are typically put in the last
+  `/16` from the container CIDR.
+
 <a id="timeouts"></a>
 ## Timeouts
 


### PR DESCRIPTION
There's a computed, output-only services_ipv4_cidr attribute for
GKE Clusters that we're currently not populating. This PR adds support
for them. See #3770.

```
=== RUN   TestAccContainerCluster_basic
=== PAUSE TestAccContainerCluster_basic
=== CONT  TestAccContainerCluster_basic
--- PASS: TestAccContainerCluster_basic (460.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 460.713s
```