### PR TITLE
Add lifecycle block for node pool resources

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -58,6 +58,10 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
       "https://www.googleapis.com/auth/monitoring",
     ]
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 ```
 

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -41,6 +41,10 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
       "https://www.googleapis.com/auth/monitoring",
     ]
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 ```
 
@@ -56,6 +60,10 @@ resource "google_container_node_pool" "np" {
   timeouts {
     create = "30m"
     update = "20m"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
**What:** Update `google_container_node_pool` documentation to include rolling update of their GKE node pools. 

**Why:** If users have only single node pool configured, this change will prevent users from destroying their only node pool when performing configuration change. Lifecycle blocks are good practice in general, so it makes sense to include it in default example. I believe it should be there by default and users can remove if they choose. 

Existing documentation is already using lifecycle blocks ([compute_ssl_certificate](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html), [compute_instance_template](https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager)).

