### PR TITLE
Document compute_backend_service set types

### DIFF
--- a/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # google\_compute\_backend\_service
 
-Provide acces to a Backend Service's attribute. For more information
+Provide access to a Backend Service's attribute. For more information
 see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
 and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
 
@@ -17,6 +17,11 @@ and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServ
 ```tf
 data "google_compute_backend_service" "baz" {
   name = "foobar"
+}
+
+resource "google_compute_backend_service" "default" {
+  name          = "backend-service"
+  health_checks = ["${tolist(data.google_compute_backend_service.baz.health_checks)[0]}"]
 }
 ```
 
@@ -52,6 +57,6 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `timeout_sec` - The number of seconds to wait for a backend to respond to a request before considering the request failed.
 
-* `backend` - The list of backends that serve this Backend Service.
+* `backend` - The set of backends that serve this Backend Service.
 
-* `health_checks` - The list of HTTP/HTTPS health checks used by the Backend Service.
+* `health_checks` - The set of HTTP/HTTPS health checks used by the Backend Service.

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `health_checks` -
   (Required)
-  The list of URLs to the HttpHealthCheck or HttpsHealthCheck resource
+  The set of URLs to the HttpHealthCheck or HttpsHealthCheck resource
   for health checking this BackendService. Currently at most one health
   check can be specified, and a health check is required.
   For internal load balancing, a URL to a HealthCheck resource must be specified instead.
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 * `backend` -
   (Optional)
-  The list of backends that serve this BackendService.  Structure is documented below.
+  The set of backends that serve this BackendService.  Structure is documented below.
 
 * `cdn_policy` -
   (Optional)


### PR DESCRIPTION
This PR clarifies documentation on an issue I encountered while upgrading to Terraform 0.12:

```tf
data "google_compute_backend_service" "k8s" {
  count = "${var.k8s_backend_service_name == "" ? 0 : 1}"
}

resource "google_compute_backend_service" "subdomains" {
  provider = "google-beta"
  # ...
  health_checks = [
    "${data.google_compute_backend_service.k8s.health_checks[0]}",
  ]
}
```

would resolve to the following error:

```
Error: Invalid index

  on ../modules/lb/main.tf line 34, in resource "google_compute_backend_service" "subdomains":
  34:     data.google_compute_backend_service.k8s.0.health_checks[0],

This value does not have any indices.
```

Turns out `health_checks` is [of type `TypeSet`](https://github.com/terraform-providers/terraform-provider-google/blob/master/google/resource_compute_backend_service.go#L140), so it needs to be converted to a list with `tolist` first: `tolist(data.google_compute_backend_service.k8s[0].health_checks)[0]`.

See a similar issue on the AWS provider [here](https://github.com/hashicorp/terraform/issues/21527).

(Also fixed a typo)
