### PR TITLE
Update container_cluster.html.markdown

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -49,7 +49,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     preemptible  = true
     machine_type = "n1-standard-1"
 
-    metadata {
+    metadata = {
       disable-legacy-endpoints = "true"
     }
 
@@ -84,7 +84,7 @@ resource "google_container_cluster" "primary" {
       "https://www.googleapis.com/auth/monitoring",
     ]
 
-    metadata {
+    metadata = {
       disable-legacy-endpoints = "true"
     }
 


### PR DESCRIPTION
Example of google_container_cluster resource in the doc didn't work due to lack of `=`