### PR TITLE
Use non-authoritative IAM policy

### DIFF
--- a/website/docs/r/logging_organization_sink.html.markdown
+++ b/website/docs/r/logging_organization_sink.html.markdown
@@ -33,12 +33,10 @@ resource "google_storage_bucket" "log-bucket" {
     name = "organization-logging-bucket"
 }
 
-resource "google_project_iam_binding" "log-writer" {
+resource "google_project_iam_member" "log-writer" {
     role    = "roles/storage.objectCreator"
 
-    members = [
-        "${google_logging_organization_sink.my-sink.writer_identity}",
-    ]
+    member = "${google_logging_organization_sink.my-sink.writer_identity}"
 }
 ```
 


### PR DESCRIPTION
What: Update `google_logging_organization_sink` example to use `google_project_iam_member` instead of `google_project_iam_binding`. 

Why: Provisioning two instances of the same example in a single project causes IAM binding to be removed from the other and vice versa. This is due to `google_project_iam_binding` being [authoritative](https://www.terraform.io/docs/providers/google/r/google_project_iam.html). I believe using `google_project_iam_member` is safer as there is no chance it will overwrite existing IAM policies. 