### PR TITLE
Updated composer output variables documentation for configs 

### DIFF
--- a/website/docs/r/composer_environment.html.markdown
+++ b/website/docs/r/composer_environment.html.markdown
@@ -282,17 +282,17 @@ The `software_config` block supports:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `config.gke_cluster` -
+* `config.0.gke_cluster` -
   The Kubernetes Engine cluster used to run this environment.
 
-* `config.dag_gcs_prefix` -
+* `config.0.dag_gcs_prefix` -
   The Cloud Storage prefix of the DAGs for this environment.
   Although Cloud Storage objects reside in a flat namespace, a
   hierarchical file tree can be simulated using '/'-delimited
   object name prefixes. DAG objects for this environment
   reside in a simulated directory with this prefix.
 
-* `config.airflow_uri` -
+* `config.0.airflow_uri` -
   The URI of the Apache Airflow Web UI hosted within this
   environment.
 


### PR DESCRIPTION
Terraform docs misleading - updated docs with proper configurations for Composer's config output variables 