### PR TITLE
Change datatype of compute_instance label

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
     **Note:** GPU accelerators can only be used with [`on_host_maintenance`](#on_host_maintenance) option set to TERMINATE.
 
-* `labels` - (Optional) A set of key/value label pairs to assign to the instance.
+* `labels` - (Optional) A map of key/value label pairs to assign to the instance.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance. Ssh keys attached in the Cloud Console will be removed.


### PR DESCRIPTION
Compute instance label has wrongly been specified as being a set.
It's actually a map.