### PR TITLE
Correct `zone` reference to `region` reference

### DIFF
--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -109,7 +109,7 @@ resides.
 has been deprecated in favor of `location`.
 
 * `region` - (Optional, Deprecated) The region in which the cluster resides (for
-regional clusters). `zone` has been deprecated in favor of `location`.
+regional clusters). `region` has been deprecated in favor of `location`.
 
 -> Note: You must specify a `location` for either cluster type or the
 type-specific `region` for regional clusters / `zone` for zonal clusters.


### PR DESCRIPTION
The description of the region field incorrectly references the zone field as deprecated. It should reference the region field as deprecated instead.