### PR TITLE
Fix nat_ips syntax in example

### DIFF
--- a/website/docs/r/compute_router_nat.html.markdown
+++ b/website/docs/r/compute_router_nat.html.markdown
@@ -83,7 +83,7 @@ resource "google_compute_router_nat" "advanced-nat" {
   router                             = "${google_compute_router.router.name}"
   region                             = "us-central1"
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = ["${google_compute_address.address.*.self_link}"]
+  nat_ips                            = "${google_compute_address.address[*].self_link}"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
     name                    = "${google_compute_subnetwork.default.self_link}"


### PR DESCRIPTION
Syntax in the previous version didn't work with Terraform 0.12. This update is based on discussion in #3980 