### PR TITLE
Fix: setting initial_node_count on imported resource forces full re-c…

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -290,7 +290,6 @@ func resourceContainerCluster() *schema.Resource {
 			"initial_node_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"logging_service": {


### PR DESCRIPTION
…reation of google_container_cluster resource

As stated by the documentation https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_pool to have a separately managed node pool one must set:
  remove_default_node_pool = true
  initial_node_count = 1

On imported google_container_cluster resource, node pool is not separately managed (ie. node_config attribute is in the resource). Setting "remove_default_node_pool = true" is working and allow to remove node_config attribute from code of resource to handle pool separately, but adding "initial_node_count = 1" forces recreation of resource whereas it seems to only be useful on the bootstrap of resource by terraform.

This fix allows using the same code for resource bootstraped via terraform or imported ones.

Workaround is to add in resource:
  lifecycle {
    ignore_changes = [initial_node_count, ]
  }