### PR TITLE
add ability to update Bigtable instance cluster node count

### DIFF
--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -178,7 +178,6 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("project", project)
 
 	clusters := d.Get("cluster").([]interface{})
-
 	clusterState := []map[string]interface{}{}
 	for _, cl := range clusters {
 		cluster := cl.(map[string]interface{})
@@ -194,7 +193,6 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	err = d.Set("cluster", clusterState)
-
 	if err != nil {
 		return fmt.Errorf("Error setting clusters in state: %s", err.Error())
 	}

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -316,9 +316,9 @@ func expandBigtableClusters(clusters []interface{}, instanceID string) []bigtabl
 func resourceBigtableInstanceClusterReorderTypeList(diff *schema.ResourceDiff, meta interface{}) error {
 	old_count, new_count := diff.GetChange("cluster.#")
 
-	// simulate Required:true and MinItems:1 for "cluster"
-	if new_count.(int) < 1 {
-		return fmt.Errorf("Error applying diff. Resource definition should contain one or more cluster blocks, got %d blocks", new_count.(int))
+	// simulate Required:true, MinItems:1, MaxItems:4 for "cluster"
+	if new_count.(int) < 1 || new_count.(int) > 4 {
+		return fmt.Errorf("Error applying diff. Resource definition should contain at least one cluster block but no more than four, got %d blocks", new_count.(int))
 	}
 
 	if old_count.(int) != new_count.(int) {

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -226,10 +226,6 @@ func resourceBigtableInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 	defer c.Close()
 
-	if d.Get("instance_type").(string) == "DEVELOPMENT" {
-		return resourceBigtableInstanceRead(d, meta)
-	}
-
 	clusters, err := c.Clusters(ctx, d.Get("name").(string))
 	if err != nil {
 		return fmt.Errorf("Error retrieving clusters for instance %s", err.Error())

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -317,8 +317,11 @@ func resourceBigtableInstanceClusterReorderTypeList(diff *schema.ResourceDiff, m
 	old_count, new_count := diff.GetChange("cluster.#")
 
 	// simulate Required:true, MinItems:1, MaxItems:4 for "cluster"
-	if new_count.(int) < 1 || new_count.(int) > 4 {
-		return fmt.Errorf("Error applying diff. Resource definition should contain at least one cluster block but no more than four, got %d blocks", new_count.(int))
+	if new_count.(int) < 1 {
+		return fmt.Errorf("config is invalid: Too few cluster blocks: Should have at least 1 \"cluster\" block")
+	}
+	if new_count.(int) > 4 {
+		return fmt.Errorf("config is invalid: Too many cluster blocks: No more than 4 \"cluster\" blocks are allowed")
 	}
 
 	if old_count.(int) != new_count.(int) {

--- a/google/resource_bigtable_instance_iam_test.go
+++ b/google/resource_bigtable_instance_iam_test.go
@@ -12,6 +12,7 @@ func TestAccBigtableInstanceIamBinding(t *testing.T) {
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + acctest.RandString(10)
+	cluster := "c-" + acctest.RandString(10)
 	account := "tf-bigtable-iam-" + acctest.RandString(10)
 	role := "roles/bigtable.user"
 
@@ -24,7 +25,7 @@ func TestAccBigtableInstanceIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccBigtableInstanceIamBinding_basic(instance, account, role),
+				Config: testAccBigtableInstanceIamBinding_basic(instance, cluster, account, role),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_bigtable_instance_iam_binding.binding", "role", role),
@@ -38,7 +39,7 @@ func TestAccBigtableInstanceIamBinding(t *testing.T) {
 			},
 			{
 				// Test IAM Binding update
-				Config: testAccBigtableInstanceIamBinding_update(instance, account, role),
+				Config: testAccBigtableInstanceIamBinding_update(instance, cluster, account, role),
 			},
 			{
 				ResourceName:      "google_bigtable_instance_iam_binding.binding",
@@ -54,6 +55,7 @@ func TestAccBigtableInstanceIamMember(t *testing.T) {
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + acctest.RandString(10)
+	cluster := "c-" + acctest.RandString(10)
 	account := "tf-bigtable-iam-" + acctest.RandString(10)
 	role := "roles/bigtable.user"
 
@@ -69,7 +71,7 @@ func TestAccBigtableInstanceIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccBigtableInstanceIamMember(instance, account, role),
+				Config: testAccBigtableInstanceIamMember(instance, cluster, account, role),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_bigtable_instance_iam_member.member", "role", role),
@@ -91,6 +93,7 @@ func TestAccBigtableInstanceIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + acctest.RandString(10)
+	cluster := "c-" + acctest.RandString(10)
 	account := "tf-bigtable-iam-" + acctest.RandString(10)
 	role := "roles/bigtable.user"
 
@@ -103,7 +106,7 @@ func TestAccBigtableInstanceIamPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccBigtableInstanceIamPolicy(instance, account, role),
+				Config: testAccBigtableInstanceIamPolicy(instance, cluster, account, role),
 			},
 			{
 				ResourceName:      "google_bigtable_instance_iam_policy.policy",
@@ -115,7 +118,7 @@ func TestAccBigtableInstanceIamPolicy(t *testing.T) {
 	})
 }
 
-func testAccBigtableInstanceIamBinding_basic(instance, account, role string) string {
+func testAccBigtableInstanceIamBinding_basic(instance, cluster, account, role string) string {
 	return fmt.Sprintf(testBigtableInstanceIam+`
 
 resource "google_service_account" "test-account1" {
@@ -135,10 +138,10 @@ resource "google_bigtable_instance_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account1.email}",
   ]
 }
-`, instance, acctest.RandString(10), account, account, role)
+`, instance, cluster, account, account, role)
 }
 
-func testAccBigtableInstanceIamBinding_update(instance, account, role string) string {
+func testAccBigtableInstanceIamBinding_update(instance, cluster, account, role string) string {
 	return fmt.Sprintf(testBigtableInstanceIam+`
 resource "google_service_account" "test-account1" {
   account_id   = "%s-1"
@@ -158,10 +161,10 @@ resource "google_bigtable_instance_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account2.email}",
   ]
 }
-`, instance, acctest.RandString(10), account, account, role)
+`, instance, cluster, account, account, role)
 }
 
-func testAccBigtableInstanceIamMember(instance, account, role string) string {
+func testAccBigtableInstanceIamMember(instance, cluster, account, role string) string {
 	return fmt.Sprintf(testBigtableInstanceIam+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -173,10 +176,10 @@ resource "google_bigtable_instance_iam_member" "member" {
   role         = "%s"
   member       = "serviceAccount:${google_service_account.test-account.email}"
 }
-`, instance, acctest.RandString(10), account, role)
+`, instance, cluster, account, role)
 }
 
-func testAccBigtableInstanceIamPolicy(instance, account, role string) string {
+func testAccBigtableInstanceIamPolicy(instance, cluster, account, role string) string {
 	return fmt.Sprintf(testBigtableInstanceIam+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -194,7 +197,7 @@ resource "google_bigtable_instance_iam_policy" "policy" {
   instance      = "${google_bigtable_instance.instance.name}"
   policy_data  = "${data.google_iam_policy.policy.policy_data}"
 }
-`, instance, acctest.RandString(10), account, role)
+`, instance, cluster, account, role)
 }
 
 // Smallest instance possible for testing
@@ -204,7 +207,7 @@ resource "google_bigtable_instance" "instance" {
     instance_type = "DEVELOPMENT"
 
     cluster {
-      cluster_id   = "c-%s"
+      cluster_id   = "%s"
       zone         = "us-central1-b"
       storage_type = "HDD"
     }

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -86,6 +86,14 @@ func TestAccBigtableInstance_development(t *testing.T) {
 		CheckDestroy: testAccCheckBigtableInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccBigtableInstance_development_invalid_no_cluster(instanceName),
+				ExpectError: regexp.MustCompile("config is invalid: instance with instance_type=\"DEVELOPMENT\" should have exactly one \"cluster\" block"),
+			},
+			{
+				Config:      testAccBigtableInstance_development_invalid_num_nodes(instanceName),
+				ExpectError: regexp.MustCompile("config is invalid: num_nodes cannot be set for instance_type=\"DEVELOPMENT\""),
+			},
+			{
 				Config: testAccBigtableInstance_development(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableInstanceExists(
@@ -298,4 +306,27 @@ resource "google_bigtable_instance" "instance" {
 	instance_type = "DEVELOPMENT"
 }
 `, instanceName, instanceName)
+}
+
+func testAccBigtableInstance_development_invalid_num_nodes(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+	name = "%s"
+	cluster {
+		cluster_id    = "%s"
+		zone          = "us-central1-b"
+        num_nodes     = 3
+	}
+	instance_type = "DEVELOPMENT"
+}
+`, instanceName, instanceName)
+}
+
+func testAccBigtableInstance_development_invalid_no_cluster(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+	name = "%s"
+	instance_type = "DEVELOPMENT"
+}
+`, instanceName)
 }

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -54,10 +54,17 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ExpectError: regexp.MustCompile("config is invalid: Too many cluster blocks: No more than 4 \"cluster\" blocks are allowed"),
 			},
 			{
-				Config: testAccBigtableInstance_cluster(instanceName),
+				Config: testAccBigtableInstance_cluster(instanceName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableInstanceExists(
 						"google_bigtable_instance.instance", 3),
+				),
+			},
+			{
+				Config: testAccBigtableInstance_cluster_reordered(instanceName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableInstanceExists(
+						"google_bigtable_instance.instance", 5),
 				),
 			},
 		},
@@ -166,36 +173,36 @@ resource "google_bigtable_instance" "instance" {
 `, instanceName, instanceName, numNodes)
 }
 
-func testAccBigtableInstance_cluster(instanceName string) string {
+func testAccBigtableInstance_cluster(instanceName string, numNodes int) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
 	name = "%s"
 	cluster {
 		cluster_id   = "%s-a"
 		zone         = "us-central1-a"
-		num_nodes    = 3
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
 		cluster_id   = "%s-b"
 		zone         = "us-central1-b"
-		num_nodes    = 3
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
 		cluster_id   = "%s-c"
 		zone         = "us-central1-c"
-		num_nodes    = 3
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
 		cluster_id   = "%s-d"
 		zone         = "us-central1-f"
-		num_nodes    = 3
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 }
-`, instanceName, instanceName, instanceName, instanceName, instanceName)
+`, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
 
 func testAccBigtableInstance_clusterMax(instanceName string) string {
@@ -217,23 +224,43 @@ resource "google_bigtable_instance" "instance" {
 	cluster {
 		cluster_id   = "%s-c"
 		zone         = "us-central1-c"
-		num_nodes    = 3
+		num_nodes    = %d
+		storage_type = "HDD"
+	}
+}
+`, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
+}
+
+func testAccBigtableInstance_cluster_reordered(instanceName string, numNodes int) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+	name = "%s"
+	cluster {
+		num_nodes    = %d
+		cluster_id   = "%s-b"
+		zone         = "us-central1-c"
 		storage_type = "HDD"
 	}
 	cluster {
 		cluster_id   = "%s-d"
 		zone         = "us-central1-f"
-		num_nodes    = 3
+		num_nodes    = %d
+		storage_type = "HDD"
+	}
+	cluster {
+		zone         = "us-central1-b"
+		cluster_id   = "%s-a"
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
 		cluster_id   = "%s-e"
 		zone         = "us-east1-a"
-		num_nodes    = 3
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 }
-`, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
+`, instanceName, numNodes, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName)
 }
 
 func testAccBigtableInstance_development(instanceName string) string {

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -117,8 +117,6 @@ func testAccBigtableInstanceExists(n string, numNodes int) resource.TestCheckFun
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		fmt.Println(s)
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}

--- a/google/resource_bigtable_instance_test.go
+++ b/google/resource_bigtable_instance_test.go
@@ -22,6 +22,10 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckBigtableInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccBigtableInstance_invalid(instanceName),
+				ExpectError: regexp.MustCompile("config is invalid: Too few cluster blocks: Should have at least 1 \"cluster\" block"),
+			},
+			{
 				Config: testAccBigtableInstance(instanceName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigtableInstanceExists(
@@ -173,6 +177,14 @@ resource "google_bigtable_instance" "instance" {
 `, instanceName, instanceName, numNodes)
 }
 
+func testAccBigtableInstance_invalid(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+	name = "%s"
+}
+`, instanceName)
+}
+
 func testAccBigtableInstance_cluster(instanceName string, numNodes int) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
@@ -202,7 +214,7 @@ resource "google_bigtable_instance" "instance" {
 		storage_type = "HDD"
 	}
 }
-`, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
+`, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
 
 func testAccBigtableInstance_clusterMax(instanceName string) string {
@@ -224,7 +236,19 @@ resource "google_bigtable_instance" "instance" {
 	cluster {
 		cluster_id   = "%s-c"
 		zone         = "us-central1-c"
-		num_nodes    = %d
+		num_nodes    = 3
+		storage_type = "HDD"
+	}
+	cluster {
+		cluster_id   = "%s-d"
+		zone         = "us-central1-f"
+		num_nodes    = 3
+		storage_type = "HDD"
+	}
+	cluster {
+		cluster_id   = "%s-e"
+		zone         = "us-east1-a"
+		num_nodes    = 3
 		storage_type = "HDD"
 	}
 }
@@ -236,9 +260,9 @@ func testAccBigtableInstance_cluster_reordered(instanceName string, numNodes int
 resource "google_bigtable_instance" "instance" {
 	name = "%s"
 	cluster {
-		num_nodes    = %d
-		cluster_id   = "%s-b"
+		cluster_id   = "%s-c"
 		zone         = "us-central1-c"
+		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
@@ -248,19 +272,19 @@ resource "google_bigtable_instance" "instance" {
 		storage_type = "HDD"
 	}
 	cluster {
-		zone         = "us-central1-b"
 		cluster_id   = "%s-a"
+		zone         = "us-central1-a"
 		num_nodes    = %d
 		storage_type = "HDD"
 	}
 	cluster {
-		cluster_id   = "%s-e"
-		zone         = "us-east1-a"
+		cluster_id   = "%s-b"
+		zone         = "us-central1-b"
 		num_nodes    = %d
 		storage_type = "HDD"
 	}
 }
-`, instanceName, numNodes, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName)
+`, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
 
 func testAccBigtableInstance_development(instanceName string) string {


### PR DESCRIPTION
This PR allows the Bigtable instance cluster `num_nodes` to updated without forcing the instance to be re-created. I also tried to support upgrading from a `DEVELOPMENT` to a `PRODUCTION` instance but the bigtable package only exposes that information at instance creation time. Switching to the `v2` admin API would allow this via [Instance.GetType](https://godoc.org/google.golang.org/genproto/googleapis/bigtable/admin/v2#Instance.GetType) but for now I've left the `instance_type` schema as `ForceNew`. All tests under `make testacc TEST=./google TESTARGS='-run=TestAccBigtableInstance*'` pass for me.

fixes #2521 