### PR TITLE
Use correct hyperlink in google_project_organization_policy data source.

### DIFF
--- a/website/docs/d/datasource_google_project_organization_policy.html.markdown
+++ b/website/docs/d/datasource_google_project_organization_policy.html.markdown
@@ -36,5 +36,5 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-See [google_project_organization_policy](https://www.terraform.io/docs/providers/google/r/google_project.html) resource for details of the available attributes.
+See [google_project_organization_policy](https://www.terraform.io/docs/providers/google/r/google_project_organization_policy.html) resource for details of the available attributes.
 


### PR DESCRIPTION
The hyperlink points to google_project instead of the intended google_project_organization_policy.