### PR TITLE
Correctly handle domain-scoped projects with GCR

### DIFF
--- a/google/data_source_container_registry_image.go
+++ b/google/data_source_container_registry_image.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -48,10 +49,11 @@ func containerRegistryImageRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("project", project)
 	region, ok := d.GetOk("region")
 	var url_base string
+	escapedProject := strings.Replace(project, ":", "/", -1)
 	if ok && region != nil && region != "" {
-		url_base = fmt.Sprintf("%s.gcr.io/%s", region, project)
+		url_base = fmt.Sprintf("%s.gcr.io/%s", region, escapedProject)
 	} else {
-		url_base = fmt.Sprintf("gcr.io/%s", project)
+		url_base = fmt.Sprintf("gcr.io/%s", escapedProject)
 	}
 	tag, t_ok := d.GetOk("tag")
 	digest, d_ok := d.GetOk("digest")

--- a/google/data_source_container_registry_repository.go
+++ b/google/data_source_container_registry_repository.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -35,10 +36,11 @@ func containerRegistryRepoRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("project", project)
 	region, ok := d.GetOk("region")
+	escapedProject := strings.Replace(project, ":", "/", -1)
 	if ok && region != nil && region != "" {
-		d.Set("repository_url", fmt.Sprintf("%s.gcr.io/%s", region, project))
+		d.Set("repository_url", fmt.Sprintf("%s.gcr.io/%s", region, escapedProject))
 	} else {
-		d.Set("repository_url", fmt.Sprintf("gcr.io/%s", project))
+		d.Set("repository_url", fmt.Sprintf("gcr.io/%s", escapedProject))
 	}
 	d.SetId(d.Get("repository_url").(string))
 	return nil

--- a/google/data_source_container_registry_test.go
+++ b/google/data_source_container_registry_test.go
@@ -9,7 +9,7 @@ import (
 func TestDataSourceGoogleContainerRegistryRepository(t *testing.T) {
 	t.Parallel()
 
-	resourceName := "data.google_container_registry_repository.default"
+	resourceName := "data.google_container_registry_repository.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -21,6 +21,8 @@ func TestDataSourceGoogleContainerRegistryRepository(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project"),
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "repository_url", "bar.gcr.io/foo"),
+					resource.TestCheckResourceAttrSet(resourceName+"Scoped", "project"),
+					resource.TestCheckResourceAttr(resourceName+"Scoped", "repository_url", "bar.gcr.io/example.com/foo"),
 				),
 			},
 		},
@@ -28,8 +30,12 @@ func TestDataSourceGoogleContainerRegistryRepository(t *testing.T) {
 }
 
 const testAccCheckGoogleContainerRegistryRepo_basic = `
-data "google_container_registry_repository" "default" {
+data "google_container_registry_repository" "test" {
 	project = "foo"
+	region = "bar"
+}
+data "google_container_registry_repository" "testScoped" {
+	project = "example.com:foo"
 	region = "bar"
 }
 `
@@ -51,6 +57,8 @@ func TestDataSourceGoogleContainerRegistryImage(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "image_url", "bar.gcr.io/foo/baz"),
 					resource.TestCheckResourceAttr(resourceName+"2", "image_url", "bar.gcr.io/foo/baz:qux"),
 					resource.TestCheckResourceAttr(resourceName+"3", "image_url", "bar.gcr.io/foo/baz@1234"),
+					resource.TestCheckResourceAttrSet(resourceName+"Scoped", "project"),
+					resource.TestCheckResourceAttr(resourceName+"Scoped", "image_url", "bar.gcr.io/example.com/foo/baz:qux"),
 				),
 			},
 		},
@@ -74,5 +82,11 @@ data "google_container_registry_image" "test3" {
 	region = "bar"
 	name = "baz"
 	digest = "1234"
+}
+data "google_container_registry_image" "testScoped" {
+	project = "example.com:foo"
+	region = "bar"
+	name = "baz"
+	tag = "qux"
 }
 `


### PR DESCRIPTION
Correctly escape domain-scoped project IDs when constructing a GCR URL.
* Related documentation:  https://cloud.google.com/container-registry/docs/overview#domain-scoped_projects

```releasenote
containerregistry: Correctly handle domain-scoped projects
```