### PR TITLE
Remove quotes from boolean

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -161,7 +161,7 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
-      ipv4_enabled = "false"
+      ipv4_enabled = false
       private_network = "${google_compute_network.private_network.self_link}"
     }
   }


### PR DESCRIPTION
Suggestion to remove quotes from boolean in the example as per https://github.com/terraform-providers/terraform-provider-google/blob/master/google/resource_sql_database_instance.go#L176