### PR TITLE
Fix typo, change 'pubsub_subscription' to 'bigtable_instance'

### DIFF
--- a/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/website/docs/r/bigtable_instance_iam.html.markdown
@@ -18,7 +18,7 @@ Three different resources help you manage IAM policies on bigtable instances. Ea
 
 ~> **Note:** `google_bigtable_instance_iam_binding` resources **can be** used in conjunction with `google_bigtable_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_pubsub\_subscription\_iam\_policy
+## google\_bigtable\_instance\_iam\_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -37,7 +37,7 @@ resource "google_bigtable_instance_iam_policy" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_binding
+## google\_bigtable\_instance\_iam\_binding
 
 ```hcl
 resource "google_bigtable_instance_iam_binding" "editor" {
@@ -49,7 +49,7 @@ resource "google_bigtable_instance_iam_binding" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_member
+## google\_bigtable\_instance\_iam\_member
 
 ```hcl
 resource "google_bigtable_instance_iam_member" "editor" {


### PR DESCRIPTION
On [bigtable_instance_iam](https://www.terraform.io/docs/providers/google/r/bigtable_instance_iam.html) page, the titles are labeled for "pubsub_subscription" not "bigtable_instance". This typo is fixed in this PR.