### PR TITLE
Add optional SA attribute for cloud funcs to docs

### DIFF
--- a/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -51,6 +51,7 @@ exported:
 * `event_trigger` - A source that fires events in response to a condition in another service. Structure is documented below.
 * `https_trigger_url` - If function is triggered by HTTP, trigger URL is set here.
 * `labels` - A map of labels applied to this function.
+* `service_account_email` - The service account email to be assumed by the cloud function.
 
 The `event_trigger` block contains:
 


### PR DESCRIPTION
The optional `service_account_email` key is missing from the docs for `google_cloudfunctions_function` -- it can be specified in both the API and the module, so I thought adding a reference to it here would make sense.