### PR TITLE
Remove bad option from example for compute_ssl_certificate docs

### DIFF
--- a/website/docs/d/datasource_compute_ssl_certificate.html.markdown
+++ b/website/docs/d/datasource_compute_ssl_certificate.html.markdown
@@ -15,7 +15,6 @@ Get info about a Google Compute SSL Certificate from its name.
 ```tf
 data "google_compute_ssl_certificate" "my_cert" {
   name       = "my-cert"
-  location   = "us-east1-a"
 }
 
 output "certificate" {


### PR DESCRIPTION
When using the example provided, the following error is returned:

```
Error: Unsupported argument

  on data.tf line 25, in data "google_compute_ssl_certificate" "api_cert":
  25:   location = "us-east1-a"

An argument named "location" is not expected here.
```

The available arguments doesn't list `location` as a supported argument. Remove it from the example.