### PR TITLE
Correct documentation about multiple ssl certificate usage

### DIFF
--- a/website/docs/r/compute_target_https_proxy.html.markdown
+++ b/website/docs/r/compute_target_https_proxy.html.markdown
@@ -110,8 +110,8 @@ The following arguments are supported:
 * `ssl_certificates` -
   (Required)
   A list of SslCertificate resources that are used to authenticate
-  connections between users and the load balancer. Currently, exactly
-  one SSL certificate must be specified.
+  connections between users and the load balancer. At least one SSL
+  certificate must be specified.
 
 * `url_map` -
   (Required)


### PR DESCRIPTION
The resource `google_compute_target_https_proxy`  attribute `ssl_certificates` is wrongly repoted in the doc as supporting only 1 certificate but goggle cloud supporte ;ultiple and in fact the code accept ;ultiple and it's working.