### PR TITLE
Update storage_notification.html.markdown

### DIFF
--- a/website/docs/r/storage_notification.html.markdown
+++ b/website/docs/r/storage_notification.html.markdown
@@ -26,7 +26,7 @@ for an example of enabling notifications by granting the correct IAM permission.
 resource "google_storage_notification" "notification" {
 	bucket            = "${google_storage_bucket.bucket.name}"
 	payload_format    = "JSON_API_V1"
-	topic             = "${google_pubsub_topic.topic.id}"
+	topic             = "${google_pubsub_topic.topic.name}"
 	event_types       = ["OBJECT_FINALIZE", "OBJECT_METADATA_UPDATE"]
 	custom_attributes = {
 		new-attribute = "new-attribute-value"


### PR DESCRIPTION
Should be topic name and not id. Was getting
```
google_storage_notification.notification: Error creating notification config for bucket some-bucket: googleapi: Error 403: The service account 'service-something@gs-project-accounts.iam.gserviceaccount.com' does not have permission to publish messages to to the Cloud Pub/Sub topic '//pubsub.googleapis.com/projects/foo/topics/some-topic', or that topic does not exist., forbidden
```