### PR TITLE
Log `go list` errors when linting.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,7 +26,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	GOPACKAGESPRINTGOLISTERRORS=1 golangci-lint run ./$(PKG_NAME)
+	GL_DEBUG=linters_output GOPACKAGESPRINTGOLISTERRORS=1 golangci-lint run -v ./$(PKG_NAME)
 
 tools:
 	@echo "==> installing required tooling..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,7 +26,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	@golangci-lint run ./$(PKG_NAME)
+	GOPACKAGESPRINTGOLISTERRORS=1 golangci-lint run ./$(PKG_NAME)
 
 tools:
 	@echo "==> installing required tooling..."


### PR DESCRIPTION
See golangci/golangci-lint#401.