### PR TITLE
Additional note: role_id must be camel case

### DIFF
--- a/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -37,7 +37,7 @@ resource "google_project_iam_custom_role" "my-custom-role" {
 
 The following arguments are supported:
 
-* `role_id` - (Required) The role id to use for this role.
+* `role_id` - (Required) The camel case role id to use for this role. Cannot contain `-` characters.
 
 * `title` - (Required) A human-readable title for the role.
 


### PR DESCRIPTION
The role_id's must be camel case, and cannot contain `-` characters, so I added those notes to the definition. I keep seeing people on our team try to use `-`'s, hence the explicit mention.