### PR TITLE
Increase make lint deadline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  deadline: 2m30s
+  modules-download-mode: vendor
+
 issues:
   max-per-linter: 0
   max-same-issues: 0
@@ -21,6 +25,3 @@ linters:
 linters-settings:
   errcheck:
     ignore: github.com/hashicorp/terraform/helper/schema:ForceNew|Set,fmt:.*,io:Close,github.com/terraform-providers/terraform-provider-google/google:Set
-
-run:
-  modules-download-mode: vendor


### PR DESCRIPTION
An upstream change to golangci made the `staticcheck` step much slower, as reflected in https://github.com/golangci/golangci-lint/issues/208 (and a handful of other issues in the repo). For now, let's increase our deadline to compensate.

They've nominally reduced the memory usage since, but we're still seeing a slowdown of 3-4x (~40s to ~140s) after those changes were applied. If this isn't resolved, we can use Go Modules to pin an older version prior to https://github.com/golangci/golangci-lint/pull/699 (the breaking commit) or investigate another linter.