### PR TITLE
[Website] Fix link path

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -16,7 +16,7 @@ and
 ~> **Warning:** As of November 1, 2019, newly created Functions are
 private-by-default and will require [appropriate IAM permissions](https://cloud.google.com/functions/docs/reference/iam/roles)
 to be invoked. See below examples for how to set up the appropriate permissions,
-or view the [Cloud Functions IAM resources](/docs/r/cloudfunctions_cloud_function_iam.html)
+or view the [Cloud Functions IAM resources](/docs/providers/google/r/cloudfunctions_cloud_function_iam.html)
 for Cloud Functions.
 
 ## Example Usage


### PR DESCRIPTION
The link path is broken causing the website build to fail. This change should fix it