### PR TITLE
Update google_service_account_key.html.markdown

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -38,7 +38,7 @@ resource "google_service_account_key" "mykey" {
 }
 
 resource "kubernetes_secret" "google-application-credentials" {
-  metadata = {
+  metadata {
     name = "google-application-credentials"
   }
   data = {

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "google-application-credentials" {
   metadata = {
     name = "google-application-credentials"
   }
-  data {
+  data = {
     credentials.json = "${base64decode(google_service_account_key.mykey.private_key)}"
   }
 }


### PR DESCRIPTION
There is an error in the syntax of `kubernetes_secret`. The `data` element is missing an `=`.

See also https://www.terraform.io/docs/providers/kubernetes/r/secret.html