### PR TITLE
Fix syntax highlighting issue from Example Usage

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -22,6 +22,7 @@ for Cloud Functions.
 ## Example Usage
 
 Secured function with a user allowed to invoke:
+
 ```hcl
 resource "google_storage_bucket" "bucket" {
   name = "test-bucket"


### PR DESCRIPTION
This section of the site:

> https://www.terraform.io/docs/providers/google/r/cloudfunctions_function.html#example-usage

Currently appears malformed. I believe this is because the opening code block too close to normal text. This just moves it down another line.