### PR TITLE
Support setting 'location' in google_sql_database_instance backup_configuration

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -118,6 +118,10 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 										// start_time is randomly assigned if not set
 										Computed: true,
 									},
+									"location": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -690,6 +694,7 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 		BinaryLogEnabled: _backupConfiguration["binary_log_enabled"].(bool),
 		Enabled:          _backupConfiguration["enabled"].(bool),
 		StartTime:        _backupConfiguration["start_time"].(string),
+		Location:         _backupConfiguration["location"].(string),
 	}
 }
 
@@ -898,6 +903,7 @@ func flattenBackupConfiguration(backupConfiguration *sqladmin.BackupConfiguratio
 		"binary_log_enabled": backupConfiguration.BinaryLogEnabled,
 		"enabled":            backupConfiguration.Enabled,
 		"start_time":         backupConfiguration.StartTime,
+		"location":           backupConfiguration.Location,
 	}
 
 	return []map[string]interface{}{data}

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -843,7 +843,8 @@ resource "google_sql_database_instance" "instance" {
 		availability_type = "REGIONAL"
 
 		backup_configuration {
-			enabled = true
+			enabled   = true
+            location  = "us"
 		}
 	}
 }


### PR DESCRIPTION
I would appreciate any feedback on this change. I am a newcomer to go, and to the terraform-provider-google project. I have added the feature to the best of my knowledge, and tested the creation of a new DB, as well as modifying the backup location after creation. I may have broken the tests, but it wasn't clear what I would have to do to get them to run locally.

Closes #4653 

```release-note:enhancement
`sql`: added `location` field to `backup_configuration` block in `google_sql_database_instance`
```
