### PR TITLE
Add retry on resource read for dns.ResourceRecordSetsListResponse

### DIFF
--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -141,7 +141,6 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
@@ -153,8 +152,13 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	dnsType := d.Get("type").(string)
 
-	resp, err := config.clientDns.ResourceRecordSets.List(
-		project, zone).Name(name).Type(dnsType).Do()
+	var resp *dns.ResourceRecordSetsListResponse
+	err = retry(func() error {
+		var reqErr error
+		resp, reqErr = config.clientDns.ResourceRecordSets.List(
+			project, zone).Name(name).Type(dnsType).Do()
+		return reqErr
+	})
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("DNS Record Set %q", d.Get("name").(string)))
 	}

--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -141,6 +141,7 @@ func resourceDnsRecordSetCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
 	project, err := getProject(d, config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hello,

I have 600 `google_dns_record_set` resources and I'm unable to plan or apply as GCP returns a lot of 503 errors (even with `--parallelism=1`):
```
Error reading DNS Record Set "xxx.": googleapi: Error 503: Backend Error, backendError
```
This PR implements retry and fixes this problem.