### PR TITLE
website: Add subcategories to docs for display on the Terraform Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 - make tools
 
 script:
+- make docscheck
 - make lint
 - make test
 - make website-test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,5 +56,8 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test
+docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
+.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test docscheck
 

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+  case "$category" in
+    "guides")
+      # Guides require a page_title
+      if ! grep "^page_title: " "$doc" > /dev/null; then
+        echo "Guide is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
+    "d" | "r")
+      # Resources and data sources require a subcategory
+      if ! grep "^subcategory: " "$doc" > /dev/null; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_config"
 sidebar_current: "docs-google-datasource-client-config"

--- a/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-datasource-cloudfunctions-function"

--- a/website/docs/d/datasource_compute_address.html.markdown
+++ b/website/docs/d/datasource_compute_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_address"
 sidebar_current: "docs-google-datasource-compute-address"

--- a/website/docs/d/datasource_compute_forwarding_rule.html.markdown
+++ b/website/docs/d/datasource_compute_forwarding_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_forwarding_rule"
 sidebar_current: "docs-google-datasource-compute-forwarding-rule"

--- a/website/docs/d/datasource_compute_global_address.html.markdown
+++ b/website/docs/d/datasource_compute_global_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_global_address"
 sidebar_current: "docs-google-datasource-compute-global-address"

--- a/website/docs/d/datasource_compute_image.html.markdown
+++ b/website/docs/d/datasource_compute_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_image"
 sidebar_current: "docs-google-datasource-compute-image"

--- a/website/docs/d/datasource_compute_instance.html.markdown
+++ b/website/docs/d/datasource_compute_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-datasource-compute-instance-x"

--- a/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
+++ b/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_lb_ip_ranges"
 sidebar_current: "docs-google-datasource-compute-lb-ip-ranges"

--- a/website/docs/d/datasource_compute_network.html.markdown
+++ b/website/docs/d/datasource_compute_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_network"
 sidebar_current: "docs-google-datasource-compute-network"

--- a/website/docs/d/datasource_compute_region_instance_group.html.markdown
+++ b/website/docs/d/datasource_compute_region_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group"
 sidebar_current: "docs-google-datasource-compute-region-instance-group"

--- a/website/docs/d/datasource_compute_ssl_certificate.html.markdown
+++ b/website/docs/d/datasource_compute_ssl_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_ssl_certificate"
 sidebar_current: "docs-google-datasource-compute-ssl-certificate"

--- a/website/docs/d/datasource_compute_ssl_policy.html.markdown
+++ b/website/docs/d/datasource_compute_ssl_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_ssl_policy"
 sidebar_current: "docs-google-datasource-compute-ssl-policy"

--- a/website/docs/d/datasource_compute_subnetwork.html.markdown
+++ b/website/docs/d/datasource_compute_subnetwork.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_subnetwork"
 sidebar_current: "docs-google-datasource-compute-subnetwork"

--- a/website/docs/d/datasource_compute_vpn_gateway.html.markdown
+++ b/website/docs/d/datasource_compute_vpn_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_vpn_gateway"
 sidebar_current: "docs-google-datasource-compute-vpn-gateway"

--- a/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
+++ b/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_openid_userinfo"
 sidebar_current: "docs-google-datasource-client-openid-userinfo"

--- a/website/docs/d/datasource_google_composer_image_versions.html.markdown
+++ b/website/docs/d/datasource_google_composer_image_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_composer_image_versions"
 sidebar_current: "docs-google-datasource-composer-image-versions"

--- a/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_backend_service"
 sidebar_current: "docs-google-datasource-compute-backend-service"

--- a/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
+++ b/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_network_endpoint_group"
 sidebar_current: "docs-google-datasource-compute-network-endpoint-group"

--- a/website/docs/d/datasource_google_folder_organization_policy.html.markdown
+++ b/website/docs/d/datasource_google_folder_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-datasource-folder-organization-policy"

--- a/website/docs/d/datasource_google_iam_role.html.markdown
+++ b/website/docs/d/datasource_google_iam_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_role"
 sidebar_current: "docs-google-datasource-iam-role"

--- a/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
+++ b/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_netblock_ip_ranges"
 sidebar_current: "docs-google-datasource-netblock-ip-ranges"

--- a/website/docs/d/datasource_google_project_organization_policy.html.markdown
+++ b/website/docs/d/datasource_google_project_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-datasource-project-organization-policy"

--- a/website/docs/d/datasource_google_service_account.html.markdown
+++ b/website/docs/d/datasource_google_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-datasource-service-account"

--- a/website/docs/d/datasource_google_service_account_access_token.html.markdown
+++ b/website/docs/d/datasource_google_service_account_access_token.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_access_token"
 sidebar_current: "docs-google-service-account-access-token"

--- a/website/docs/d/datasource_google_service_account_key.html.markdown
+++ b/website/docs/d/datasource_google_service_account_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-datasource-service-account-key"

--- a/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
+++ b/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_tpu_tensorflow_versions"
 sidebar_current: "docs-google-datasource-tpu-tensorflow-versions"

--- a/website/docs/d/dns_managed_zone.html.markdown
+++ b/website/docs/d/dns_managed_zone.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_dns_managed_zone"
 sidebar_current: "docs-google-datasource-dns-managed-zone"

--- a/website/docs/d/google_active_folder.html.markdown
+++ b/website/docs/d/google_active_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_active_folder"
 sidebar_current: "docs-google-datasource-active-folder"

--- a/website/docs/d/google_billing_account.html.markdown
+++ b/website/docs/d/google_billing_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account"
 sidebar_current: "docs-google-datasource-billing-account"

--- a/website/docs/d/google_compute_default_service_account.html.markdown
+++ b/website/docs/d/google_compute_default_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_default_service_account"
 sidebar_current: "docs-google-datasource-compute-default-service-account"

--- a/website/docs/d/google_compute_instance_group.html.markdown
+++ b/website/docs/d/google_compute_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-datasource-compute-instance-group"

--- a/website/docs/d/google_compute_node_types.html.markdown
+++ b/website/docs/d/google_compute_node_types.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_node_types"
 sidebar_current: "docs-google-datasource-compute-node-types"

--- a/website/docs/d/google_compute_regions.html.markdown
+++ b/website/docs/d/google_compute_regions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_regions"
 sidebar_current: "docs-google-datasource-compute-regions"

--- a/website/docs/d/google_compute_zones.html.markdown
+++ b/website/docs/d/google_compute_zones.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_zones"
 sidebar_current: "docs-google-datasource-compute-zones"

--- a/website/docs/d/google_container_cluster.html.markdown
+++ b/website/docs/d/google_container_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-datasource-container-cluster"

--- a/website/docs/d/google_container_engine_versions.html.markdown
+++ b/website/docs/d/google_container_engine_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_engine_versions"
 sidebar_current: "docs-google-datasource-container-versions"

--- a/website/docs/d/google_container_registry_image.html.markdown
+++ b/website/docs/d/google_container_registry_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_registry_image"
 sidebar_current: "docs-google-datasource-container-image"

--- a/website/docs/d/google_container_registry_repository.html.markdown
+++ b/website/docs/d/google_container_registry_repository.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_registry_repository"
 sidebar_current: "docs-google-datasource-container-repo"

--- a/website/docs/d/google_folder.html.markdown
+++ b/website/docs/d/google_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-datasource-folder"

--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_policy"
 sidebar_current: "docs-google-datasource-iam-policy"

--- a/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/website/docs/d/google_kms_key_ring.html.markdown
+++ b/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/website/docs/d/google_kms_secret.html.markdown
+++ b/website/docs/d/google_kms_secret.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"

--- a/website/docs/d/google_organization.html.markdown
+++ b/website/docs/d/google_organization.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization"
 sidebar_current: "docs-google-datasource-organization"

--- a/website/docs/d/google_project.html.markdown
+++ b/website/docs/d/google_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-datasource-project"

--- a/website/docs/d/google_project_services.html.markdown
+++ b/website/docs/d/google_project_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-datasource-project-services"

--- a/website/docs/d/google_projects.html.markdown
+++ b/website/docs/d/google_projects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_projects"
 sidebar_current: "docs-google-datasource-projects"

--- a/website/docs/d/google_storage_project_service_account.html.markdown
+++ b/website/docs/d/google_storage_project_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_project_service_account"
 sidebar_current: "docs-google-datasource-storage-project-service-account"

--- a/website/docs/d/google_storage_transfer_project_service_account.html.markdown
+++ b/website/docs/d/google_storage_transfer_project_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_transfer_project_service_account"
 sidebar_current: "docs-google-datasource-storage-transfer-project-service-account"

--- a/website/docs/d/signed_url.html.markdown
+++ b/website/docs/d/signed_url.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_object_signed_url"
 sidebar_current: "docs-google-datasource-signed_url"

--- a/website/docs/d/storage_bucket_object.html.markdown
+++ b/website/docs/d/storage_bucket_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-datasource-storage-bucket-object"

--- a/website/docs/r/app_engine_application.html.markdown
+++ b/website/docs/r/app_engine_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 layout: "google"
 page_title: "Google: google_app_engine_application"
 sidebar_current: "docs-google-app-engine-application"

--- a/website/docs/r/app_engine_application_url_dispatch_rules.html.markdown
+++ b/website/docs/r/app_engine_application_url_dispatch_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/app_engine_domain_mapping.html.markdown
+++ b/website/docs/r/app_engine_domain_mapping.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/app_engine_firewall_rule.html.markdown
+++ b/website/docs/r/app_engine_firewall_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/app_engine_standard_app_version.html.markdown
+++ b/website/docs/r/app_engine_standard_app_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/bigquery_data_transfer_config.html.markdown
+++ b/website/docs/r/bigquery_data_transfer_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google BigQuery Data Transfer"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google BigQuery"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google BigQuery"
 layout: "google"
 page_title: "Google: google_bigquery_table"
 sidebar_current: "docs-google-bigquery-table"

--- a/website/docs/r/bigtable_app_profile.html.markdown
+++ b/website/docs/r/bigtable_app_profile.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_gc_policy"
 sidebar_current: "docs-google-bigtable-gc-policy"

--- a/website/docs/r/bigtable_instance.html.markdown
+++ b/website/docs/r/bigtable_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance"
 sidebar_current: "docs-google-bigtable-instance"

--- a/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/website/docs/r/bigtable_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance_iam"
 sidebar_current: "docs-google-bigtable-instance-iam"

--- a/website/docs/r/bigtable_table.html.markdown
+++ b/website/docs/r/bigtable_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_table"
 sidebar_current: "docs-google-bigtable-table"

--- a/website/docs/r/binary_authorization_attestor.html.markdown
+++ b/website/docs/r/binary_authorization_attestor.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google Binary Authorization"
 layout: "google"
 page_title: "Google: google_binary_authorization_attestor"
 sidebar_current: "docs-google-binary-authorization-attestor"

--- a/website/docs/r/binary_authorization_attestor_iam.html.markdown
+++ b/website/docs/r/binary_authorization_attestor_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google Binary Authorization"
 layout: "google"
 page_title: "Google: google_binary_authorization_attestor_iam"
 sidebar_current: "docs-google-binary-authorization-attestor-iam"

--- a/website/docs/r/binary_authorization_policy.html.markdown
+++ b/website/docs/r/binary_authorization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Binary Authorization"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Build"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/cloudfunctions_cloud_function_iam.html.markdown
+++ b/website/docs/r/cloudfunctions_cloud_function_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function_iam"
 sidebar_current: "docs-google-cloudfunctions-function-iam"

--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-cloudfunctions-function"

--- a/website/docs/r/cloudiot_registry.html.markdown
+++ b/website/docs/r/cloudiot_registry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud IoT Core"
 layout: "google"
 page_title: "Google: google_cloudiot_registry"
 sidebar_current: "docs-google-cloudiot-registry-x"

--- a/website/docs/r/composer_environment.html.markdown
+++ b/website/docs/r/composer_environment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Composer"
 layout: "google"
 page_title: "Google: google_composer_environment"
 sidebar_current: "docs-google-composer-environment"

--- a/website/docs/r/compute_address.html.markdown
+++ b/website/docs/r/compute_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_attached_disk.html.markdown
+++ b/website/docs/r/compute_attached_disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_attached_disk"
 sidebar_current: "docs-google-compute-attached-disk"

--- a/website/docs/r/compute_autoscaler.html.markdown
+++ b/website/docs/r/compute_autoscaler.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_backend_bucket.html.markdown
+++ b/website/docs/r/compute_backend_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
+++ b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_backend_service.html.markdown
+++ b/website/docs/r/compute_backend_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_backend_service_signed_url_key.html.markdown
+++ b/website/docs/r/compute_backend_service_signed_url_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_disk.html.markdown
+++ b/website/docs/r/compute_disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_disk_resource_policy_attachment.html.markdown
+++ b/website/docs/r/compute_disk_resource_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_health_check.html.markdown
+++ b/website/docs/r/compute_health_check.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_http_health_check.html.markdown
+++ b/website/docs/r/compute_http_health_check.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_https_health_check.html.markdown
+++ b/website/docs/r/compute_https_health_check.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_image.html.markdown
+++ b/website/docs/r/compute_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-compute-instance-x"

--- a/website/docs/r/compute_instance_from_template.html.markdown
+++ b/website/docs/r/compute_instance_from_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_from_template"
 sidebar_current: "docs-google-compute-instance-from-template"

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-compute-instance-group-x"

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group_manager"
 sidebar_current: "docs-google-compute-instance-group-manager"

--- a/website/docs/r/compute_instance_iam.html.markdown
+++ b/website/docs/r/compute_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_iam"
 sidebar_current: "docs-google-compute-instance-iam"

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_template"
 sidebar_current: "docs-google-compute-instance-template"

--- a/website/docs/r/compute_interconnect_attachment.html.markdown
+++ b/website/docs/r/compute_interconnect_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_network.html.markdown
+++ b/website/docs/r/compute_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_network_peering.html.markdown
+++ b/website/docs/r/compute_network_peering.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network_peering"
 sidebar_current: "docs-google-compute-network-peering"

--- a/website/docs/r/compute_node_group.html.markdown
+++ b/website/docs/r/compute_node_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_node_template.html.markdown
+++ b/website/docs/r/compute_node_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_default_network_tier"
 sidebar_current: "docs-google-compute-project-default-network-tier"

--- a/website/docs/r/compute_project_metadata.html.markdown
+++ b/website/docs/r/compute_project_metadata.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata"
 sidebar_current: "docs-google-compute-project-metadata"

--- a/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/website/docs/r/compute_project_metadata_item.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata_item"
 sidebar_current: "docs-google-compute-project-metadata-item"

--- a/website/docs/r/compute_region_autoscaler.html.markdown
+++ b/website/docs/r/compute_region_autoscaler.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_region_backend_service.html.markdown
+++ b/website/docs/r/compute_region_backend_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_region_disk.html.markdown
+++ b/website/docs/r/compute_region_disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group_manager"
 sidebar_current: "docs-google-compute-region_instance-group-manager"

--- a/website/docs/r/compute_reservation.html.markdown
+++ b/website/docs/r/compute_reservation.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_resource_policy.html.markdown
+++ b/website/docs/r/compute_resource_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_route.html.markdown
+++ b/website/docs/r/compute_route.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_router.html.markdown
+++ b/website/docs/r/compute_router.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_router_interface.html.markdown
+++ b/website/docs/r/compute_router_interface.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_interface"
 sidebar_current: "docs-google-compute-router-interface"

--- a/website/docs/r/compute_router_nat.html.markdown
+++ b/website/docs/r/compute_router_nat.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_router_peer.html.markdown
+++ b/website/docs/r/compute_router_peer.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_peer"
 sidebar_current: "docs-google-compute-router-peer"

--- a/website/docs/r/compute_security_policy.html.markdown
+++ b/website/docs/r/compute_security_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_security_policy"
 sidebar_current: "docs-google-compute-security-policy"

--- a/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_host_project"
 sidebar_current: "docs-google-compute-shared-vpc-host-project"

--- a/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_service_project"
 sidebar_current: "docs-google-compute-shared-vpc-service-project"

--- a/website/docs/r/compute_snapshot.html.markdown
+++ b/website/docs/r/compute_snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_ssl_certificate.html.markdown
+++ b/website/docs/r/compute_ssl_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_ssl_policy.html.markdown
+++ b/website/docs/r/compute_ssl_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_subnetwork.html.markdown
+++ b/website/docs/r/compute_subnetwork.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_subnetwork_iam.html.markdown
+++ b/website/docs/r/compute_subnetwork_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_subnetwork_iam"
 sidebar_current: "docs-google-compute-subnetwork-iam"

--- a/website/docs/r/compute_target_http_proxy.html.markdown
+++ b/website/docs/r/compute_target_http_proxy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_target_https_proxy.html.markdown
+++ b/website/docs/r/compute_target_https_proxy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_target_instance.html.markdown
+++ b/website/docs/r/compute_target_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_target_pool.html.markdown
+++ b/website/docs/r/compute_target_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_target_pool"
 sidebar_current: "docs-google-compute-target-pool"

--- a/website/docs/r/compute_target_ssl_proxy.html.markdown
+++ b/website/docs/r/compute_target_ssl_proxy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_target_tcp_proxy.html.markdown
+++ b/website/docs/r/compute_target_tcp_proxy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_url_map.html.markdown
+++ b/website/docs/r/compute_url_map.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_vpn_gateway.html.markdown
+++ b/website/docs/r/compute_vpn_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/compute_vpn_tunnel.html.markdown
+++ b/website/docs/r/compute_vpn_tunnel.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/container_analysis_note.html.markdown
+++ b/website/docs/r/container_analysis_note.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Container Analysis"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-container-cluster"

--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_node_pool"
 sidebar_current: "docs-google-container-node-pool"

--- a/website/docs/r/dataflow_job.html.markdown
+++ b/website/docs/r/dataflow_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataflow"
 layout: "google"
 page_title: "Google: google_dataflow_job"
 sidebar_current: "docs-google-dataflow-job"

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster"
 sidebar_current: "docs-google-dataproc-cluster"

--- a/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster_iam"
 sidebar_current: "docs-google-dataproc-cluster-iam"

--- a/website/docs/r/dataproc_job.html.markdown
+++ b/website/docs/r/dataproc_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job"
 sidebar_current: "docs-google-dataproc-job"

--- a/website/docs/r/dataproc_job_iam.html.markdown
+++ b/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job_iam"
 sidebar_current: "docs-google-dataproc-job-iam"

--- a/website/docs/r/dns_managed_zone.html.markdown
+++ b/website/docs/r/dns_managed_zone.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google DNS"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google DNS"
 layout: "google"
 page_title: "Google: google_dns_record_set"
 sidebar_current: "docs-google-dns-record-set"

--- a/website/docs/r/endpoints_service.html.markdown
+++ b/website/docs/r/endpoints_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Endpoints"
 layout: "google"
 page_title: "Google: google_endpoints_service"
 sidebar_current: "docs-google-endpoints-service"

--- a/website/docs/r/filestore_instance.html.markdown
+++ b/website/docs/r/filestore_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Filestore"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/firestore_index.html.markdown
+++ b/website/docs/r/firestore_index.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Firestore"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/google_billing_account_iam_binding.md
+++ b/website/docs/r/google_billing_account_iam_binding.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_binding"
 sidebar_current: "docs-google-billing-account-iam-binding"

--- a/website/docs/r/google_billing_account_iam_member.md
+++ b/website/docs/r/google_billing_account_iam_member.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_member"
 sidebar_current: "docs-google-billing-account-iam-member"

--- a/website/docs/r/google_billing_account_iam_policy.md
+++ b/website/docs/r/google_billing_account_iam_policy.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_policy"
 sidebar_current: "docs-google-billing-account-iam-policy"

--- a/website/docs/r/google_folder.html.markdown
+++ b/website/docs/r/google_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-folder-x"

--- a/website/docs/r/google_folder_iam_binding.html.markdown
+++ b/website/docs/r/google_folder_iam_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_binding"
 sidebar_current: "docs-google-folder-iam-binding"

--- a/website/docs/r/google_folder_iam_member.html.markdown
+++ b/website/docs/r/google_folder_iam_member.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_member"
 sidebar_current: "docs-google-folder-iam-member"

--- a/website/docs/r/google_folder_iam_policy.html.markdown
+++ b/website/docs/r/google_folder_iam_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_policy"
 sidebar_current: "docs-google-folders-iam-policy"

--- a/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/website/docs/r/google_folder_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-folder-organization-policy"

--- a/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
+++ b/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_binding"
 sidebar_current: "docs-google-kms-crypto-key-iam-binding"

--- a/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
+++ b/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_member"
 sidebar_current: "docs-google-kms-crypto-key-iam-member"

--- a/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring_iam"
 sidebar_current: "docs-google-kms-key-ring-iam"

--- a/website/docs/r/google_organization_iam_binding.md
+++ b/website/docs/r/google_organization_iam_binding.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_binding"
 sidebar_current: "docs-google-organization-iam-binding"

--- a/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_custom_role"
 sidebar_current: "docs-google-organization-iam-custom-role"

--- a/website/docs/r/google_organization_iam_member.md
+++ b/website/docs/r/google_organization_iam_member.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_member"
 sidebar_current: "docs-google-organization-iam-member"

--- a/website/docs/r/google_organization_iam_policy.md
+++ b/website/docs/r/google_organization_iam_policy.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_policy"
 sidebar_current: "docs-google-organization-iam-policy"

--- a/website/docs/r/google_organization_policy.html.markdown
+++ b/website/docs/r/google_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_policy"
 sidebar_current: "docs-google-organization-policy"

--- a/website/docs/r/google_project.html.markdown
+++ b/website/docs/r/google_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-project-x"

--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam"
 sidebar_current: "docs-google-project-iam-x"

--- a/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam_custom_role"
 sidebar_current: "docs-google-project-iam-custom-role"

--- a/website/docs/r/google_project_organization_policy.html.markdown
+++ b/website/docs/r/google_project_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-project-organization-policy"

--- a/website/docs/r/google_project_service.html.markdown
+++ b/website/docs/r/google_project_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_service"
 sidebar_current: "docs-google-project-service-x"

--- a/website/docs/r/google_project_services.html.markdown
+++ b/website/docs/r/google_project_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-project-services"

--- a/website/docs/r/google_service_account.html.markdown
+++ b/website/docs/r/google_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-service-account-x"

--- a/website/docs/r/google_service_account_iam.html.markdown
+++ b/website/docs/r/google_service_account_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_iam"
 sidebar_current: "docs-google-service-account-iam"
@@ -193,3 +194,4 @@ With conditions:
 $ terraform import -provider=google-beta google_service_account_iam_binding.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser expires_after_2019_12_31"
 
 $ terraform import -provider=google-beta google_service_account_iam_member.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser user:foo@example.com expires_after_2019_12_31"
+```

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-service-account-key"

--- a/website/docs/r/iap_app_engine_service_iam.html.markdown
+++ b/website/docs/r/iap_app_engine_service_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_app_engine_service_iam"
 sidebar_current: "docs-google-iap-app-engine-service-iam"

--- a/website/docs/r/iap_app_engine_version_iam.html.markdown
+++ b/website/docs/r/iap_app_engine_version_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_app_engine_version_iam"
 sidebar_current: "docs-google-iap-app-engine-version-iam"

--- a/website/docs/r/iap_web_backend_service_iam.html.markdown
+++ b/website/docs/r/iap_web_backend_service_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_web_backend_service_iam"
 sidebar_current: "docs-google-iap-web-backend-service-iam"

--- a/website/docs/r/iap_web_iam.html.markdown
+++ b/website/docs/r/iap_web_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_web_iam"
 sidebar_current: "docs-google-iap-web-iam"

--- a/website/docs/r/iap_web_type_app_engine_iam.html.markdown
+++ b/website/docs/r/iap_web_type_app_engine_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_web_type_app_engine_iam"
 sidebar_current: "docs-google-iap-web-type-app-engine-iam"

--- a/website/docs/r/iap_web_type_compute_iam.html.markdown
+++ b/website/docs/r/iap_web_type_compute_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google IAP"
 layout: "google"
 page_title: "Google: google_iap_web_type_compute_iam"
 sidebar_current: "docs-google-iap-web-type-compute-iam"

--- a/website/docs/r/kms_crypto_key.html.markdown
+++ b/website/docs/r/kms_crypto_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/kms_key_ring.html.markdown
+++ b/website/docs/r/kms_key_ring.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_exclusion"
 sidebar_current: "docs-google-logging-billing_account-exclusion"

--- a/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/website/docs/r/logging_billing_account_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_sink"
 sidebar_current: "docs-google-logging-billing-account-sink"

--- a/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/website/docs/r/logging_folder_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_exclusion"
 sidebar_current: "docs-google-logging-folder-exclusion"

--- a/website/docs/r/logging_folder_sink.html.markdown
+++ b/website/docs/r/logging_folder_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_sink"
 sidebar_current: "docs-google-logging-folder-sink"

--- a/website/docs/r/logging_metric.html.markdown
+++ b/website/docs/r/logging_metric.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/website/docs/r/logging_organization_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_exclusion"
 sidebar_current: "docs-google-logging-organization-exclusion"

--- a/website/docs/r/logging_organization_sink.html.markdown
+++ b/website/docs/r/logging_organization_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_sink"
 sidebar_current: "docs-google-logging-organization-sink"

--- a/website/docs/r/logging_project_exclusion.html.markdown
+++ b/website/docs/r/logging_project_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_exclusion"
 sidebar_current: "docs-google-logging-project-exclusion"

--- a/website/docs/r/logging_project_sink.html.markdown
+++ b/website/docs/r/logging_project_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_sink"
 sidebar_current: "docs-google-logging-project-sink"

--- a/website/docs/r/ml_engine_model.html.markdown
+++ b/website/docs/r/ml_engine_model.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google ML Engine"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/monitoring_alert_policy.html.markdown
+++ b/website/docs/r/monitoring_alert_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Monitoring"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/monitoring_group.html.markdown
+++ b/website/docs/r/monitoring_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Monitoring"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/monitoring_notification_channel.html.markdown
+++ b/website/docs/r/monitoring_notification_channel.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Monitoring"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/monitoring_uptime_check_config.html.markdown
+++ b/website/docs/r/monitoring_uptime_check_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Monitoring"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google PubSub"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google PubSub"
 layout: "google"
 page_title: "Google: google_pubsub_subscription_iam"
 sidebar_current: "docs-google-pubsub-subscription-iam"

--- a/website/docs/r/pubsub_topic.html.markdown
+++ b/website/docs/r/pubsub_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google PubSub"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/pubsub_topic_iam.html.markdown
+++ b/website/docs/r/pubsub_topic_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google PubSub"
 layout: "google"
 page_title: "Google: google_pubsub_topic_iam"
 sidebar_current: "docs-google-pubsub-topic-iam"

--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Redis (Cloud Memorystore)"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/resource_manager_lien.html.markdown
+++ b/website/docs/r/resource_manager_lien.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/runtimeconfig_config.html.markdown
+++ b/website/docs/r/runtimeconfig_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_config"
 sidebar_current: "docs-google-runtimeconfig-config"

--- a/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/website/docs/r/runtimeconfig_variable.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_variable"
 sidebar_current: "docs-google-runtimeconfig-variable"

--- a/website/docs/r/scc_source.html.markdown
+++ b/website/docs/r/scc_source.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Security Command Center (SCC)"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/service_networking_connection.html.markdown
+++ b/website/docs/r/service_networking_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Service Networking"
 layout: "google"
 page_title: "Google: google_service_networking_connection"
 sidebar_current: "docs-google-service-networking-connection"

--- a/website/docs/r/sourcerepo_repository.html.markdown
+++ b/website/docs/r/sourcerepo_repository.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Source Repositories"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/sourcerepo_repository_iam.html.markdown
+++ b/website/docs/r/sourcerepo_repository_iam.html.markdown
@@ -12,6 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
+subcategory: "Google Source Repositories"
 layout: "google"
 page_title: "Google: google_sourcerepo_repository_iam"
 sidebar_current: "docs-google-sourcerepo-repository-iam"

--- a/website/docs/r/spanner_database.html.markdown
+++ b/website/docs/r/spanner_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/spanner_database_iam.html.markdown
+++ b/website/docs/r/spanner_database_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 layout: "google"
 page_title: "Google: google_spanner_database_iam"
 sidebar_current: "docs-google-spanner-database-iam"

--- a/website/docs/r/spanner_instance.html.markdown
+++ b/website/docs/r/spanner_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/spanner_instance_iam.html.markdown
+++ b/website/docs/r/spanner_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 layout: "google"
 page_title: "Google: google_spanner_instance_iam"
 sidebar_current: "docs-google-spanner-instance-iam"

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_database_instance"
 sidebar_current: "docs-google-sql-database-instance"

--- a/website/docs/r/sql_ssl_cert.html.markdown
+++ b/website/docs/r/sql_ssl_cert.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_ssl_cert"
 sidebar_current: "docs-google-sql-ssl-cert"

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_user"
 sidebar_current: "docs-google-sql-user"

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket"
 sidebar_current: "docs-google-storage-bucket-x"

--- a/website/docs/r/storage_bucket_access_control.html.markdown
+++ b/website/docs/r/storage_bucket_access_control.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/storage_bucket_acl.html.markdown
+++ b/website/docs/r/storage_bucket_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_acl"
 sidebar_current: "docs-google-storage-bucket-acl"

--- a/website/docs/r/storage_bucket_iam.html.markdown
+++ b/website/docs/r/storage_bucket_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_iam"
 sidebar_current: "docs-google-storage-bucket-iam"

--- a/website/docs/r/storage_bucket_object.html.markdown
+++ b/website/docs/r/storage_bucket_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-storage-bucket-object"

--- a/website/docs/r/storage_default_object_access_control.html.markdown
+++ b/website/docs/r/storage_default_object_access_control.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/storage_default_object_acl.html.markdown
+++ b/website/docs/r/storage_default_object_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_default_object_acl"
 sidebar_current: "docs-google-storage-default-object-acl"

--- a/website/docs/r/storage_notification.html.markdown
+++ b/website/docs/r/storage_notification.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_notification"
 sidebar_current: "docs-google-storage-notification"

--- a/website/docs/r/storage_object_access_control.html.markdown
+++ b/website/docs/r/storage_object_access_control.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/storage_object_acl.html.markdown
+++ b/website/docs/r/storage_object_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_object_acl"
 sidebar_current: "docs-google-storage-object-acl"

--- a/website/docs/r/storage_transfer_job.html.markdown
+++ b/website/docs/r/storage_transfer_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage Transfer"
 layout: "google"
 page_title: "Google: google_storage_transfer_job"
 sidebar_current: "docs-google-storage-transfer-job-x"

--- a/website/docs/r/tpu_node.html.markdown
+++ b/website/docs/r/tpu_node.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud TPU"
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/website/docs/r/usage_export_bucket.html.markdown
+++ b/website/docs/r/usage_export_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_usage_export_bucket"
 sidebar_current: "docs-google-project-usage-export-bucket"


### PR DESCRIPTION
We will soon be displaying documentation for this provider both on [terraform.io](https://www.terraform.io/docs/providers/index.html) and on [the Terraform Registry](https://registry.terraform.io/providers).

Documentation displayed on the Terraform Registry will not use the ERB layout containing the existing navigation, and will instead build the navigation dynamically based on the directory and YAML frontmatter of a file. For providers that group similar resources and data sources by service or use case (subcategories), we'll need to add this information to the Markdown source file.

This PR modifies resource and data source documentation source files by adding a subcategory to the metadata if those files are currently grouped on terraform.io.

For more information about how documentation is rendered on the Terraform Registry, please see this reference: [Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).