### PR TITLE
Fixed description of `ip_configuration` in docs

### DIFF
--- a/website/docs/r/dataflow_job.html.markdown
+++ b/website/docs/r/dataflow_job.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `network` - (Optional) The network to which VMs will be assigned. If it is not provided, "default" will be used.
 * `subnetwork` - (Optional) The subnetwork to which VMs will be assigned. Should be of the form "regions/REGION/subnetworks/SUBNETWORK".
 * `machine_type` - (Optional) The machine type to use for the job.
-* `ip_configuration` - (Optional) The configuration for VM IPs.  Options are `"WORKER_IP_PUBLIC"` or `"WORKER_IP_PUBLIC"`.
+* `ip_configuration` - (Optional) The configuration for VM IPs.  Options are `"WORKER_IP_PUBLIC"` or `"WORKER_IP_PRIVATE"`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Fixed description of `ip_configuration` setting for `dataflow_job` resource in docs 