### PR TITLE
Add docscheck make target/script for website docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 - make tools
 
 script:
+- make docscheck
 - make lint
 - make test
 - make website-test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,5 +56,8 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test
+docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
+.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test docscheck
 

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown website/docs/**/*.md)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+
+  case "$category" in
+    "guides")
+      # Guides require a page_title
+      grep "^page_title: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Guide is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
+    "d" | "r")
+      # Resources and datasources require a subcategory
+      grep "^subcategory: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Follow-up PR from https://github.com/terraform-providers/terraform-provider-google/pull/4795

This adds a script to verify expected fields for customized docs structure for the [Terraform Registry](https://www.terraform.io/docs/registry/providers/docs.html).
* Require custom `subcategories` to frontmatter for resources and data sources -- useful to organize large # of docs in navigation
* Require `page_title` for guides
* Error explicitly on any other files in the `website/docs` that will not be ingressed by the Registry