### PR TITLE
Revert "Correct default GCP env var for credential path in Guide"

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -158,10 +158,10 @@ file. Name it something you can remember, and store it somewhere secure on your
 machine.
 
 You supply the key to Terraform using the environment variable
-`GOOGLE_APPLICATION_CREDENTIALS`, setting the value to the location of the file.
+`GOOGLE_CLOUD_KEYFILE_JSON`, setting the value to the location of the file.
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS={{path}}
+export GOOGLE_CLOUD_KEYFILE_JSON={{path}}
 ```
 
 -> Remember to add this line to a startup file such as `bash_profile` or


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-google#5021.
Accidentally merged this instead of a different one, too many tabs open, my mistake.