### PR TITLE
Update GCP env var for credential path in Getting started guide

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -158,10 +158,10 @@ file. Name it something you can remember, and store it somewhere secure on your
 machine.
 
 You supply the key to Terraform using the environment variable
-`GOOGLE_CLOUD_KEYFILE_JSON`, setting the value to the location of the file.
+`GOOGLE_CREDENTIALS`, setting the value to the location of the file.
 
 ```bash
-export GOOGLE_CLOUD_KEYFILE_JSON={{path}}
+export GOOGLE_CREDENTIALS={{path}}
 ```
 
 -> Remember to add this line to a startup file such as `bash_profile` or


### PR DESCRIPTION
Hi,

Opening a new PR requested by @megan07. This issue needs further investigation.
TL;DR: Using `GOOGLE_CLOUD_KEYFILE_JSON ` env var is not working for finding credential file

History can be found in: https://github.com/terraform-providers/terraform-provider-google/pull/5021

Cheers :)
