### PR TITLE
POC for resumable GKE creates

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	RequestTimeout      time.Duration
 
 	client           *http.Client
+	context          context.Context
 	terraformVersion string
 	userAgent        string
 
@@ -243,7 +244,7 @@ var defaultClientScopes = []string{
 	"https://www.googleapis.com/auth/userinfo.email",
 }
 
-func (c *Config) LoadAndValidate() error {
+func (c *Config) LoadAndValidate(ctx context.Context) error {
 	if len(c.Scopes) == 0 {
 		c.Scopes = defaultClientScopes
 	}
@@ -264,9 +265,8 @@ func (c *Config) LoadAndValidate() error {
 	userAgent := fmt.Sprintf("%s %s", tfUserAgent, providerVersion)
 
 	c.client = client
+	c.context = ctx
 	c.userAgent = userAgent
-
-	context := context.Background()
 
 	// This base path and some others below need the version and possibly more of the path
 	// set on them. The client libraries are inconsistent about which values they need;
@@ -275,7 +275,7 @@ func (c *Config) LoadAndValidate() error {
 	// the basePath value in the client library file.
 	computeClientBasePath := c.ComputeBasePath + "projects/"
 	log.Printf("[INFO] Instantiating GCE client for path %s", computeClientBasePath)
-	c.clientCompute, err = compute.NewService(context, option.WithHTTPClient(client))
+	c.clientCompute, err = compute.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (c *Config) LoadAndValidate() error {
 
 	computeBetaClientBasePath := c.ComputeBetaBasePath + "projects/"
 	log.Printf("[INFO] Instantiating GCE Beta client for path %s", computeBetaClientBasePath)
-	c.clientComputeBeta, err = computeBeta.NewService(context, option.WithHTTPClient(client))
+	c.clientComputeBeta, err = computeBeta.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (c *Config) LoadAndValidate() error {
 
 	containerClientBasePath := removeBasePathVersion(c.ContainerBasePath)
 	log.Printf("[INFO] Instantiating GKE client for path %s", containerClientBasePath)
-	c.clientContainer, err = container.NewService(context, option.WithHTTPClient(client))
+	c.clientContainer, err = container.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func (c *Config) LoadAndValidate() error {
 
 	containerBetaClientBasePath := removeBasePathVersion(c.ContainerBetaBasePath)
 	log.Printf("[INFO] Instantiating GKE Beta client for path %s", containerBetaClientBasePath)
-	c.clientContainerBeta, err = containerBeta.NewService(context, option.WithHTTPClient(client))
+	c.clientContainerBeta, err = containerBeta.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (c *Config) LoadAndValidate() error {
 
 	dnsClientBasePath := c.DNSBasePath + "projects/"
 	log.Printf("[INFO] Instantiating Google Cloud DNS client for path %s", dnsClientBasePath)
-	c.clientDns, err = dns.NewService(context, option.WithHTTPClient(client))
+	c.clientDns, err = dns.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (c *Config) LoadAndValidate() error {
 
 	dnsBetaClientBasePath := c.DnsBetaBasePath + "projects/"
 	log.Printf("[INFO] Instantiating Google Cloud DNS Beta client for path %s", dnsBetaClientBasePath)
-	c.clientDnsBeta, err = dnsBeta.NewService(context, option.WithHTTPClient(client))
+	c.clientDnsBeta, err = dnsBeta.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (c *Config) LoadAndValidate() error {
 
 	kmsClientBasePath := removeBasePathVersion(c.KMSBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud KMS client for path %s", kmsClientBasePath)
-	c.clientKms, err = cloudkms.NewService(context, option.WithHTTPClient(client))
+	c.clientKms, err = cloudkms.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ func (c *Config) LoadAndValidate() error {
 
 	loggingClientBasePath := removeBasePathVersion(c.LoggingBasePath)
 	log.Printf("[INFO] Instantiating Google Stackdriver Logging client for path %s", loggingClientBasePath)
-	c.clientLogging, err = cloudlogging.NewService(context, option.WithHTTPClient(client))
+	c.clientLogging, err = cloudlogging.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func (c *Config) LoadAndValidate() error {
 
 	storageClientBasePath := c.StorageBasePath
 	log.Printf("[INFO] Instantiating Google Storage client for path %s", storageClientBasePath)
-	c.clientStorage, err = storage.NewService(context, option.WithHTTPClient(client))
+	c.clientStorage, err = storage.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (c *Config) LoadAndValidate() error {
 
 	sqlClientBasePath := c.SQLBasePath
 	log.Printf("[INFO] Instantiating Google SqlAdmin client for path %s", sqlClientBasePath)
-	c.clientSqlAdmin, err = sqladmin.NewService(context, option.WithHTTPClient(client))
+	c.clientSqlAdmin, err = sqladmin.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (c *Config) LoadAndValidate() error {
 
 	pubsubClientBasePath := removeBasePathVersion(c.PubsubBasePath)
 	log.Printf("[INFO] Instantiating Google Pubsub client for path %s", pubsubClientBasePath)
-	c.clientPubsub, err = pubsub.NewService(context, option.WithHTTPClient(client))
+	c.clientPubsub, err = pubsub.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -374,7 +374,7 @@ func (c *Config) LoadAndValidate() error {
 
 	dataflowClientBasePath := removeBasePathVersion(c.DataflowBasePath)
 	log.Printf("[INFO] Instantiating Google Dataflow client for path %s", dataflowClientBasePath)
-	c.clientDataflow, err = dataflow.NewService(context, option.WithHTTPClient(client))
+	c.clientDataflow, err = dataflow.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (c *Config) LoadAndValidate() error {
 
 	resourceManagerBasePath := removeBasePathVersion(c.ResourceManagerBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud ResourceManager client for path %s", resourceManagerBasePath)
-	c.clientResourceManager, err = cloudresourcemanager.NewService(context, option.WithHTTPClient(client))
+	c.clientResourceManager, err = cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (c *Config) LoadAndValidate() error {
 
 	resourceManagerV2Beta1BasePath := removeBasePathVersion(c.ResourceManagerV2Beta1BasePath)
 	log.Printf("[INFO] Instantiating Google Cloud ResourceManager V client for path %s", resourceManagerV2Beta1BasePath)
-	c.clientResourceManagerV2Beta1, err = resourceManagerV2Beta1.NewService(context, option.WithHTTPClient(client))
+	c.clientResourceManagerV2Beta1, err = resourceManagerV2Beta1.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -401,7 +401,7 @@ func (c *Config) LoadAndValidate() error {
 
 	runtimeConfigClientBasePath := removeBasePathVersion(c.RuntimeConfigBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Runtimeconfig client for path %s", runtimeConfigClientBasePath)
-	c.clientRuntimeconfig, err = runtimeconfig.NewService(context, option.WithHTTPClient(client))
+	c.clientRuntimeconfig, err = runtimeconfig.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -410,7 +410,7 @@ func (c *Config) LoadAndValidate() error {
 
 	iamClientBasePath := removeBasePathVersion(c.IAMBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud IAM client for path %s", iamClientBasePath)
-	c.clientIAM, err = iam.NewService(context, option.WithHTTPClient(client))
+	c.clientIAM, err = iam.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func (c *Config) LoadAndValidate() error {
 
 	iamCredentialsClientBasePath := removeBasePathVersion(c.IamCredentialsBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud IAMCredentials client for path %s", iamCredentialsClientBasePath)
-	c.clientIamCredentials, err = iamcredentials.NewService(context, option.WithHTTPClient(client))
+	c.clientIamCredentials, err = iamcredentials.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -428,7 +428,7 @@ func (c *Config) LoadAndValidate() error {
 
 	serviceManagementClientBasePath := removeBasePathVersion(c.ServiceManagementBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Service Management client for path %s", serviceManagementClientBasePath)
-	c.clientServiceMan, err = servicemanagement.NewService(context, option.WithHTTPClient(client))
+	c.clientServiceMan, err = servicemanagement.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -437,7 +437,7 @@ func (c *Config) LoadAndValidate() error {
 
 	serviceUsageClientBasePath := removeBasePathVersion(c.ServiceUsageBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Service Usage client for path %s", serviceUsageClientBasePath)
-	c.clientServiceUsage, err = serviceusage.NewService(context, option.WithHTTPClient(client))
+	c.clientServiceUsage, err = serviceusage.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (c *Config) LoadAndValidate() error {
 
 	cloudBillingClientBasePath := removeBasePathVersion(c.CloudBillingBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Billing client for path %s", cloudBillingClientBasePath)
-	c.clientBilling, err = cloudbilling.NewService(context, option.WithHTTPClient(client))
+	c.clientBilling, err = cloudbilling.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -455,7 +455,7 @@ func (c *Config) LoadAndValidate() error {
 
 	cloudBuildClientBasePath := removeBasePathVersion(c.CloudBuildBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Build client for path %s", cloudBuildClientBasePath)
-	c.clientBuild, err = cloudbuild.NewService(context, option.WithHTTPClient(client))
+	c.clientBuild, err = cloudbuild.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (c *Config) LoadAndValidate() error {
 
 	bigQueryClientBasePath := c.BigQueryBasePath
 	log.Printf("[INFO] Instantiating Google Cloud BigQuery client for path %s", bigQueryClientBasePath)
-	c.clientBigQuery, err = bigquery.NewService(context, option.WithHTTPClient(client))
+	c.clientBigQuery, err = bigquery.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func (c *Config) LoadAndValidate() error {
 
 	cloudFunctionsClientBasePath := removeBasePathVersion(c.CloudFunctionsBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud CloudFunctions Client for path %s", cloudFunctionsClientBasePath)
-	c.clientCloudFunctions, err = cloudfunctions.NewService(context, option.WithHTTPClient(client))
+	c.clientCloudFunctions, err = cloudfunctions.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func (c *Config) LoadAndValidate() error {
 	bigtableAdminBasePath := removeBasePathVersion(c.BigtableAdminBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud BigtableAdmin for path %s", bigtableAdminBasePath)
 
-	clientBigtable, err := bigtableadmin.NewService(context, option.WithHTTPClient(client))
+	clientBigtable, err := bigtableadmin.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -498,7 +498,7 @@ func (c *Config) LoadAndValidate() error {
 
 	sourceRepoClientBasePath := removeBasePathVersion(c.SourceRepoBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Source Repo client for path %s", sourceRepoClientBasePath)
-	c.clientSourceRepo, err = sourcerepo.NewService(context, option.WithHTTPClient(client))
+	c.clientSourceRepo, err = sourcerepo.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -507,7 +507,7 @@ func (c *Config) LoadAndValidate() error {
 
 	spannerClientBasePath := removeBasePathVersion(c.SpannerBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Spanner client for path %s", spannerClientBasePath)
-	c.clientSpanner, err = spanner.NewService(context, option.WithHTTPClient(client))
+	c.clientSpanner, err = spanner.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -516,7 +516,7 @@ func (c *Config) LoadAndValidate() error {
 
 	dataprocClientBasePath := removeBasePathVersion(c.DataprocBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Dataproc client for path %s", dataprocClientBasePath)
-	c.clientDataproc, err = dataproc.NewService(context, option.WithHTTPClient(client))
+	c.clientDataproc, err = dataproc.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -525,7 +525,7 @@ func (c *Config) LoadAndValidate() error {
 
 	dataprocBetaClientBasePath := removeBasePathVersion(c.DataprocBetaBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Dataproc Beta client for path %s", dataprocBetaClientBasePath)
-	c.clientDataprocBeta, err = dataprocBeta.NewService(context, option.WithHTTPClient(client))
+	c.clientDataprocBeta, err = dataprocBeta.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -534,7 +534,7 @@ func (c *Config) LoadAndValidate() error {
 
 	filestoreClientBasePath := removeBasePathVersion(c.FilestoreBasePath)
 	log.Printf("[INFO] Instantiating Filestore client for path %s", filestoreClientBasePath)
-	c.clientFilestore, err = file.NewService(context, option.WithHTTPClient(client))
+	c.clientFilestore, err = file.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -543,7 +543,7 @@ func (c *Config) LoadAndValidate() error {
 
 	cloudIoTClientBasePath := removeBasePathVersion(c.CloudIoTBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud IoT Core client for path %s", cloudIoTClientBasePath)
-	c.clientCloudIoT, err = cloudiot.NewService(context, option.WithHTTPClient(client))
+	c.clientCloudIoT, err = cloudiot.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -552,7 +552,7 @@ func (c *Config) LoadAndValidate() error {
 
 	appEngineClientBasePath := removeBasePathVersion(c.AppEngineBasePath)
 	log.Printf("[INFO] Instantiating App Engine client for path %s", appEngineClientBasePath)
-	c.clientAppEngine, err = appengine.NewService(context, option.WithHTTPClient(client))
+	c.clientAppEngine, err = appengine.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -561,7 +561,7 @@ func (c *Config) LoadAndValidate() error {
 
 	composerClientBasePath := removeBasePathVersion(c.ComposerBasePath)
 	log.Printf("[INFO] Instantiating Cloud Composer client for path %s", composerClientBasePath)
-	c.clientComposer, err = composer.NewService(context, option.WithHTTPClient(client))
+	c.clientComposer, err = composer.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -570,7 +570,7 @@ func (c *Config) LoadAndValidate() error {
 
 	serviceNetworkingClientBasePath := removeBasePathVersion(c.ServiceNetworkingBasePath)
 	log.Printf("[INFO] Instantiating Service Networking client for path %s", serviceNetworkingClientBasePath)
-	c.clientServiceNetworking, err = servicenetworking.NewService(context, option.WithHTTPClient(client))
+	c.clientServiceNetworking, err = servicenetworking.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -579,7 +579,7 @@ func (c *Config) LoadAndValidate() error {
 
 	storageTransferClientBasePath := removeBasePathVersion(c.StorageTransferBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Storage Transfer client for path %s", storageTransferClientBasePath)
-	c.clientStorageTransfer, err = storagetransfer.NewService(context, option.WithHTTPClient(client))
+	c.clientStorageTransfer, err = storagetransfer.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
@@ -588,8 +588,8 @@ func (c *Config) LoadAndValidate() error {
 
 	c.Region = GetRegionFromRegionSelfLink(c.Region)
 
-	c.requestBatcherServiceUsage = NewRequestBatcher("Service Usage", context, c.BatchingConfig)
-	c.requestBatcherIam = NewRequestBatcher("IAM", context, c.BatchingConfig)
+	c.requestBatcherServiceUsage = NewRequestBatcher("Service Usage", ctx, c.BatchingConfig)
+	c.requestBatcherIam = NewRequestBatcher("IAM", ctx, c.BatchingConfig)
 
 	return nil
 }

--- a/google/provider.go
+++ b/google/provider.go
@@ -462,7 +462,7 @@ func Provider() terraform.ResourceProvider {
 			// We can therefore assume that if it's missing it's 0.10 or 0.11
 			terraformVersion = "0.11+compatible"
 		}
-		return providerConfigure(d, terraformVersion)
+		return providerConfigure(d, provider, terraformVersion)
 	}
 
 	return provider
@@ -721,7 +721,7 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 	)
 }
 
-func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
+func providerConfigure(d *schema.ResourceData, p *schema.Provider, terraformVersion string) (interface{}, error) {
 	config := Config{
 		Project:             d.Get("project").(string),
 		Region:              d.Get("region").(string),
@@ -814,7 +814,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	config.StorageTransferBasePath = d.Get(StorageTransferCustomEndpointEntryKey).(string)
 	config.BigtableAdminBasePath = d.Get(BigtableAdminCustomEndpointEntryKey).(string)
 
-	if err := config.LoadAndValidate(); err != nil {
+	if err := config.LoadAndValidate(p.StopContext()); err != nil {
 		return nil, err
 	}
 

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -109,6 +109,11 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"operation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"location": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -916,6 +921,16 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
 	waitErr := containerOperationWait(config, op, project, location, "creating GKE cluster", timeoutInMinutes)
 	if waitErr != nil {
+		// Check if the create operation failed because Terraform was prematurely terminated. If it was we can persist the
+		// operation id to state so that a subsequent refresh of this resource will wait until the operation has terminated
+		// before attempting to Read the state of the cluster. This allows a graceful resumption of a Create that was killed
+		// by the upstream Terraform process exiting early such as a sigterm.
+		select {
+		case <-config.context.Done():
+			log.Printf("[DEBUG] Persisting %s so this operation can be resumed \n", op.Name)
+			d.Set("operation", op.Name)
+			return nil
+		}
 		// Try a GET on the cluster so we can see the state in debug logs. This will help classify error states.
 		_, getErr := config.clientContainerBeta.Projects.Locations.Clusters.Get(containerClusterFullName(project, location, clusterName)).Do()
 		if getErr != nil {
@@ -972,6 +987,19 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	location, err := getLocation(d, config)
 	if err != nil {
 		return err
+	}
+
+	operation := d.Get("operation").(string)
+	if operation != "" {
+		log.Printf("[DEBUG] in progress operation detected at %v, attempting to resume\n", operation)
+		op := &containerBeta.Operation{
+			Name: operation,
+		}
+		d.Set("operation", "")
+		waitErr := containerOperationWait(config, op, project, location, "resuming GKE cluster", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		if waitErr != nil {
+			return waitErr
+		}
 	}
 
 	clusterName := d.Get("name").(string)


### PR DESCRIPTION
Implementation of the suggestions from https://github.com/hashicorp/terraform/issues/21652

When GKE clusters are being created if the Terraform process gets killed it will not persist anything to state, but if the cluster succeeds in the mean time subsequent `apply` calls will attempt to create an identical cluster which will result in a collision error. This will allow the provider to catch the stop call when Terraform is killed in order to persist the operation id. If there is an operation id we will assume there was a prematurely killed operation in progress and resume polling for success/failure.

![gke_resume](https://user-images.githubusercontent.com/1569002/70953675-faf9bd00-201e-11ea-8f53-fc36bcbbe0d7.gif)

