### PR TITLE
Set name attribute on compute_subnetwork data source

### DIFF
--- a/google/data_source_google_compute_subnetwork.go
+++ b/google/data_source_google_compute_subnetwork.go
@@ -93,6 +93,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	d.Set("network", subnetwork.Network)
 	d.Set("project", project)
 	d.Set("region", region)
+	d.Set("name", name)
 	d.Set("secondary_ip_range", flattenSecondaryRanges(subnetwork.SecondaryIpRanges))
 
 	d.SetId(fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", project, region, name))

--- a/google/data_source_google_compute_subnetwork_test.go
+++ b/google/data_source_google_compute_subnetwork_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
 				Config: testAccDataSourceGoogleSubnetwork(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork", "google_compute_subnetwork.foobar"),
+					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork_self_link", "google_compute_subnetwork.foobar"),
 				),
 			},
 		},


### PR DESCRIPTION
Previously, it was missing if `self_link` was used.

```release-note:bug
compute: Fixed behaviour where `google_compute_subnetwork` did not record a value for `name` when `self_link` was specified.
```