### PR TITLE
FIX ISSUE 5502 : unable to use "expr" in google_compute_security_policy.rule.match 

### DIFF
--- a/google/resource_compute_security_policy.go
+++ b/google/resource_compute_security_policy.go
@@ -93,6 +93,21 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 										Optional:     true,
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 									},
+									
+									"expr": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"expression": {
+													Type:     schema.TypeString,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/google/resource_compute_security_policy.go
+++ b/google/resource_compute_security_policy.go
@@ -93,10 +93,10 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 										Optional:     true,
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 									},
-									
+
 									"expr": {
-										Type:         schema.TypeList,
-										Optional:     true,
+										Type:     schema.TypeList,
+										Optional: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/google/resource_compute_security_policy_test.go
+++ b/google/resource_compute_security_policy_test.go
@@ -139,6 +139,18 @@ resource "google_compute_security_policy" "policy" {
   }
 
   rule {
+	action   = "deny(403)"
+	priority = "1000"
+	match {
+		expr {
+			expression = "evaluatePreconfiguredExpr('xss-stable') || evaluatePreconfiguredExpr('sqli-stable')"
+		}
+	}
+	description = "Deny access to xss and sqli rules"
+	preview = true
+  }
+
+  rule {
     action   = "allow"
     priority = "2000"
     match {


### PR DESCRIPTION
As described in the issue : https://github.com/terraform-providers/terraform-provider-google/issues/5502
I have tried to fix the use of "expr" in google_compute_security_policy.rule.match

**I was not able to launch the test to be sure it works (tests are skipped).**