### PR TITLE
Clarify how to get debug logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -48,7 +48,7 @@ about: For when something is there, but doesn't work how it should.
 <!---
 Please provide a link to a GitHub Gist containing the complete debug output. Please do NOT paste the debug output in the issue; just paste a link to the Gist.
 
-To obtain the debug output, see the [Terraform documentation on debugging](https://www.terraform.io/docs/internals/debugging.html).
+To obtain the debug output, run `terraform apply` with the environment variable `TF_LOG=DEBUG`. See the [Terraform documentation on debugging](https://www.terraform.io/docs/internals/debugging.html) for more information.
 --->
 
 ### Panic Output


### PR DESCRIPTION
Prompted by https://github.com/terraform-providers/terraform-provider-google/issues/5497#issuecomment-579954748. The debugging section on the terraform website has a lot of information, but it's not actually relevant to most users who just need to know to set the env variable.