### PR TITLE
Add note about Postgres requiring user passwords

### DIFF
--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -50,8 +50,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the user. Changing this forces a new resource
     to be created.
 
-* `password` - (Optional) The password for the user, for Postgres instances this
-    field is Required. Can be updated.
+* `password` - (Optional) The password for the user. Can be updated. For Postgres
+    instances this is a Required field.
 
 - - -
 

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the user. Changing this forces a new resource
     to be created.
 
-* `password` - (Optional) The password for the user. Can be updated.
+* `password` - (Optional) The password for the user, for Postgres instances this
+    field is Required. Can be updated.
 
 - - -
 


### PR DESCRIPTION
As it's been noted this field is required on instances of Postgres: https://github.com/terraform-providers/terraform-provider-google/issues/4123#issuecomment-553198771

This was previously changed since some instances don't require a password, and the documentation had to display the "lowest common level of validation".

>the issue here is that Postgres instances require a password and will fail without one but MySql instances don't

Last updated: https://github.com/terraform-providers/terraform-provider-google/pull/1056

You'll notice in the debug output provided by the user in issue #4123 shows:

>Missing user password for PostgreSQL instance

I think this PR might close issue 4123?