### PR TITLE
project: check for billing account permissions as pre-requisite

### DIFF
--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if err != nil {
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
-	if has := sliceContains(perm, resp.Permissions); !has {
+	if !stringInSlice(resp.Permissions); !has {
 		return fmt.Errorf("missing permissions on %q: %v", ba, perm)
 	}
 	return nil

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
 	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-		return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
+		return fmt.Errorf("missing permissions on billing account %q: %v", ba, diff)
 	}
 	return nil
 }

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -191,19 +191,10 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if err != nil {
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
-	if !stringInSlice(resp.Permissions); !has {
-		return fmt.Errorf("missing permissions on %q: %v", ba, perm)
+	if !stringInSlice(resp.Permissions, perm) {
+		return fmt.Errorf("missing permission on %q: %v", ba, perm)
 	}
 	return nil
-}
-
-func sliceContains(want string, ss []string) bool {
-	for _, s := range ss {
-		if s == want {
-			return true
-		}
-	}
-	return false
 }
 
 func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
 	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-		return fmt.Errorf("missing permissions on billing account %q: %v", ba, diff)
+		return fmt.Errorf("missing permissions on %q: %v", ba, diff)
 	}
 	return nil
 }

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -179,18 +179,19 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceData) error {
 	ib, ok := d.GetOk("billing_account")
-	if ok {
-		ba := "billingAccounts/" + ib.(string)
-		req := &cloudbilling.TestIamPermissionsRequest{
-			Permissions: []string{"billing.resourceAssociations.create"},
-		}
-		resp, err := config.clientBilling.BillingAccounts.TestIamPermissions(ba, req).Do()
-		if err != nil {
-			return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
-		}
-		if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-			return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
-		}
+	if !ok {
+		return nil
+	}
+	ba := "billingAccounts/" + ib.(string)
+	req := &cloudbilling.TestIamPermissionsRequest{
+		Permissions: []string{"billing.resourceAssociations.create"},
+	}
+	resp, err := config.clientBilling.BillingAccounts.TestIamPermissions(ba, req).Do()
+	if err != nil {
+		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
+	}
+	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
+		return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, the provider will create the project but then fail the billing account link step leaving the resource in a 'tainted' state. This pre-emptively checks whether the caller will have access to the billing account before the project is created.

We now get an error like:

```
Error: failed pre-requisites: missing permissions on "billingAccounts/abc": [billing.resourceAssociations.create]
```

https://github.com/terraform-google-modules/terraform-google-project-factory/issues/373