### PR TITLE
update d/datasource_compute_network documentation

### DIFF
--- a/website/docs/d/datasource_compute_network.html.markdown
+++ b/website/docs/d/datasource_compute_network.html.markdown
@@ -35,9 +35,6 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The network name or resource link to the parent
-    network of this network.
-
 * `description` - Description of this network.
 
 * `gateway_ipv4` - The IP address of the gateway.

--- a/website/docs/d/datasource_compute_network.html.markdown
+++ b/website/docs/d/datasource_compute_network.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `network` - The network name or resource link to the parent
+* `id` - The network name or resource link to the parent
     network of this network.
 
 * `description` - Description of this network.


### PR DESCRIPTION
Changed the `network` attribute to `id` inside the d/datasource_compute_network documentation.
https://www.terraform.io/docs/providers/google/d/datasource_compute_network.html

Fixes #5623.