### PR TITLE
features: add data_source_google_compute_backend_bucket

### DIFF
--- a/google/data_source_google_compute_backend_bucket.go
+++ b/google/data_source_google_compute_backend_bucket.go
@@ -1,0 +1,37 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceGoogleComputeBackendBucket() *schema.Resource {
+	dsSchema := datasourceSchemaFromResourceSchema(resourceComputeBackendBucket().Schema)
+
+	// Set 'Required' schema elements
+	addRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	addOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceComputeBackendBucketRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceComputeBackendBucketRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serviceName := d.Get("name").(string)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("projects/%s/global/backendBuckets/%s", project, serviceName))
+
+	return resourceComputeBackendBucketRead(d, meta)
+}

--- a/google/data_source_google_compute_backend_bucket_test.go
+++ b/google/data_source_google_compute_backend_bucket_test.go
@@ -1,0 +1,48 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceComputeBackendBucket_basic(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComputeBackendBucket_basic(serviceName, bucketName),
+				Check:  checkDataSourceStateMatchesResourceState("data.google_compute_backend_bucket.baz", "google_compute_backend_bucket.foobar"),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeBackendBucket_basic(serviceName, bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  description = "Contains beautiful images"
+  bucket_name = google_storage_bucket.image_bucket.name
+  enable_cdn  = true
+}
+
+resource "google_storage_bucket" "image_bucket" {
+  name     = "%s"
+  location = "EU"
+}
+
+data "google_compute_backend_bucket" "baz" {
+  name = google_compute_backend_bucket.foobar.name
+}
+`, serviceName, bucketName)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -435,6 +435,7 @@ func Provider() terraform.ResourceProvider {
 			"google_cloudfunctions_function":                  dataSourceGoogleCloudFunctionsFunction(),
 			"google_composer_image_versions":                  dataSourceGoogleComposerImageVersions(),
 			"google_compute_address":                          dataSourceGoogleComputeAddress(),
+			"google_compute_backend_bucket":                   dataSourceGoogleComputeBackendBucket(),
 			"google_compute_backend_service":                  dataSourceGoogleComputeBackendService(),
 			"google_compute_default_service_account":          dataSourceGoogleComputeDefaultServiceAccount(),
 			"google_compute_forwarding_rule":                  dataSourceGoogleComputeForwardingRule(),


### PR DESCRIPTION
Hi,

I try to fix my [issue](https://github.com/terraform-providers/terraform-provider-google/issues/5690) with this PR.
I made a backport in https://github.com/terraform-providers/terraform-provider-google/pull/5699

## Testing

```bash 
 make testacc TEST=./google TESTARGS='-run=TestAccDataSourceComputeBackendBucket_basic'
==> Checking source code against gofmt...                                                                                               
==> Checking that code complies with gofmt requirements...                                                                              
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccDataSourceComputeBackendBucket_basic -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceComputeBackendBucket_basic                                                                                   
=== PAUSE TestAccDataSourceComputeBackendBucket_basic                                                                                   
=== CONT  TestAccDataSourceComputeBackendBucket_basic                                                                                   
--- PASS: TestAccDataSourceComputeBackendBucket_basic (23.22s)                                                                          
PASS                                                                                                                                    
ok      github.com/terraform-providers/terraform-provider-google/google 23.261s 
```

```release-note:none
Release note added with upstreaming PR
```