### PR TITLE
Allow `projects/` prefix for the project field in project IAM resources

### DIFF
--- a/google/iam_project.go
+++ b/google/iam_project.go
@@ -10,10 +10,11 @@ import (
 
 var IamProjectSchema = map[string]*schema.Schema{
 	"project": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
+		Type:             schema.TypeString,
+		Optional:         true,
+		Computed:         true,
+		ForceNew:         true,
+		DiffSuppressFunc: compareProjectName,
 	},
 }
 
@@ -42,7 +43,8 @@ func ProjectIdParseFunc(d *schema.ResourceData, _ *Config) error {
 }
 
 func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(u.resourceId,
+	projectId := GetResourceNameFromSelfLink(u.resourceId)
+	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(projectId,
 		&cloudresourcemanager.GetIamPolicyRequest{
 			Options: &cloudresourcemanager.GetPolicyOptions{
 				RequestedPolicyVersion: iamPolicyVersion,
@@ -57,10 +59,12 @@ func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy
 }
 
 func (u *ProjectIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Policy) error {
-	_, err := u.Config.clientResourceManager.Projects.SetIamPolicy(u.resourceId, &cloudresourcemanager.SetIamPolicyRequest{
-		Policy:     policy,
-		UpdateMask: "bindings,etag,auditConfigs",
-	}).Do()
+	projectId := GetResourceNameFromSelfLink(u.resourceId)
+	_, err := u.Config.clientResourceManager.Projects.SetIamPolicy(projectId,
+		&cloudresourcemanager.SetIamPolicyRequest{
+			Policy:     policy,
+			UpdateMask: "bindings,etag,auditConfigs",
+		}).Do()
 
 	if err != nil {
 		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)


### PR DESCRIPTION
This patch allows the user to specify the value of the project field for
project IAM resources as `project-id` or `projects/project-id`.

Note that the above was already true for google_project_iam_policy [1].
This patch ensures that the above is also true for other project IAM
resources like google_project_iam_member and google_project_iam_binding.

[1] See commit 2f2f19f2776d238fe854088f9906cff8b1a2db67

```release-note:enhancement
iam: `google_project_iam_member` and `google_project_iam_binding`'s `project` field can be specified with an optional `projects/` prefix
```