### PR TITLE
Fixed broken URL

### DIFF
--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `included_files` -
   (Optional)
-  ignoredFiles and includedFiles are file glob matches using http://godoc/pkg/path/filepath#Match
+  ignoredFiles and includedFiles are file glob matches using https://golang.org/pkg/path/filepath/#Match
   extended with support for `**`.
   If any of the files altered in the commit pass the ignoredFiles filter
   and includedFiles is empty, then as far as this filter is concerned, we


### PR DESCRIPTION
As I was reading through the documentation while implementing automatic cloud build triggers I came across this broken link. Seems like a typo, so I fixed it. Just copy-pasted the link in the same description above (ignoredFiles/includedFiles).