### PR TITLE
Remove expression to avoid the interpolation-only expressions warning

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -134,7 +134,7 @@ with a subnetwork in each region. Next, change the network of the
 network_interface {
 -  # A default network is created for all GCP projects
 -  network = "default"
-+  network = "${google_compute_network.vpc_network.self_link}"
++  network = google_compute_network.vpc_network.self_link
   access_config {
 ```
 
@@ -189,7 +189,7 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     # A default network is created for all GCP projects
-    network       = "${google_compute_network.vpc_network.self_link}"
+    network       = google_compute_network.vpc_network.self_link
     access_config {
     }
   }


### PR DESCRIPTION
In order to avoid the warning message, since version 0.12.14
``` 
Warning: Interpolation-only expressions are deprecated
```
That can lead beginner users to misinterpretation. Considering current version is 0.12.23, I think removing that expression won't cause any issue.