### PR TITLE
Add missing quotes to example for saving GCP SA key as k8s secret

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -43,7 +43,7 @@ resource "kubernetes_secret" "google-application-credentials" {
     name = "google-application-credentials"
   }
   data = {
-    credentials.json = base64decode(google_service_account_key.mykey.private_key)
+    "credentials.json" = base64decode(google_service_account_key.mykey.private_key)
   }
 }
 ```


### PR DESCRIPTION
Without the quotes, terraform complains about missing quotes.