### PR TITLE
Make batching documentation match code

### DIFF
--- a/website/docs/guides/provider_reference.html.markdown
+++ b/website/docs/guides/provider_reference.html.markdown
@@ -335,7 +335,7 @@ after which a request should be sent. Defaults to 10s. Should be a non-negative
 integer or float string with a unit suffix, such as "300ms", "1.5h" or "2h45m".
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-* `disable_batching` - (Optional) Defaults to false. If true, disables global
+* `enable_batching` - (Optional) Defaults to true. If false, disables global
 batching and each request is sent normally.
 
 ---


### PR DESCRIPTION
[The provider code](https://github.com/terraform-providers/terraform-provider-google/blob/master/google/provider.go#L92) references a flag for changing batching settings. However, the documentation has the flag backwards. 

The flag is not `disable_batching`, but `enable_batching`. 

This PR simply updates the documentation.

```release-note:none

```