### PR TITLE
Update compute_forwarding_rule.html.markdown

### DIFF
--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -466,7 +466,7 @@ The following arguments are supported:
   object.
 
 * `allow_global_access` -
-  (Optional)
+  (Optional, Beta)
   If true, clients can access ILB from all regions.
   Otherwise only allows from the local region the ILB is located at.
 


### PR DESCRIPTION
I have added the Beta comment to the **allow_global_access** option since this is a google-beta only option.
Even though I did not see that it is mention anywhere, I found out that this option was release to google-beta 3.3.0 inside the google provider repository.

This comment will help others to use this feature without getting the following error:

```
on .terraform/XXX/main.tf line XXX, in resource "google_compute_forwarding_rule" "default":
 XXX:   allow_global_access   = true

An argument named "allow_global_access" is not expected here.
```