### PR TITLE
Add `ipip` to list of protocols supported by compute_firewall resource

### DIFF
--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -211,7 +211,7 @@ The `allow` block supports:
   The IP protocol to which this rule applies. The protocol type is
   required when creating a firewall rule. This value can either be
   one of the following well known protocol strings (tcp, udp,
-  icmp, esp, ah, sctp), or the IP protocol number.
+  icmp, esp, ah, sctp, ipip), or the IP protocol number.
 
 * `ports` -
   (Optional)
@@ -229,7 +229,7 @@ The `deny` block supports:
   The IP protocol to which this rule applies. The protocol type is
   required when creating a firewall rule. This value can either be
   one of the following well known protocol strings (tcp, udp,
-  icmp, esp, ah, sctp), or the IP protocol number.
+  icmp, esp, ah, sctp, ipip), or the IP protocol number.
 
 * `ports` -
   (Optional)


### PR DESCRIPTION
Addresses https://github.com/terraform-providers/terraform-provider-google/issues/6032

This is a simple documentation-only update to add the `ipip` protocol to `allow` and `deny` blocks within the `google_compute_firewall` resource. The `ipip` protocol is [supported](https://cloud.google.com/vpc/docs/firewalls#protocols_and_ports) by GCP, but not presently documented.
```release-note:none

```