### PR TITLE
Allow one and two nodes production bigtable clusters

### DIFF
--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -54,7 +54,7 @@ func resourceBigtableInstance() *schema.Resource {
 							// DEVELOPMENT instances could get returned with either zero or one node,
 							// so mark as computed.
 							Computed:     true,
-							ValidateFunc: validation.IntAtLeast(3),
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"storage_type": {
 							Type:         schema.TypeString,

--- a/website/docs/r/bigtable_instance.html.markdown
+++ b/website/docs/r/bigtable_instance.html.markdown
@@ -23,7 +23,7 @@ resource "google_bigtable_instance" "production-instance" {
   cluster {
     cluster_id   = "tf-instance-cluster"
     zone         = "us-central1-b"
-    num_nodes    = 3
+    num_nodes    = 1
     storage_type = "HDD"
   }
 }
@@ -73,7 +73,7 @@ cluster must have a different zone in the same region. Zones that support
 Bigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations).
 
 * `num_nodes` - (Optional) The number of nodes in your Cloud Bigtable cluster.
-Required, with a minimum of `3` for a `PRODUCTION` instance. Must be left unset
+Required, with a minimum of `1` for a `PRODUCTION` instance. Must be left unset
 for a `DEVELOPMENT` instance.
 
 * `storage_type` - (Optional) The storage type to use. One of `"SSD"` or


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5959

Relax number of nodes validation to one for PRODUCTION clusters.

```release-note:enhancement
bigtable: Reduced the minimum number of nodes for the `bigtable_instace` resource from 3 to 1.
```