### PR TITLE
Fix fetching of app_engine_standard_app_version data

### DIFF
--- a/google/resource_app_engine_standard_app_version.go
+++ b/google/resource_app_engine_standard_app_version.go
@@ -548,7 +548,7 @@ func resourceAppEngineStandardAppVersionCreate(d *schema.ResourceData, meta inte
 func resourceAppEngineStandardAppVersionRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	url, err := replaceVars(d, config, "{{AppEngineBasePath}}apps/{{project}}/services/{{service}}/versions/{{version_id}}")
+	url, err := replaceVars(d, config, "{{AppEngineBasePath}}apps/{{project}}/services/{{service}}/versions/{{version_id}}?view=FULL")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When omitting the `view` query parameter some fields (such as `handlers`) are not returned and lead terraform to show changes in the resource when there are none.