### PR TITLE
Update environment variable `GOOGLE_CLOUD_KEYFILE_JSON` 

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -158,10 +158,10 @@ file. Name it something you can remember, and store it somewhere secure on your
 machine.
 
 You supply the key to Terraform using the environment variable
-`GOOGLE_CLOUD_KEYFILE_JSON`, setting the value to the location of the file.
+`GOOGLE_APPLICATION_CREDENTIALS`, setting the value to the location of the file.
 
 ```bash
-export GOOGLE_CLOUD_KEYFILE_JSON={{path}}
+export GOOGLE_APPLICATION_CREDENTIALS={{path}}
 ```
 
 -> Remember to add this line to a startup file such as `bash_profile` or


### PR DESCRIPTION
When exporting the `GOOGLE_CLOUD_KEYFILE_JSON` environment variable, running a `terraform init` threw an error regarding credentials missing.

```
$ export GOOGLE_CLOUD_KEYFILE_JSON=~/Downloads/playground-s-11-2211f8-941f6dbcc691.json
 
$ terraform init
Initializing modules...
- bastion in ../../modules/core/bastion

Initializing the backend...

Error: storage.NewClient() failed: dialing: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
``` 

However, exporting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable allowed Terraform to find the credentials file.

```
$ export GOOGLE_APPLICATION_CREDENTIALS=~/Downloads/playground-s-11-2211f8-941f6dbcc691.json

$ terraform init
Initializing modules...

Initializing the backend...

Successfully configured the backend "gcs"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "google" (hashicorp/google) 3.0.0-beta.1...
- Downloading plugin for provider "google-beta" (terraform-providers/google-beta) 3.0.0-beta.1...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```