### PR TITLE
Update storage_bucket_iam.html.markdown

### DIFF
--- a/website/docs/r/storage_bucket_iam.html.markdown
+++ b/website/docs/r/storage_bucket_iam.html.markdown
@@ -118,7 +118,7 @@ Cloud Storage bucket IAM resources can be imported using the resource identifier
 
 IAM member imports use space-delimited identifiers: the resource in question, the role, and the member identity, e.g.
 ```
-$ terraform import google_storage_bucket_iam_member.editor "b/{{bucket}}?projection=full roles/storage.objectViewer jane@example.com"
+$ terraform import google_storage_bucket_iam_member.editor "b/{{bucket}} roles/storage.objectViewer jane@example.com"
 ```
 
 IAM binding imports use space-delimited identifiers: the resource in question and the role, e.g.


### PR DESCRIPTION
Import with b/{{bucket}}?projection=full does not work as expected. With google provider v3.22 I get following when importing with "?projection=full":
```
Error: Error reading Resource "storage bucket \"b/appadstxt-staging?projection=full\"" with IAM Member: Role "roles/storage.objectViewer" Member "allusers": Error retrieving IAM policy for storage bucket "b/appadstxt-staging.?projection=full": googleapi: Error 400: Invalid string value: 'full/iam'. Allowed values: [full, noacl], invalidParameter
```

Without "?projection=full" import works as expected.