### PR TITLE
Fixing instances[] reference in the examples

### DIFF
--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -36,8 +36,8 @@ resource "google_compute_instance_group" "webservers" {
   description = "Terraform test instance group"
 
   instances = [
-    google_compute_instance.test.id,
-    google_compute_instance.test2.id,
+    google_compute_instance.test.self_link,
+    google_compute_instance.test2.self_link,
   ]
 
   named_port {
@@ -63,7 +63,7 @@ as shown in this example to avoid this type of error.
 resource "google_compute_instance_group" "staging_group" {
   name      = "staging-instance-group"
   zone      = "us-central1-c"
-  instances = [google_compute_instance.staging_vm.id]
+  instances = [google_compute_instance.staging_vm.self_link]
   named_port {
     name = "http"
     port = "8080"


### PR DESCRIPTION
In the example is used:

>   instances = [
>     google_compute_instance.test.id,
>     google_compute_instance.test2.id,
>   ]
> 

while https://www.terraform.io/docs/providers/google/r/compute_instance_group.html#instances suggest **self_link** (https://www.terraform.io/docs/providers/google/r/compute_instance_group.html#instances ) to be used.

Indeed with:

>   instances = [
>     google_compute_instance.tfe.id
>   ]

I got error **Error: Error invalid instance URLs: [...instances/tfe]** while the following works:

>  instances = [
>     google_compute_instance.tfe.self_link
>   ]