### PR TITLE
Add instanceId validation to redis resource.

### DIFF
--- a/google/resource_redis_instance.go
+++ b/google/resource_redis_instance.go
@@ -50,10 +50,11 @@ func resourceRedisInstance() *schema.Resource {
 				Description: `Redis memory size in GiB.`,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The ID of the instance or a fully qualified identifier for the instance.`,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRFC1035Name(1, 40),
+				Description:  `The ID of the instance or a fully qualified identifier for the instance.`,
 			},
 			"alternative_location_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
I got this error today while creating a redis-instance. 

```
Error: Error creating Instance: googleapi: Error 400: Instance ID must be 1 to 40 characters and use lowercase letters, numbers, or hyphens. It must start with a lowercase letter and end with a lowercase letter or number.
com.google.apps.framework.request.StatusException: <eye3 title='INVALID_ARGUMENT'/> generic::INVALID_ARGUMENT: Instance ID must be 1 to 40 characters and use lowercase letters, numbers, or hyphens. It must start with a lowercase letter and end with a lowercase letter or number.
```