### PR TITLE
Add support for BigQuery hourly time partitioning 

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -336,13 +336,14 @@ func resourceBigQueryTable() *schema.Resource {
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 
-						// Type: [Required] The only type supported is DAY, which will generate
-						// one partition per day based on data loading time.
+            // TODO: check https://github.com/googleapis/google-cloud-go/commit/8618bf3d044f4da30b144689b870354c0071cfb0
+						// Type: [Required] The supported types are DAY and HOUR, which will generate
+						// one partition per day or hour based on data loading time.
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  `The only type supported is DAY, which will generate one partition per day based on data loading time.`,
-							ValidateFunc: validation.StringInSlice([]string{"DAY"}, false),
+							Description:  `The supported types are DAY and HOUR, which will generate one partition per day or hour based on data loading time`,
+							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR"}, false),
 						},
 
 						// Field: [Optional] The field used to determine how to create a time-based

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -336,7 +336,6 @@ func resourceBigQueryTable() *schema.Resource {
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 
-            // TODO: check https://github.com/googleapis/google-cloud-go/commit/8618bf3d044f4da30b144689b870354c0071cfb0
 						// Type: [Required] The supported types are DAY and HOUR, which will generate
 						// one partition per day or hour based on data loading time.
 						"type": {

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -20,7 +20,7 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTable(datasetID, tableID),
+				Config: testAccBigQueryTableDailyTimePartitioning(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -57,6 +57,37 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBigQueryTable_HourlyTimePartitioning(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID),
+			},
+			{
+				ResourceName:      "google_bigquery_table.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
+			},
+			{
+				ResourceName:      "google_bigquery_table.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -261,7 +292,7 @@ func testAccCheckBigQueryTableDestroyProducer(t *testing.T) func(s *terraform.St
 	}
 }
 
-func testAccBigQueryTable(datasetID, tableID string) string {
+func testAccBigQueryTableDailyTimePartitioning(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
 	dataset_id = "%s"
@@ -273,6 +304,63 @@ resource "google_bigquery_table" "test" {
 
 	time_partitioning {
 		type                     = "DAY"
+		field                    = "ts"
+		require_partition_filter = true
+	}
+	clustering = ["some_int", "some_string"]
+	schema     = <<EOH
+[
+	{
+		"name": "ts",
+		"type": "TIMESTAMP"
+	},
+	{
+		"name": "some_string",
+		"type": "STRING"
+	},
+	{
+		"name": "some_int",
+		"type": "INTEGER"
+	},
+	{
+		"name": "city",
+		"type": "RECORD",
+		"fields": [
+	{
+		"name": "id",
+		"type": "INTEGER"
+	},
+	{
+		"name": "coord",
+		"type": "RECORD",
+		"fields": [
+		{
+		"name": "lon",
+		"type": "FLOAT"
+		}
+		]
+	}
+		]
+	}
+]
+EOH
+
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+	dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+	table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+
+	time_partitioning {
+		type                     = "HOUR"
 		field                    = "ts"
 		require_partition_filter = true
 	}
@@ -338,7 +426,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
 	time_partitioning {
-		type = "HOUR"
+		type = "DAY"
 		field = "ts"
 	}
 

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -338,7 +338,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
 	time_partitioning {
-		type = "DAY"
+		type = "HOUR"
 		field = "ts"
 	}
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6676.

Check https://github.com/googleapis/google-cloud-go/commit/8618bf3d044f4da30b144689b870354c0071cfb0 functionality.

My commits here were not the nicest (totally Go noob), guess it will be just squashed? 

So in the end 
- update validations and description for HOUR time partitioning
- add one unit test for creating a table using HOUR time partitioning