### PR TITLE
Apply formatting and replace 0.11 syntax with 0.12 syntax in guides

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -80,7 +80,7 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     # A default network is created for all GCP projects
-    network       = "default"
+    network = "default"
     access_config {
     }
   }
@@ -193,7 +193,7 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     # A default network is created for all GCP projects
-    network       = google_compute_network.vpc_network.self_link
+    network = google_compute_network.vpc_network.self_link
     access_config {
     }
   }

--- a/website/docs/guides/provider_reference.html.markdown
+++ b/website/docs/guides/provider_reference.html.markdown
@@ -18,7 +18,7 @@ location (`zone` and/or `region`) for your resources.
 
 ```hcl
 provider "google" {
-  credentials = "${file("account.json")}"
+  credentials = file("account.json")
   project     = "my-project-id"
   region      = "us-central1"
   zone        = "us-central1-c"
@@ -27,7 +27,7 @@ provider "google" {
 
 ```hcl
 provider "google-beta" {
-  credentials = "${file("account.json")}"
+  credentials = file("account.json")
   project     = "my-project-id"
   region      = "us-central1"
   zone        = "us-central1-c"

--- a/website/docs/guides/using_gke_with_terraform.html.markdown
+++ b/website/docs/guides/using_gke_with_terraform.html.markdown
@@ -190,7 +190,7 @@ resource "google_container_cluster" "my-gke-cluster" {
   node_config {
     service_account = "{{service_account}}"
   }
-  
+
   lifecycle {
     ignore_changes = ["node_config"]
   }

--- a/website/docs/guides/version_2_upgrade.html.markdown
+++ b/website/docs/guides/version_2_upgrade.html.markdown
@@ -298,21 +298,21 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     branch_name = "master-updated"
     repo_name   = "some-repo-updated"
   }
-  
+
   build {
     images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA"]
-    tags = ["team-a", "service-b", "updated"]
-    
+    tags   = ["team-a", "service-b", "updated"]
+
     step {
       name = "gcr.io/cloud-builders/gsutil"
       args = ["cp", "gs://mybucket/remotefile.zip", "localfile-updated.zip"]
     }
-    
+
     step {
       name = "gcr.io/cloud-builders/go"
       args = ["build", "my_package_updated"]
     }
-    
+
     step {
       name = "gcr.io/cloud-builders/docker"
       args = ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA", "-f", "Dockerfile", "."]
@@ -393,11 +393,11 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_disk" "foobar" {
-  name = "example-disk"
+  name  = "example-disk"
   image = "${data.google_compute_image.my_image.self_link}"
-  size = 50
-  type = "pd-ssd"
-  zone = "us-central1-a"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
   disk_encryption_key {
     raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
   }
@@ -488,25 +488,25 @@ Use the `snapshot_encryption_key` block instead:
 
 ```hcl
 data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_compute_disk" "my_disk" {
-	name = "my-disk"
-	image = "${data.google_compute_image.my_image.self_link}"
-	size = 10
-	type = "pd-ssd"
-	zone = "us-central1-a"
+  name  = "my-disk"
+  image = "${data.google_compute_image.my_image.self_link}"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
 }
 
 resource "google_compute_snapshot" "my_snapshot" {
-	name = "my-snapshot"
-	source_disk = "${google_compute_disk.my_disk.name}"
-	zone = "us-central1-a"
-	snapshot_encryption_key {
-		raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
-	}
+  name        = "my-snapshot"
+  source_disk = "${google_compute_disk.my_disk.name}"
+  zone        = "us-central1-a"
+  snapshot_encryption_key {
+    raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+  }
 }
 ```
 
@@ -516,26 +516,26 @@ Use the `source_disk_encryption_key` block instead:
 
 ```hcl
 data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 resource "google_compute_disk" "my_disk" {
-	name = "my-disk"
-	image = "${data.google_compute_image.my_image.self_link}"
-	size = 10
-	type = "pd-ssd"
-	zone = "us-central1-a"
-	disk_encryption_key {
-		raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
-	}
+  name  = "my-disk"
+  image = "${data.google_compute_image.my_image.self_link}"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  disk_encryption_key {
+    raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+  }
 }
 resource "google_compute_snapshot" "my_snapshot" {
-	name = "my-snapshot"
-	source_disk = "${google_compute_disk.my_disk.name}"
-	zone = "us-central1-a"
-	source_disk_encryption_key {
-		raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
-	}
+  name        = "my-snapshot"
+  source_disk = "${google_compute_disk.my_disk.name}"
+  zone        = "us-central1-a"
+  source_disk_encryption_key {
+    raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+  }
 }
 
 ```
@@ -609,10 +609,10 @@ resource "random_id" "np" {
 }
 
 resource "google_container_node_pool" "example" {
-  name               = "${random_id.np.dec}"
-  zone               = "us-central1-a"
-  cluster            = "${google_container_cluster.example.name}"
-  node_count         = 1
+  name       = "${random_id.np.dec}"
+  zone       = "us-central1-a"
+  cluster    = "${google_container_cluster.example.name}"
+  node_count = 1
 
   node_config {
     machine_type = "${var.machine_type}"

--- a/website/docs/guides/version_3_upgrade.html.markdown
+++ b/website/docs/guides/version_3_upgrade.html.markdown
@@ -426,8 +426,8 @@ resource "google_cloud_run_service" "default" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale"      = "1000"
-        "run.googleapis.com/client-name"        = "terraform"
+        "autoscaling.knative.dev/maxScale" = "1000"
+        "run.googleapis.com/client-name"   = "terraform"
       }
       name = "revision-name"
     }
@@ -660,11 +660,11 @@ directed to that version.
 
 ```hcl
 resource "google_compute_instance_group_manager" "my_igm" {
-    name               = "my-igm"
-    zone               = "us-central1-c"
-    base_instance_name = "igm"
+  name               = "my-igm"
+  zone               = "us-central1-c"
+  base_instance_name = "igm"
 
-    instance_template = google_compute_instance_template.my_tmpl.self_link
+  instance_template = google_compute_instance_template.my_tmpl.self_link
 }
 ```
 
@@ -672,14 +672,14 @@ resource "google_compute_instance_group_manager" "my_igm" {
 
 ```hcl
 resource "google_compute_instance_group_manager" "my_igm" {
-    name               = "my-igm"
-    zone               = "us-central1-c"
-    base_instance_name = "igm"
+  name               = "my-igm"
+  zone               = "us-central1-c"
+  base_instance_name = "igm"
 
-    version {
-        name = "prod"
-        instance_template = google_compute_instance_template.my_tmpl.self_link
-    }
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.my_tmpl.self_link
+  }
 }
 ```
 
@@ -695,13 +695,13 @@ For more details see the
 
 ```hcl
 resource "google_compute_instance_group_manager" "my_igm" {
-    name               = "my-igm"
-    zone               = "us-central1-c"
-    base_instance_name = "igm"
+  name               = "my-igm"
+  zone               = "us-central1-c"
+  base_instance_name = "igm"
 
-    instance_template = "${google_compute_instance_template.my_tmpl.self_link}"
+  instance_template = "${google_compute_instance_template.my_tmpl.self_link}"
 
-    update_strategy   = "NONE"
+  update_strategy = "NONE"
 }
 ```
 
@@ -709,19 +709,19 @@ resource "google_compute_instance_group_manager" "my_igm" {
 
 ```hcl
 resource "google_compute_instance_group_manager" "my_igm" {
-    name               = "my-igm"
-    zone               = "us-central1-c"
-    base_instance_name = "igm"
+  name               = "my-igm"
+  zone               = "us-central1-c"
+  base_instance_name = "igm"
 
-    version {
-        name = "prod"
-        instance_template = "${google_compute_instance_template.my_tmpl.self_link}"
-    }
+  version {
+    name              = "prod"
+    instance_template = "${google_compute_instance_template.my_tmpl.self_link}"
+  }
 
-    update_policy {
-      minimal_action = "RESTART"
-      type           = "OPPORTUNISTIC"
-    }
+  update_policy {
+    minimal_action = "RESTART"
+    type           = "OPPORTUNISTIC"
+  }
 }
 ```
 
@@ -749,10 +749,10 @@ the following is valid:
 
 ```hcl
 disk {
-    auto_delete  = true
-    type         = "SCRATCH"
-    disk_type    = "local-ssd"
-    disk_size_gb = 375
+  auto_delete  = true
+  type         = "SCRATCH"
+  disk_type    = "local-ssd"
+  disk_size_gb = 375
 }
 ```
 
@@ -761,26 +761,26 @@ fail:
 
 ```hcl
 disk {
-    source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
-    auto_delete  = true
-    type         = "SCRATCH"
+  source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  auto_delete  = true
+  type         = "SCRATCH"
 }
 ```
 
 ```hcl
 disk {
-    source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
-    auto_delete  = true
-    disk_type    = "local-ssd"
+  source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  auto_delete  = true
+  disk_type    = "local-ssd"
 }
 ```
 
 ```hcl
 disk {
-    auto_delete  = true
-    type         = "SCRATCH"
-    disk_type    = "local-ssd"
-    disk_size_gb = 300
+  auto_delete  = true
+  type         = "SCRATCH"
+  disk_type    = "local-ssd"
+  disk_size_gb = 300
 }
 ```
 
@@ -983,8 +983,8 @@ to `false`.
 
 ```hcl
 resource "google_container_cluster" "primary" {
-  name       = "my-cluster"
-  location   = "us-central1"
+  name     = "my-cluster"
+  location = "us-central1"
 
   initial_node_count = 1
 
@@ -998,8 +998,8 @@ resource "google_container_cluster" "primary" {
 
 ```hcl
 resource "google_container_cluster" "primary" {
-  name       = "my-cluster"
-  location   = "us-central1"
+  name     = "my-cluster"
+  location = "us-central1"
 
   initial_node_count = 1
 }
@@ -1057,9 +1057,9 @@ resource "google_compute_network" "container_network" {
 }
 
 resource "google_container_cluster" "primary" {
-  name       = "my-cluster"
-  location   = "us-central1"
-  network    = google_compute_network.container_network.name
+  name     = "my-cluster"
+  location = "us-central1"
+  network  = google_compute_network.container_network.name
 
   initial_node_count = 1
 
@@ -1528,8 +1528,8 @@ module "project_services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "3.3.0"
 
-  project_id    = "your-project-id"
-  activate_apis =  [
+  project_id = "your-project-id"
+  activate_apis = [
     "iam.googleapis.com",
     "cloudresourcemanager.googleapis.com",
   ]
@@ -1550,7 +1550,7 @@ resource "google_project_service" "service" {
 
   service = each.key
 
-  project = "your-project-id"
+  project            = "your-project-id"
   disable_on_destroy = false
 }
 ```


### PR DESCRIPTION
Uses the terrafmt tool to apply formatting to examples and replace 0.11 syntax with 0.12 in the website guides.