### PR TITLE
feat(sql_instance): add support for point_in_time_recovery

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -40,6 +40,7 @@ var (
 		"settings.0.backup_configuration.0.enabled",
 		"settings.0.backup_configuration.0.start_time",
 		"settings.0.backup_configuration.0.location",
+		"settings.0.backup_configuration.0.point_in_time_recovery_enabled",
 	}
 
 	ipConfigurationKeys = []string{
@@ -182,6 +183,12 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 										Optional:     true,
 										AtLeastOneOf: backupConfigurationKeys,
 										Description:  `Location of the backup configuration.`,
+									},
+									"point_in_time_recovery_enabled": {
+										Type:         schema.TypeBool,
+										Optional:     true,
+										AtLeastOneOf: backupConfigurationKeys,
+										Description:  `True if Point-in-time recovery is enabled.`,
 									},
 								},
 							},
@@ -841,11 +848,12 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 
 	_backupConfiguration := configured[0].(map[string]interface{})
 	return &sqladmin.BackupConfiguration{
-		BinaryLogEnabled: _backupConfiguration["binary_log_enabled"].(bool),
-		Enabled:          _backupConfiguration["enabled"].(bool),
-		StartTime:        _backupConfiguration["start_time"].(string),
-		Location:         _backupConfiguration["location"].(string),
-		ForceSendFields:  []string{"BinaryLogEnabled", "Enabled"},
+		BinaryLogEnabled:           _backupConfiguration["binary_log_enabled"].(bool),
+		Enabled:                    _backupConfiguration["enabled"].(bool),
+		StartTime:                  _backupConfiguration["start_time"].(string),
+		Location:                   _backupConfiguration["location"].(string),
+		PointInTimeRecoveryEnabled: _backupConfiguration["point_in_time_recovery_enabled"].(bool),
+		ForceSendFields:            []string{"BinaryLogEnabled", "Enabled"},
 	}
 }
 
@@ -1050,10 +1058,11 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 
 func flattenBackupConfiguration(backupConfiguration *sqladmin.BackupConfiguration) []map[string]interface{} {
 	data := map[string]interface{}{
-		"binary_log_enabled": backupConfiguration.BinaryLogEnabled,
-		"enabled":            backupConfiguration.Enabled,
-		"start_time":         backupConfiguration.StartTime,
-		"location":           backupConfiguration.Location,
+		"binary_log_enabled":             backupConfiguration.BinaryLogEnabled,
+		"enabled":                        backupConfiguration.Enabled,
+		"start_time":                     backupConfiguration.StartTime,
+		"location":                       backupConfiguration.Location,
+		"point_in_time_recovery_enabled": backupConfiguration.PointInTimeRecoveryEnabled,
 	}
 
 	return []map[string]interface{}{data}

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -853,7 +853,7 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 		StartTime:                  _backupConfiguration["start_time"].(string),
 		Location:                   _backupConfiguration["location"].(string),
 		PointInTimeRecoveryEnabled: _backupConfiguration["point_in_time_recovery_enabled"].(bool),
-		ForceSendFields:            []string{"BinaryLogEnabled", "Enabled"},
+		ForceSendFields:            []string{"BinaryLogEnabled", "Enabled", "PointInTimeRecoveryEnabled"},
 	}
 }
 

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -629,6 +629,29 @@ func testAccCheckGoogleSqlDatabaseRootUserDoesNotExist(t *testing.T, instance st
 	}
 }
 
+func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
+	t.Parallel()
+
+	masterID := randInt(t)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled, masterID),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var testGoogleSqlDatabaseInstance_basic2 = `
 resource "google_sql_database_instance" "instance" {
   region = "us-central1"
@@ -955,6 +978,23 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     user_labels = {
       track = "production"
+    }
+  }
+}
+`
+var testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled = `
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%d"
+  region           = "us-central1"
+  database_version = "POSTGRES_9_6"
+
+  settings {
+    tier = "db-f1-micro"
+
+    backup_configuration {
+      enabled                = true
+      start_time             = "00:00"
+      point_in_time_recovery = true
     }
   }
 }

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -640,8 +640,17 @@ func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(
-					testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled, masterID),
+				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, true),
+				Check:  resource.TestCheckResourceAttr("google_sql_database_instance.instance", "point_in_time_recovery", "true"),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, false),
+				Check:  resource.TestCheckResourceAttr("google_sql_database_instance.instance", "point_in_time_recovery", "false"),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -982,7 +991,9 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
-var testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled = `
+
+func testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID int, PointInTimeRecoveryEnabled bool) string {
+	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name             = "tf-test-%d"
   region           = "us-central1"
@@ -994,8 +1005,9 @@ resource "google_sql_database_instance" "instance" {
     backup_configuration {
       enabled                = true
       start_time             = "00:00"
-      point_in_time_recovery = true
+      point_in_time_recovery = %t
     }
   }
 }
-`
+`, masterID, PointInTimeRecoveryEnabled)
+}

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -641,7 +641,6 @@ func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, true),
-				Check:  resource.TestCheckResourceAttr("google_sql_database_instance.instance", "point_in_time_recovery", "true"),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -650,7 +649,6 @@ func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
 			},
 			{
 				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, false),
-				Check:  resource.TestCheckResourceAttr("google_sql_database_instance.instance", "point_in_time_recovery", "false"),
 			},
 			{
 				ResourceName:      "google_sql_database_instance.instance",
@@ -1003,8 +1001,8 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
 
     backup_configuration {
-      enabled                = true
-      start_time             = "00:00"
+      enabled                        = true
+      start_time                     = "00:00"
       point_in_time_recovery_enabled = %t
     }
   }

--- a/google/resource_sql_database_instance_test.go
+++ b/google/resource_sql_database_instance_test.go
@@ -992,7 +992,7 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-func testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID int, PointInTimeRecoveryEnabled bool) string {
+func testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID int, pointInTimeRecoveryEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name             = "tf-test-%d"
@@ -1005,9 +1005,9 @@ resource "google_sql_database_instance" "instance" {
     backup_configuration {
       enabled                = true
       start_time             = "00:00"
-      point_in_time_recovery = %t
+      point_in_time_recovery_enabled = %t
     }
   }
 }
-`, masterID, PointInTimeRecoveryEnabled)
+`, masterID, pointInTimeRecoveryEnabled)
 }

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -282,6 +282,7 @@ The optional `settings.backup_configuration` subblock supports:
 
 * `start_time` - (Optional) `HH:MM` format time indicating when backup
     configuration starts.
+* `point_in_time_recovery_enabled` - (Optional) True if Point-in-time recovery is enabled. Will restart database if enabled after instance creation. 
 
 The optional `settings.ip_configuration` subblock supports:
 


### PR DESCRIPTION
This allows enabling [Point in time recovery](https://cloud.google.com/sql/docs/mysql/backup-recovery/backups#tips-pitr) feature for Cloud SQL. 
