### PR TITLE
Update google_service_account markdown import example

### DIFF
--- a/website/docs/r/google_service_account.html.markdown
+++ b/website/docs/r/google_service_account.html.markdown
@@ -72,5 +72,5 @@ This resource provides the following
 Service accounts can be imported using their URI, e.g.
 
 ```
-$ terraform import google_service_account.my_sa projects/my-project/serviceAccounts/my-sa@my-project.iam.gserviceaccount.com
+$ terraform import google_service_account.my_sa my-project/my-sa@my-project.iam.gserviceaccount.com
 ```


### PR DESCRIPTION
Terraform Version: 0.12.24
Google Provider Version: 3.27.0

The example for importing an existing google service account was not succesful. Updating the example to drop `projects` and `serviceAccounts` resulted in a succesful import. 