### PR TITLE
Add import example

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -197,4 +197,5 @@ Functions can be imported using the `name`, e.g.
 
 ```
 $ terraform import google_cloudfunctions_function.default function-test
+$ terraform import google_cloudfunctions_function.default {{project}}/{{region}}/function-test
 ```


### PR DESCRIPTION
Adds an import example to google_cloudfunctions_function documentation to import a function from another project and/or region.

In my case, the functions run in a separate region that differs from the default one defined in the `provider` block. Setting the `region` key in the `resource` itself did not change the import behavior. Defining the region as in the example did work, but it took some tries/effort to figure out that syntax. Hopefully this update will help someone else along the way to achieve the same in an easier way.