### PR TITLE
Update documentation with useful role to access secret

### DIFF
--- a/website/docs/r/secret_manager_secret_iam.html.markdown
+++ b/website/docs/r/secret_manager_secret_iam.html.markdown
@@ -71,7 +71,7 @@ resource "google_secret_manager_secret_iam_binding" "binding" {
 resource "google_secret_manager_secret_iam_member" "member" {
   project = google_secret_manager_secret.secret-basic.project
   secret_id = google_secret_manager_secret.secret-basic.secret_id
-  role = "roles/viewer"
+  role = "roles/secretmanager.secretAccessor"
   member = "user:jane@example.com"
 }
 ```


### PR DESCRIPTION
I spent an hour trying to figure out why my function did not have permission.  I suggest updating the docs so that the example allows you to read the secret