### PR TITLE
Update Redis instance documentation to add v 5.0

### DIFF
--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -197,6 +197,7 @@ The following arguments are supported:
   (Optional)
   The version of Redis software. If not provided, latest supported
   version will be used. Currently, the supported values are:
+  - REDIS_5_0 for Redis 5.0 compatibility
   - REDIS_4_0 for Redis 4.0 compatibility
   - REDIS_3_2 for Redis 3.2 compatibility
 


### PR DESCRIPTION
Version 5.0 is now supported