### PR TITLE
Add the Go 1.13 runtime

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `name` - (Required) A user-defined name of the function. Function names must be unique globally.
 
 * `runtime` - (Required) The runtime in which the function is going to run.
-Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
+Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`, `"go113"`.
 
 - - -
 


### PR DESCRIPTION
We received an email from Gcloud saying they are deprecating the Cloud Functions + Go 1.11 runtime soon:

> We are writing to inform you that the Go 1.11 runtime on Cloud Functions will be deprecated on August 5, 2020. You have been identified as having used it in the past six months and may be affected by this change.
>
> To avoid any potential disruptions or security risks, we recommend you update your functions to use the Go 1.13 GA runtime.

https://cloud.google.com/functions/docs/concepts/go-runtime