### PR TITLE
Update Google service account docs to display correct public key type

### DIFF
--- a/website/docs/d/service_account_key.html.markdown
+++ b/website/docs/d/service_account_key.html.markdown
@@ -7,10 +7,9 @@ description: |-
   Get a Google Cloud Platform service account Public Key
 ---
 
-# google\_service\_account\_key
+# google_service_account_key
 
 Get service account public key. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys/get).
-
 
 ## Example Usage
 
@@ -33,17 +32,17 @@ data "google_service_account_key" "mykey" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the service account key. This must have format
-    `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
-    is the email address or unique id of the service account.
+- `name` - (Required) The name of the service account key. This must have format
+  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
+  is the email address or unique id of the service account.
 
-* `project` - (Optional) The ID of the project that the service account will be created in.
-    Defaults to the provider project configuration.
+- `project` - (Optional) The ID of the project that the service account will be created in.
+  Defaults to the provider project configuration.
 
-* `public_key_type` (Optional) The output format of the public key requested. X509_PEM is the default output format.
+- `public_key_type` (Optional) The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `public_key` - The public key, base64 encoded
+- `public_key` - The public key, base64 encoded

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -7,10 +7,9 @@ description: |-
   Allows management of a Google Cloud Platform service account Key Pair
 ---
 
-# google\_service\_account\_key
+# google_service_account_key
 
 Creates and manages service account key-pairs, which allow the user to establish identity of a service account outside of GCP. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys).
-
 
 ## Example Usage, creating a new Key Pair
 
@@ -52,34 +51,33 @@ resource "kubernetes_secret" "google-application-credentials" {
 
 The following arguments are supported:
 
-* `service_account_id` - (Required) The Service account id of the Key Pair. This can be a string in the format
-`{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the email address or
-unique id of the service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
+- `service_account_id` - (Required) The Service account id of the Key Pair. This can be a string in the format
+  `{ACCOUNT}` or `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`, where `{ACCOUNT}` is the email address or
+  unique id of the service account. If the `{ACCOUNT}` syntax is used, the project will be inferred from the account.
 
-* `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
-Valid values are listed at
-[ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKeyAlgorithm)
-(only used on create)
+- `key_algorithm` - (Optional) The algorithm used to generate the key. KEY_ALG_RSA_2048 is the default algorithm.
+  Valid values are listed at
+  [ServiceAccountPrivateKeyType](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKeyAlgorithm)
+  (only used on create)
 
-* `public_key_type` (Optional) The output format of the public key requested. X509_PEM is the default output format.
+- `public_key_type` (Optional) The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.
 
-* `private_key_type` (Optional) The output format of the private key. TYPE_GOOGLE_CREDENTIALS_FILE is the default output format.
+- `private_key_type` (Optional) The output format of the private key. TYPE_GOOGLE_CREDENTIALS_FILE is the default output format.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - an identifier for the resource with format `projects/{{project}}/serviceAccounts/{{account}}/keys/{{key}}`
+- `id` - an identifier for the resource with format `projects/{{project}}/serviceAccounts/{{account}}/keys/{{key}}`
 
-* `name` - The name used for this key pair
+- `name` - The name used for this key pair
 
-* `public_key` - The public key, base64 encoded
+- `public_key` - The public key, base64 encoded
 
-* `private_key` - The private key in JSON format, base64 encoded. This is what you normally get as a file when creating
-service account keys through the CLI or web console. This is only populated when creating a new key.
+- `private_key` - The private key in JSON format, base64 encoded. This is what you normally get as a file when creating
+  service account keys through the CLI or web console. This is only populated when creating a new key.
 
-* `valid_after` - The key can be used after this timestamp. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
+- `valid_after` - The key can be used after this timestamp. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
 
-* `valid_before` - The key can be used before this timestamp.
-A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
-
+- `valid_before` - The key can be used before this timestamp.
+  A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".


### PR DESCRIPTION
Fixes #6861 by updating the Google Service Account Key - Public Key Type in the documentation.